### PR TITLE
Implement hover for application.properties keys

### DIFF
--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/QuarkusLanguageServer.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/QuarkusLanguageServer.java
@@ -57,7 +57,7 @@ public class QuarkusLanguageServer implements LanguageServer, ProcessLanguageSer
 		this.parentProcessId = params.getProcessId();
 		ServerCapabilities serverCapabilities = new ServerCapabilities();
 		serverCapabilities.setTextDocumentSync(TextDocumentSyncKind.Incremental);
-		serverCapabilities.setHoverProvider(false);
+		serverCapabilities.setHoverProvider(true);
 		serverCapabilities.setCompletionProvider(new CompletionOptions(false, Collections.emptyList()));
 		serverCapabilities.setDefinitionProvider(false);
 		serverCapabilities.setTypeDefinitionProvider(false);

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/QuarkusTextDocumentService.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/QuarkusTextDocumentService.java
@@ -117,7 +117,7 @@ public class QuarkusTextDocumentService implements TextDocumentService {
 		QuarkusProjectInfoParams projectInfoParams = createProjectInfoParams(params.getTextDocument(), null);
 		return projectInfoCache.getQuarkusProjectInfo(projectInfoParams).thenApplyAsync(projectInfo -> {
 			if (!projectInfo.isQuarkusProject()) {
-				return new Hover();
+				return null;
 			}
 			
 			String uri = params.getTextDocument().getUri();

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusHover.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusHover.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.services;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.redhat.quarkus.commons.ExtendedConfigDescriptionBuildItem;
+import com.redhat.quarkus.commons.QuarkusProjectInfo;
+import com.redhat.quarkus.ls.commons.BadLocationException;
+import com.redhat.quarkus.ls.commons.TextDocument;
+import com.redhat.quarkus.settings.QuarkusHoverSettings;
+import com.redhat.quarkus.utils.DocumentationUtils;
+import com.redhat.quarkus.utils.PropertiesScannerUtils;
+import com.redhat.quarkus.utils.PropertiesScannerUtils.PropertiesToken;
+
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.MarkupContent;
+import org.eclipse.lsp4j.MarkupKind;
+import org.eclipse.lsp4j.Position;
+
+class QuarkusHover {
+
+	private static final Logger LOGGER = Logger.getLogger(QuarkusCompletions.class.getName());
+
+	/**
+	 * Returns Hover object for the currently hovered token
+	 * 
+	 * @param document      the document
+	 * @param position      the hover position
+	 * @param projectInfo   the Quarkus project information
+	 * @param hoverSettings the hover settings
+	 * @return Hover object for the currently hovered token
+	 */
+	public Hover doHover(TextDocument document, Position position, QuarkusProjectInfo projectInfo,
+			QuarkusHoverSettings hoverSettings) {
+		Hover hover = new Hover();
+		String text = document.getText();
+		int offset;
+		try {
+			offset = document.offsetAt(position);
+		} catch (BadLocationException e) {
+			LOGGER.log(Level.SEVERE, "In QuarkusHover, position error", e);
+			return hover;
+		}
+		int startLineOffset = offset - position.getCharacter();
+		PropertiesToken token = PropertiesScannerUtils.getTokenAt(text, startLineOffset, offset);
+		
+		switch (token.getType()) {
+			case COMMENTS:
+				// no hover documentation
+				break;
+			case KEY:
+				// hover documentation on property key
+				collectPropertyKeyDocumentation(document, token, projectInfo, hoverSettings, hover);
+				break;
+			case VALUE:
+				// no hover documentation
+				break;
+			}
+		return hover;
+	}
+
+	/**
+	 * Collect the documentation for property key represented by token
+	 * 
+	 * @param document      the document
+	 * @param token         the token representing the property key being hovered
+	 * @param projectInfo   the Quarkus project information
+	 * @param hoverSettings the hover settings
+	 * @param hover         the hover object to fill with documentation
+	 */
+	private static void collectPropertyKeyDocumentation(TextDocument document, PropertiesToken token, QuarkusProjectInfo projectInfo, 
+			QuarkusHoverSettings hoverSettings, Hover hover) {
+
+		String keyName = null;
+		try {
+			int keyLength = (token.getEnd() - token.getStart()) + 1;
+			Position positionStart = document.positionAt(token.getStart());
+			String line = document.lineText(positionStart.getLine());
+			keyName = line.substring(0, keyLength).trim();
+		} catch (BadLocationException e) {
+			LOGGER.log(Level.SEVERE, "In QuarkusHover, position error", e);
+		}
+		
+		boolean markdownSupported = hoverSettings.isDocumentationFormatSupported(MarkupKind.MARKDOWN);
+		for (ExtendedConfigDescriptionBuildItem property : projectInfo.getProperties()) {
+			if (keyName.equals(property.getPropertyName())) {
+				MarkupContent markupContent = DocumentationUtils.getDocumentation(property, markdownSupported);
+				hover.setContents(markupContent);
+				return;
+			}
+		}
+	}
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusLanguageService.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusLanguageService.java
@@ -10,12 +10,14 @@
 package com.redhat.quarkus.services;
 
 import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
 import com.redhat.quarkus.commons.QuarkusProjectInfo;
 import com.redhat.quarkus.ls.commons.TextDocument;
 import com.redhat.quarkus.settings.QuarkusCompletionSettings;
+import com.redhat.quarkus.settings.QuarkusHoverSettings;
 
 /**
  * The Quarkus language service.
@@ -26,13 +28,20 @@ import com.redhat.quarkus.settings.QuarkusCompletionSettings;
 public class QuarkusLanguageService {
 
 	private final QuarkusCompletions completions;
+	private final QuarkusHover hover;
 
 	public QuarkusLanguageService() {
 		this.completions = new QuarkusCompletions();
+		this.hover = new QuarkusHover();
 	}
 
 	public CompletionList doComplete(TextDocument document, Position position, QuarkusProjectInfo projectInfo,
 			QuarkusCompletionSettings completionSettings, CancelChecker cancelChecker) {
 		return completions.doComplete(document, position, projectInfo, completionSettings, cancelChecker);
+	}
+
+	public Hover doHover(TextDocument document, Position position, QuarkusProjectInfo projectInfo,
+			QuarkusHoverSettings hoverSettings) {
+		return hover.doHover(document, position, projectInfo, hoverSettings);
 	}
 }

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusLanguageService.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusLanguageService.java
@@ -40,8 +40,19 @@ public class QuarkusLanguageService {
 		return completions.doComplete(document, position, projectInfo, completionSettings, cancelChecker);
 	}
 
+	/**
+	 * Returns Hover object for the currently hovered token
+	 * 
+	 * @param document      the document
+	 * @param position      the hover position
+	 * @param projectInfo   the Quarkus project information
+	 * @param hoverSettings the hover settings
+	 * @return Hover object for the currently hovered token
+	 */
 	public Hover doHover(TextDocument document, Position position, QuarkusProjectInfo projectInfo,
 			QuarkusHoverSettings hoverSettings) {
 		return hover.doHover(document, position, projectInfo, hoverSettings);
 	}
+
+	
 }

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/QuarkusHoverSettings.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/QuarkusHoverSettings.java
@@ -34,7 +34,7 @@ public class QuarkusHoverSettings {
 	 * @return <code>true</code> if the client support the given documentation
 	 *         format and <code>false</code> otherwise.
 	 */
-	public boolean isDocumentationFormatSupported(String documentationFormat) {
+	public boolean isContentFormatSupported(String documentationFormat) {
 		return capabilities.getContentFormat() != null
 				&& capabilities.getContentFormat().contains(documentationFormat);
 	}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/QuarkusHoverSettings.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/QuarkusHoverSettings.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.settings;
+
+import org.eclipse.lsp4j.HoverCapabilities;
+
+/**
+ * A wrapper around LSP {@link HoverCapabilities}.
+ *
+ */
+public class QuarkusHoverSettings {
+
+	private HoverCapabilities capabilities;
+
+	public void setCapabilities(HoverCapabilities capabilities) {
+		this.capabilities = capabilities;
+	}
+
+	public HoverCapabilities getCapabilities() {
+		return capabilities;
+	}
+
+	/**
+	 * Returns <code>true</code> if the client support the given documentation
+	 * format and <code>false</code> otherwise.
+	 * 
+	 * @return <code>true</code> if the client support the given documentation
+	 *         format and <code>false</code> otherwise.
+	 */
+	public boolean isDocumentationFormatSupported(String documentationFormat) {
+		return capabilities.getContentFormat() != null
+				&& capabilities.getContentFormat().contains(documentationFormat);
+	}
+
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/SharedSettings.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/SharedSettings.java
@@ -18,9 +18,11 @@ package com.redhat.quarkus.settings;
 public class SharedSettings {
 
 	private final QuarkusCompletionSettings completionSettings;
+	private final QuarkusHoverSettings hoverSettings;
 
 	public SharedSettings() {
 		this.completionSettings = new QuarkusCompletionSettings();
+		this.hoverSettings = new QuarkusHoverSettings();
 	}
 
 	/**
@@ -30,5 +32,14 @@ public class SharedSettings {
 	 */
 	public QuarkusCompletionSettings getCompletionSettings() {
 		return completionSettings;
+	}
+
+	/**
+	 * Returns the hover settings.
+	 * 
+	 * @return the hover settings.
+	 */
+	public QuarkusHoverSettings getHoverSettings() {
+		return hoverSettings;
 	}
 }

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/utils/PositionUtils.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/utils/PositionUtils.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.utils;
+
+import com.redhat.quarkus.ls.commons.BadLocationException;
+import com.redhat.quarkus.ls.commons.TextDocument;
+
+import org.eclipse.lsp4j.Range;
+
+public class PositionUtils {
+
+	public static Range createRange(int startOffset, int endOffset, TextDocument document) {
+		try {
+			return new Range(document.positionAt(startOffset), document.positionAt(endOffset));
+		} catch (BadLocationException e) {
+			return null;
+		}
+	}
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/utils/PropertiesScannerUtils.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/utils/PropertiesScannerUtils.java
@@ -121,7 +121,7 @@ public class PropertiesScannerUtils {
 			return new PropertiesToken(startLineOffset, text.length() - 1, PropertiesTokenType.COMMENTS);
 		case KEY:
 			// In key type, end offset is the end of line or '='
-			for (int i = startLineOffset; i < text.length() - startLineOffset; i++) {
+			for (int i = startLineOffset; i < text.length(); i++) {
 				char c = text.charAt(i);
 				if (c == '=' || c == '\r' || c == '\n') {
 					return new PropertiesToken(startLineOffset, i - 1, PropertiesTokenType.KEY);

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/utils/PropertiesScannerUtils.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/utils/PropertiesScannerUtils.java
@@ -132,19 +132,27 @@ public class PropertiesScannerUtils {
 			// In value type, end offset is the end of line only if there are not a '\'
 			// character before (multi value)
 			boolean lastCharIsBackSlash = false;
-			for (int i = startLineOffset; i < text.length() - startLineOffset; i++) {
+			boolean reachedEquals = false;
+			int tokenStartOffset = startLineOffset;
+
+			for (int i = startLineOffset; i < text.length(); i++) {
 				char c = text.charAt(i);
 				if (c == '\\') {
 					lastCharIsBackSlash = true;
 				} else if (c == '\r' || c == '\n') {
 					if (!lastCharIsBackSlash) {
-						return new PropertiesToken(startLineOffset, i - 1, PropertiesTokenType.VALUE);
+						return new PropertiesToken(tokenStartOffset, i - 1, PropertiesTokenType.VALUE);
 					}
+				} else if (c == '=') {
+					reachedEquals = true;
 				} else {
 					lastCharIsBackSlash = false;
+					if (c != ' ' && reachedEquals && tokenStartOffset == startLineOffset) {
+						tokenStartOffset = i;
+					}
 				}
 			}
-			return new PropertiesToken(startLineOffset, text.length() - 1, PropertiesTokenType.VALUE);
+			return new PropertiesToken(tokenStartOffset, text.length() - 1, PropertiesTokenType.VALUE);
 		default:
 			return new PropertiesToken(startLineOffset, text.length() - 1, PropertiesTokenType.KEY);
 		}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesHoverTest.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesHoverTest.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+
+package com.redhat.quarkus.services;
+
+
+import static com.redhat.quarkus.services.QuarkusAssert.assertHoverMarkdown;
+import static com.redhat.quarkus.services.QuarkusAssert.assertHoverPlaintext;
+
+import org.junit.Test;
+
+import com.redhat.quarkus.ls.commons.BadLocationException;
+
+/**
+ * Test with completion in 'application.properties' file.
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class ApplicationPropertiesHoverTest {
+
+	@Test
+	public void testQuarkusKeyHoverMarkdown() throws BadLocationException {
+		String value = "quarkus.applica|tion.name = \"name\"";
+		String hoverLabel = "**quarkus.application.name**\n\nThe name of the application.\n If not set, defaults to the name of the project.\n\n * Type: `java.lang.String`\n * Phase: `buildtime`\n * Location: `quarkus-core-deployment-0.19.1.jar`\n * Source: `io.quarkus.deployment.ApplicationConfig#name`";
+		assertHoverMarkdown(value, hoverLabel, 0);
+	};
+
+	@Test
+	public void testQuarkusKeyHoverPlaintext() throws BadLocationException {
+		String value = "quarkus.applica|tion.name = \"name\"";
+		String hoverLabel = "quarkus.application.name\n\nThe name of the application.\n If not set, defaults to the name of the project.\n\nType: java.lang.String\nPhase: buildtime\nLocation: quarkus-core-deployment-0.19.1.jar\nSource: io.quarkus.deployment.ApplicationConfig#name";
+		assertHoverPlaintext(value, hoverLabel, 0);
+	};
+
+	@Test
+	public void testQuarkusKeyHoverNoSpaces() throws BadLocationException {
+		String value = "quarkus.applica|tion.name=\"name\"";
+		String hoverLabel = "**quarkus.application.name**\n\nThe name of the application.\n If not set, defaults to the name of the project.\n\n * Type: `java.lang.String`\n * Phase: `buildtime`\n * Location: `quarkus-core-deployment-0.19.1.jar`\n * Source: `io.quarkus.deployment.ApplicationConfig#name`";
+		assertHoverMarkdown(value, hoverLabel, 0);
+	};
+
+	@Test
+	public void testQuarkusKeyHoverOnEqualsSign() throws BadLocationException {
+		String value = "quarkus.application.name |= \"name\"";
+		String hoverLabel = "**quarkus.application.name**\n\nThe name of the application.\n If not set, defaults to the name of the project.\n\n * Type: `java.lang.String`\n * Phase: `buildtime`\n * Location: `quarkus-core-deployment-0.19.1.jar`\n * Source: `io.quarkus.deployment.ApplicationConfig#name`";
+		assertHoverMarkdown(value, hoverLabel, 0);
+	};
+
+	@Test
+	public void testQuarkusKeyHoverOnEqualsSignNoSpaces() throws BadLocationException {
+		String value = "quarkus.application.name|=\"name\"";
+		String hoverLabel = "**quarkus.application.name**\n\nThe name of the application.\n If not set, defaults to the name of the project.\n\n * Type: `java.lang.String`\n * Phase: `buildtime`\n * Location: `quarkus-core-deployment-0.19.1.jar`\n * Source: `io.quarkus.deployment.ApplicationConfig#name`";
+		assertHoverMarkdown(value, hoverLabel, 0);
+	};
+
+}


### PR DESCRIPTION
Fixes #6 

Example:
![image](https://user-images.githubusercontent.com/20326645/62895761-913e6f00-bd1d-11e9-996d-6a70e2088927.png)

I did not write tests for this feature yet.
I also did not write an extension/participant for hover.

I might be wrong, but I think there are some small problems with [`PropertiesScannerUtils.java`](https://github.com/xorye/quarkus-ls/blob/3a32cc72b7300f91dbdebad7b3a311ce9915d3bb/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/utils/PropertiesScannerUtils.java). More specifically [here](https://github.com/xorye/quarkus-ls/blob/3a32cc72b7300f91dbdebad7b3a311ce9915d3bb/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/utils/PropertiesScannerUtils.java#L135) and [here](https://github.com/xorye/quarkus-ls/blob/3a32cc72b7300f91dbdebad7b3a311ce9915d3bb/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/utils/PropertiesScannerUtils.java#L141).

For the first one, I think the for loop condition should be `i < text.length()` and for the second one, I think we need to change `startLineOffset`. I can fix these if needed.

Signed-off-by: David Kwon <dakwon@redhat.com>