### PR TITLE
Log Quarkus LS version and Java home version on initialization

### DIFF
--- a/quarkus.ls/com.redhat.quarkus.ls/pom.xml
+++ b/quarkus.ls/com.redhat.quarkus.ls/pom.xml
@@ -13,10 +13,41 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
+		<dev.build.timestamp>${maven.build.timestamp}</dev.build.timestamp>
 	</properties>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources/</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>**/*.properties</include>
+				</includes>
+			</resource>
+			<resource>
+				<directory>src/main/resources/</directory>
+				<filtering>false</filtering>
+				<excludes>
+					<exclude>**/*.properties</exclude>
+				</excludes>
+			</resource>
+		</resources>
 		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>3.0.0</version>
+				<executions>
+					<execution>
+						<id>parse-version</id>
+						<goals>
+							<goal>parse-version</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<version>3.1.1</version>

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/QuarkusLanguageServer.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/QuarkusLanguageServer.java
@@ -10,6 +10,7 @@
 package com.redhat.quarkus.ls;
 
 import static org.eclipse.lsp4j.jsonrpc.CompletableFutures.computeAsync;
+import static com.redhat.quarkus.utils.VersionHelper.getVersion;
 
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
@@ -52,7 +53,7 @@ public class QuarkusLanguageServer implements LanguageServer, ProcessLanguageSer
 	}
 
 	public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
-		LOGGER.info("Inside initialize");
+		LOGGER.info("Initializing Quarkus server " + getVersion() + " with " + System.getProperty("java.home"));
 		this.parentProcessId = params.getProcessId();
 		ServerCapabilities serverCapabilities = new ServerCapabilities();
 		serverCapabilities.setTextDocumentSync(TextDocumentSyncKind.Incremental);

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/utils/VersionHelper.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/utils/VersionHelper.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright (c) 2018 Red Hat, Inc.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v20.html
+ *
+ *  Contributors:
+ *  Fred Bricon <fbricon@gmail.com>, Red Hat Inc. - initial API and implementation
+ */
+package com.redhat.quarkus.utils;
+
+import java.util.ResourceBundle;
+
+/**
+ * Helper object to retrieve the current version of the server.
+ */
+public class VersionHelper {
+
+	private VersionHelper() {
+		// No instantiation
+	}
+
+	/**
+	 * Returns the version of the server with the format
+	 * <code>major.minor.incremental-timestamp</code>.
+	 * 
+	 * @return the server version
+	 */
+	public static String getVersion() {
+		// No need to make it a static field as it'll be used only once
+		ResourceBundle bundle = ResourceBundle.getBundle("version");
+		String version = bundle.getString("version");
+		return version;
+	}
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/resources/version.properties
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+version=${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}-${dev.build.timestamp}


### PR DESCRIPTION
Fixes #13 
![image](https://user-images.githubusercontent.com/20326645/62393213-8f172c00-b537-11e9-8841-7a21cd640ea7.png)
Some of the code from this [commit](https://github.com/angelozerr/lsp4xml/commit/edfee175e923a9f2c3a553e240c833280e9cec21) was used for this PR. 

I kept the copyright header as is, for `VersionHelper.java`.

Signed-off-by: David Kwon <dakwon@redhat.com>