### PR TITLE
Manage completion and hover capability dynamically

### DIFF
--- a/quarkus.ls/.vscode/settings.json
+++ b/quarkus.ls/.vscode/settings.json
@@ -11,5 +11,5 @@
 	"editor.detectIndentation": false,
 	"editor.tabSize": 4,
 	"editor.insertSpaces": false,
-	"java.test.defaultConfig": "default",
+	"java.test.defaultConfig": "default"
 }

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/QuarkusTextDocumentService.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/QuarkusTextDocumentService.java
@@ -39,6 +39,7 @@ import com.redhat.quarkus.ls.commons.ModelTextDocuments;
 import com.redhat.quarkus.ls.commons.TextDocument;
 import com.redhat.quarkus.model.PropertiesModel;
 import com.redhat.quarkus.services.QuarkusLanguageService;
+import com.redhat.quarkus.settings.QuarkusCompletionSettings;
 import com.redhat.quarkus.settings.SharedSettings;
 
 /**

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusLanguageService.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusLanguageService.java
@@ -63,5 +63,4 @@ public class QuarkusLanguageService {
 			QuarkusHoverSettings hoverSettings) {
 		return hover.doHover(document, position, projectInfo, hoverSettings);
 	}
-
 }

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/capabilities/ClientCapabilitiesWrapper.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/capabilities/ClientCapabilitiesWrapper.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat Inc. and others. All rights reserved. This program
+ * and the accompanying materials which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors: Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.quarkus.settings.capabilities;
+
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.DynamicRegistrationCapabilities;
+import org.eclipse.lsp4j.TextDocumentClientCapabilities;
+
+/**
+ * Determines if a client supports a specific capability dynamically
+ */
+public class ClientCapabilitiesWrapper {
+
+	private boolean v3Supported;
+	
+	private ClientCapabilities capabilities;
+
+	public ClientCapabilitiesWrapper() {
+		this(new ClientCapabilities());
+	}
+
+	public ClientCapabilitiesWrapper(ClientCapabilities capabilities) {
+		this.capabilities = capabilities;
+		this.v3Supported = capabilities != null ? capabilities.getTextDocument() != null : false;
+	}
+
+	/**
+	 * IMPORTANT
+	 * 
+	 * This should be up to date with all Server supported capabilities
+	 * 
+	 */
+
+	public boolean isCompletionDynamicRegistrationSupported() {
+		return v3Supported && isDynamicRegistrationSupported(getTextDocument().getCompletion());
+	}
+
+	public boolean isHoverDynamicRegistered() {
+		return v3Supported && isDynamicRegistrationSupported(getTextDocument().getHover());
+	}
+	
+	private boolean isDynamicRegistrationSupported(DynamicRegistrationCapabilities capability) {
+		return capability != null && capability.getDynamicRegistration() != null
+				&& capability.getDynamicRegistration().booleanValue();
+	}
+
+	public TextDocumentClientCapabilities getTextDocument() {
+		return this.capabilities.getTextDocument();
+	}
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/capabilities/QuarkusCapabilityManager.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/capabilities/QuarkusCapabilityManager.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat Inc. and others. All rights reserved. This program
+ * and the accompanying materials which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors: Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.quarkus.settings.capabilities;
+
+import static com.redhat.quarkus.settings.capabilities.ServerCapabilitiesConstants.COMPLETION_ID;
+import static com.redhat.quarkus.settings.capabilities.ServerCapabilitiesConstants.HOVER_ID;
+import static com.redhat.quarkus.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_COMPLETION;
+import static com.redhat.quarkus.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_HOVER;
+import static com.redhat.quarkus.settings.capabilities.ServerCapabilitiesConstants.DEFAULT_COMPLETION_OPTIONS;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.Registration;
+import org.eclipse.lsp4j.RegistrationParams;
+import org.eclipse.lsp4j.Unregistration;
+import org.eclipse.lsp4j.UnregistrationParams;
+import org.eclipse.lsp4j.services.LanguageClient;
+
+/**
+ * Manages dynamic capabilities
+ */
+public class QuarkusCapabilityManager {
+
+	private final Set<String> registeredCapabilities = new HashSet<>(3);
+	private final LanguageClient languageClient;
+
+	private ClientCapabilitiesWrapper clientWrapper;
+
+	public QuarkusCapabilityManager(LanguageClient languageClient) {
+		this.languageClient = languageClient;
+	}
+
+	/**
+	 * Registers all dynamic capabilities that the server does not support client
+	 * side preferences turning on/off
+	 */
+	public void initializeCapabilities() {
+		if (this.getClientCapabilities().isCompletionDynamicRegistrationSupported()) {
+			registerCapability(COMPLETION_ID, TEXT_DOCUMENT_COMPLETION, DEFAULT_COMPLETION_OPTIONS);
+		}
+
+		if (this.getClientCapabilities().isHoverDynamicRegistered()) {
+			registerCapability(HOVER_ID, TEXT_DOCUMENT_HOVER);
+		}
+	}
+
+	public void setClientCapabilities(ClientCapabilities clientCapabilities) {
+		this.clientWrapper = new ClientCapabilitiesWrapper(clientCapabilities);
+	}
+
+	public ClientCapabilitiesWrapper getClientCapabilities() {
+		if (this.clientWrapper == null) {
+			this.clientWrapper = new ClientCapabilitiesWrapper();
+		}
+		return this.clientWrapper;
+	}
+
+	public Set<String> getRegisteredCapabilities() {
+		return registeredCapabilities;
+	}
+
+	private void registerCapability(String id, String method) {
+		registerCapability(id, method, null);
+	}
+
+	private void registerCapability(String id, String method, Object options) {
+		if (registeredCapabilities.add(id)) {
+			Registration registration = new Registration(id, method, options);
+			RegistrationParams registrationParams = new RegistrationParams(Collections.singletonList(registration));
+			languageClient.registerCapability(registrationParams);
+		}
+	}
+
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/capabilities/ServerCapabilitiesConstants.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/capabilities/ServerCapabilitiesConstants.java
@@ -1,0 +1,33 @@
+/**
+ *  Copyright (c) 2018 Red Hat, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v20.html
+ *
+ *  Contributors:
+ *  Red Hat Inc. - initial API and implementation
+ */
+package com.redhat.quarkus.settings.capabilities;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import org.eclipse.lsp4j.CompletionOptions;
+
+/**
+ * Server Capabilities Constants
+ */
+public class ServerCapabilitiesConstants {
+
+	private ServerCapabilitiesConstants() {
+	}
+
+	public static final String TEXT_DOCUMENT_COMPLETION = "textDocument/completion";
+	public static final String TEXT_DOCUMENT_HOVER = "textDocument/hover";
+
+	public static final String COMPLETION_ID = UUID.randomUUID().toString();
+	public static final String HOVER_ID = UUID.randomUUID().toString();
+
+	public static final CompletionOptions DEFAULT_COMPLETION_OPTIONS = new CompletionOptions(false, Collections.emptyList());
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/capabilities/ServerCapabilitiesInitializer.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/capabilities/ServerCapabilitiesInitializer.java
@@ -1,0 +1,47 @@
+/**
+ *  Copyright (c) 2018 Red Hat, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v20.html
+ *
+ *  Contributors:
+ *  Red Hat Inc. - initial API and implementation
+ */
+
+package com.redhat.quarkus.settings.capabilities;
+
+import static com.redhat.quarkus.settings.capabilities.ServerCapabilitiesConstants.DEFAULT_COMPLETION_OPTIONS;
+
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.TextDocumentSyncKind;
+
+/**
+ * All default capabilities of this server
+ */
+public class ServerCapabilitiesInitializer {
+
+	private ServerCapabilitiesInitializer() {
+	}
+
+	/**
+	 * Returns all server capabilities (with default values) that aren't dynamic.
+	 * 
+	 * A service's dynamic capability is indicated by the client.
+	 * 
+	 * @param clientCapabilities
+	 * @return ServerCapabilities object
+	 */
+	public static ServerCapabilities getNonDynamicServerCapabilities(ClientCapabilitiesWrapper clientCapabilities) {
+		
+		ServerCapabilities serverCapabilities = new ServerCapabilities();
+		serverCapabilities.setTextDocumentSync(TextDocumentSyncKind.Incremental);
+		serverCapabilities.setHoverProvider(!clientCapabilities.isHoverDynamicRegistered());
+
+		if (!clientCapabilities.isCompletionDynamicRegistrationSupported()) {
+			serverCapabilities.setCompletionProvider(DEFAULT_COMPLETION_OPTIONS);
+		}
+		
+		return serverCapabilities;
+	}
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/settings/capabilities/QuarkusCapabilitiesTest.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/settings/capabilities/QuarkusCapabilitiesTest.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.settings.capabilities;
+
+import static com.redhat.quarkus.settings.capabilities.ServerCapabilitiesConstants.DEFAULT_COMPLETION_OPTIONS;
+import static com.redhat.quarkus.settings.capabilities.ServerCapabilitiesConstants.COMPLETION_ID;
+import static com.redhat.quarkus.settings.capabilities.ServerCapabilitiesConstants.HOVER_ID;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.CompletionCapabilities;
+import org.eclipse.lsp4j.HoverCapabilities;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.RegistrationParams;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.TextDocumentClientCapabilities;
+import org.eclipse.lsp4j.WorkspaceClientCapabilities;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * XMLCapabilityManagerTest
+ */
+public class QuarkusCapabilitiesTest {
+
+	private LanguageClient languageClient = new LanguageClientMock();
+	private QuarkusCapabilityManager manager;
+	private ClientCapabilities clientCapabilities;
+	private TextDocumentClientCapabilities textDocument;
+	private WorkspaceClientCapabilities workspace;
+	private Set<String> capabilityIDs;
+
+	@Before
+	public void startup() {
+
+		textDocument = new TextDocumentClientCapabilities();
+		workspace = new WorkspaceClientCapabilities();
+		manager = new QuarkusCapabilityManager(languageClient);
+		clientCapabilities = new ClientCapabilities();
+		capabilityIDs = null;
+
+	}
+
+	@Test
+	public void testAllDynamicCapabilities() {
+		setAllCapabilities(true);
+		setAndInitializeCapabilities();
+
+		assertEquals(2, capabilityIDs.size());
+		assertEquals(true, capabilityIDs.contains(COMPLETION_ID));
+		assertEquals(true, capabilityIDs.contains(HOVER_ID));
+
+		ServerCapabilities serverCapabilities = ServerCapabilitiesInitializer
+				.getNonDynamicServerCapabilities(manager.getClientCapabilities());
+
+		assertEquals(null, serverCapabilities.getCompletionProvider());
+		assertEquals(false, serverCapabilities.getHoverProvider());
+	}
+
+	@Test
+	public void testNoDynamicCapabilities() {
+		setAllCapabilities(false);
+		setAndInitializeCapabilities();
+
+		assertEquals(0, capabilityIDs.size());
+
+		ServerCapabilities serverCapabilities = ServerCapabilitiesInitializer
+				.getNonDynamicServerCapabilities(manager.getClientCapabilities());
+
+		assertEquals(DEFAULT_COMPLETION_OPTIONS, serverCapabilities.getCompletionProvider());
+		assertEquals(true, serverCapabilities.getHoverProvider());
+	}
+
+	@Test
+	public void testBothCapabilityTypes() {
+
+		// Dynamic capabilities
+		CompletionCapabilities completion = new CompletionCapabilities();
+		completion.setDynamicRegistration(true);
+		textDocument.setCompletion(completion);
+
+		// Non dynamic capabilities
+		textDocument.setHover(new HoverCapabilities(false));
+
+		setAndInitializeCapabilities();
+
+		assertEquals(1, capabilityIDs.size());
+		assertEquals(true, capabilityIDs.contains(COMPLETION_ID));
+		assertEquals(false, capabilityIDs.contains(HOVER_ID));
+
+		ServerCapabilities serverCapabilities = ServerCapabilitiesInitializer
+				.getNonDynamicServerCapabilities(manager.getClientCapabilities());
+
+		assertEquals(true, serverCapabilities.getHoverProvider());
+		assertEquals(null, serverCapabilities.getCompletionProvider());
+	}
+
+	private void setAllCapabilities(boolean areAllDynamic) {
+		CompletionCapabilities completion = new CompletionCapabilities();
+		completion.setDynamicRegistration(areAllDynamic);
+		textDocument.setCompletion(completion);
+		textDocument.setHover(new HoverCapabilities(areAllDynamic));
+	}
+
+	private void setAndInitializeCapabilities() {
+		clientCapabilities.setTextDocument(textDocument);
+		clientCapabilities.setWorkspace(workspace);
+		manager.setClientCapabilities(clientCapabilities);
+		manager.initializeCapabilities();
+		capabilityIDs = manager.getRegisteredCapabilities();
+	}
+
+	class LanguageClientMock implements LanguageClient {
+		@Override
+		public void telemetryEvent(Object object) {
+		}
+
+		@Override
+		public void publishDiagnostics(PublishDiagnosticsParams diagnostics) {
+		}
+
+		@Override
+		public void showMessage(MessageParams messageParams) {
+		}
+
+		@Override
+		public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams) {
+			return null;
+		}
+
+		@Override
+		public void logMessage(MessageParams message) {
+		}
+
+		@Override
+		public CompletableFuture<Void> registerCapability(RegistrationParams params) {
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
Fixes #14 

For completion and hover, if the client supports dynamic registration, they are both registered in `QuarkusCapabilityManager.java`.

Signed-off-by: David Kwon <dakwon@redhat.com>