### PR TITLE
Fix hover test on Windows

### DIFF
--- a/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesHoverTest.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesHoverTest.java
@@ -10,7 +10,6 @@
 
 package com.redhat.quarkus.services;
 
-
 import static com.redhat.quarkus.services.QuarkusAssert.assertHoverMarkdown;
 import static com.redhat.quarkus.services.QuarkusAssert.assertHoverPlaintext;
 
@@ -19,9 +18,7 @@ import org.junit.Test;
 import com.redhat.quarkus.ls.commons.BadLocationException;
 
 /**
- * Test with completion in 'application.properties' file.
- * 
- * @author Angelo ZERR
+ * Test with hover in 'application.properties' file.
  *
  */
 public class ApplicationPropertiesHoverTest {
@@ -29,35 +26,50 @@ public class ApplicationPropertiesHoverTest {
 	@Test
 	public void testQuarkusKeyHoverMarkdown() throws BadLocationException {
 		String value = "quarkus.applica|tion.name = \"name\"";
-		String hoverLabel = "**quarkus.application.name**\n\nThe name of the application.\n If not set, defaults to the name of the project.\n\n * Type: `java.lang.String`\n * Phase: `buildtime`\n * Location: `quarkus-core-deployment-0.19.1.jar`\n * Source: `io.quarkus.deployment.ApplicationConfig#name`";
+		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator()
+				+ "The name of the application.\n If not set, defaults to the name of the project."
+				+ System.lineSeparator() + System.lineSeparator()
+				+ " * Type: `java.lang.String`" + System.lineSeparator() + " * Phase: `buildtime`" + System.lineSeparator() + " * Location: `quarkus-core-deployment-0.19.1.jar`" + System.lineSeparator() + " * Source: `io.quarkus.deployment.ApplicationConfig#name`";
 		assertHoverMarkdown(value, hoverLabel, 0);
 	};
 
 	@Test
 	public void testQuarkusKeyHoverPlaintext() throws BadLocationException {
 		String value = "quarkus.applica|tion.name = \"name\"";
-		String hoverLabel = "quarkus.application.name\n\nThe name of the application.\n If not set, defaults to the name of the project.\n\nType: java.lang.String\nPhase: buildtime\nLocation: quarkus-core-deployment-0.19.1.jar\nSource: io.quarkus.deployment.ApplicationConfig#name";
+		String hoverLabel = "quarkus.application.name" + System.lineSeparator() + System.lineSeparator()
+				+ "The name of the application.\n If not set, defaults to the name of the project."
+				+ System.lineSeparator() + System.lineSeparator()
+				+ "Type: java.lang.String" + System.lineSeparator() + "Phase: buildtime" + System.lineSeparator() + "Location: quarkus-core-deployment-0.19.1.jar" + System.lineSeparator() + "Source: io.quarkus.deployment.ApplicationConfig#name";
 		assertHoverPlaintext(value, hoverLabel, 0);
 	};
 
 	@Test
 	public void testQuarkusKeyHoverNoSpaces() throws BadLocationException {
 		String value = "quarkus.applica|tion.name=\"name\"";
-		String hoverLabel = "**quarkus.application.name**\n\nThe name of the application.\n If not set, defaults to the name of the project.\n\n * Type: `java.lang.String`\n * Phase: `buildtime`\n * Location: `quarkus-core-deployment-0.19.1.jar`\n * Source: `io.quarkus.deployment.ApplicationConfig#name`";
+		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator()
+				+ "The name of the application.\n If not set, defaults to the name of the project."
+				+ System.lineSeparator() + System.lineSeparator()
+				+ " * Type: `java.lang.String`" + System.lineSeparator() + " * Phase: `buildtime`" + System.lineSeparator() + " * Location: `quarkus-core-deployment-0.19.1.jar`" + System.lineSeparator() + " * Source: `io.quarkus.deployment.ApplicationConfig#name`";
 		assertHoverMarkdown(value, hoverLabel, 0);
 	};
 
 	@Test
 	public void testQuarkusKeyHoverOnEqualsSign() throws BadLocationException {
 		String value = "quarkus.application.name |= \"name\"";
-		String hoverLabel = "**quarkus.application.name**\n\nThe name of the application.\n If not set, defaults to the name of the project.\n\n * Type: `java.lang.String`\n * Phase: `buildtime`\n * Location: `quarkus-core-deployment-0.19.1.jar`\n * Source: `io.quarkus.deployment.ApplicationConfig#name`";
+		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator()
+				+ "The name of the application.\n If not set, defaults to the name of the project."
+				+ System.lineSeparator() + System.lineSeparator()
+				+ " * Type: `java.lang.String`" + System.lineSeparator() + " * Phase: `buildtime`" + System.lineSeparator() + " * Location: `quarkus-core-deployment-0.19.1.jar`" + System.lineSeparator() + " * Source: `io.quarkus.deployment.ApplicationConfig#name`";
 		assertHoverMarkdown(value, hoverLabel, 0);
 	};
 
 	@Test
 	public void testQuarkusKeyHoverOnEqualsSignNoSpaces() throws BadLocationException {
 		String value = "quarkus.application.name|=\"name\"";
-		String hoverLabel = "**quarkus.application.name**\n\nThe name of the application.\n If not set, defaults to the name of the project.\n\n * Type: `java.lang.String`\n * Phase: `buildtime`\n * Location: `quarkus-core-deployment-0.19.1.jar`\n * Source: `io.quarkus.deployment.ApplicationConfig#name`";
+		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator()
+				+ "The name of the application.\n If not set, defaults to the name of the project."
+				+ System.lineSeparator() + System.lineSeparator()
+				+ " * Type: `java.lang.String`" + System.lineSeparator() + " * Phase: `buildtime`" + System.lineSeparator() + " * Location: `quarkus-core-deployment-0.19.1.jar`" + System.lineSeparator() + " * Source: `io.quarkus.deployment.ApplicationConfig#name`";
 		assertHoverMarkdown(value, hoverLabel, 0);
 	};
 


### PR DESCRIPTION
On Windows OS, the line separator is \r\n. This PR fix that. The hard coded \n comes from the Javadoc of Quarkus properties (see META-INF/quarkus-javadoc.properties files from JAR)