### PR TITLE
Add test diagnostic

### DIFF
--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/QuarkusLanguageServer.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/QuarkusLanguageServer.java
@@ -66,7 +66,7 @@ public class QuarkusLanguageServer implements LanguageServer, ProcessLanguageSer
 		serverCapabilities.setDocumentHighlightProvider(false);
 		serverCapabilities.setDocumentSymbolProvider(false);
 		serverCapabilities.setWorkspaceSymbolProvider(false);
-		serverCapabilities.setCodeActionProvider(false);
+		serverCapabilities.setCodeActionProvider(true);
 		serverCapabilities.setDocumentFormattingProvider(true);
 		serverCapabilities.setDocumentRangeFormattingProvider(true);
 		serverCapabilities.setRenameProvider(false);

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusCodeActions.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusCodeActions.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.services;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.redhat.quarkus.ls.commons.CodeActionFactory;
+import com.redhat.quarkus.ls.commons.TextDocument;
+
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionContext;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.Range;
+
+public class QuarkusCodeActions {
+
+	public List<CodeAction> doCodeActions(CodeActionContext context, Range range, TextDocument document) {
+		List<CodeAction> codeActions = new ArrayList<>();
+
+		for (Diagnostic diagnostic: context.getDiagnostics()) {
+			switch (diagnostic.getCode()) {
+				case "missing_equals_after_key": {
+					codeActions.add(codeAction_missing_equals_after_key(diagnostic, range, document));
+					break;
+				}
+			}
+		}
+		return codeActions;
+	}
+
+	private CodeAction codeAction_missing_equals_after_key(Diagnostic diagnostic, Range range, TextDocument textDocument) {
+		// TODO equals sign should be placed with respect to the user's formatting settings
+		return CodeActionFactory.insert("Add '=' after key", range.getEnd(), " = ", textDocument, diagnostic);
+	}
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusDiagnostics.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusDiagnostics.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.services;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.redhat.quarkus.utils.PropertiesScannerUtils.PropertiesToken;
+import static com.redhat.quarkus.utils.PropertiesScannerUtils.getTokenAt;
+
+import com.redhat.quarkus.ls.commons.BadLocationException;
+import com.redhat.quarkus.ls.commons.TextDocument;
+import com.redhat.quarkus.settings.QuarkusValidationSettings;
+import com.redhat.quarkus.utils.ApplicationPropertiesDocumentUtils;
+import com.redhat.quarkus.utils.PropertiesScannerUtils.PropertiesTokenType;
+
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+
+class QuarkusDiagnostics {
+
+	public List<Diagnostic> doDiagnostics(TextDocument document, QuarkusValidationSettings validationSettings) {
+		List<Diagnostic> diagnostics = new ArrayList<Diagnostic>();
+
+		if (validationSettings.isEnabled()) {
+			scanForMissingEquals(document, diagnostics);
+		}
+
+		return diagnostics;
+	}
+
+	private void scanForMissingEquals(TextDocument document, List<Diagnostic> diagnostics) {
+		try {
+			int lines = ApplicationPropertiesDocumentUtils.getTotalLines(document);
+			String lineText;
+
+			for (int i = 0; i < lines; i++) {
+				lineText = document.lineText(i);
+				
+				if (lineText.length() == 0) {
+					continue;
+				}
+
+				if (lineRequiresEqualsToken(lineText)) {
+					diagnostics.add(createMissingEqualsDiagnostic(i, lineText.length()));
+				}
+			}
+		} catch (BadLocationException e) {
+			// Do nothing
+		}
+	}
+
+	private boolean lineRequiresEqualsToken(String lineText) {
+
+		boolean lineContainsKey = false;
+		int startLineOffset = 0;
+		int offset = 0;
+		PropertiesToken curr;
+
+		while (offset < lineText.length()) {
+			curr = getTokenAt(lineText, startLineOffset, offset);
+			
+			if (curr.getType() == PropertiesTokenType.KEY) {
+				lineContainsKey = true;
+			} else if (curr.getType() == PropertiesTokenType.EQUALS) {
+				return false;
+			}
+
+			offset = curr.getEnd() + 1;
+		}
+
+		return lineContainsKey;
+	}
+
+	private Diagnostic createMissingEqualsDiagnostic(int lineIndex, int lineLength) {
+		Position start = new Position(lineIndex, 0);
+		Position end = new Position(lineIndex, lineLength);
+		Range range = new Range(start, end);
+		return new Diagnostic(range, "Missing '=' after key", DiagnosticSeverity.Error, "application.properties", "missing_equals_after_key");
+	}
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusHover.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusHover.java
@@ -26,7 +26,6 @@ import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.Range;
 
 /**
  * Retreives hover documentation and creating Hover object

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusLanguageService.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusLanguageService.java
@@ -9,15 +9,26 @@
 *******************************************************************************/
 package com.redhat.quarkus.services;
 
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 import com.redhat.quarkus.commons.QuarkusProjectInfo;
 import com.redhat.quarkus.ls.commons.TextDocument;
 import com.redhat.quarkus.settings.QuarkusCompletionSettings;
 import com.redhat.quarkus.settings.QuarkusHoverSettings;
+import com.redhat.quarkus.settings.QuarkusValidationSettings;
 
 /**
  * The Quarkus language service.
@@ -29,10 +40,14 @@ public class QuarkusLanguageService {
 
 	private final QuarkusCompletions completions;
 	private final QuarkusHover hover;
+	private final QuarkusDiagnostics diagnostics;
+	private final QuarkusCodeActions codeActions;
 
 	public QuarkusLanguageService() {
 		this.completions = new QuarkusCompletions();
 		this.hover = new QuarkusHover();
+		this.diagnostics = new QuarkusDiagnostics();
+		this.codeActions = new QuarkusCodeActions();
 	}
 
 	public CompletionList doComplete(TextDocument document, Position position, QuarkusProjectInfo projectInfo,
@@ -54,5 +69,21 @@ public class QuarkusLanguageService {
 		return hover.doHover(document, position, projectInfo, hoverSettings);
 	}
 
-	
+	public List<CodeAction> doCodeActions(CodeActionContext context, Range range, TextDocument document) {
+		return codeActions.doCodeActions(context, range, document);
+	}
+
+	public List<Diagnostic> doDiagnostics(TextDocument document, QuarkusValidationSettings validationSettings) {
+		return diagnostics.doDiagnostics(document, validationSettings);
+	}
+
+	public CompletableFuture<Path> publishDiagnostics(TextDocument document, 
+			Consumer<PublishDiagnosticsParams> publishDiagnostics,
+			QuarkusValidationSettings validationSettings) {
+		
+		String uri = document.getUri();
+		List<Diagnostic> diagnostics = this.doDiagnostics(document, validationSettings);
+		publishDiagnostics.accept(new PublishDiagnosticsParams(uri, diagnostics));
+		return null;
+	}
 }

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/QuarkusValidationSettings.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/QuarkusValidationSettings.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+
+package com.redhat.quarkus.settings;
+
+public class QuarkusValidationSettings {
+
+	private boolean enabled;
+
+	public QuarkusValidationSettings() {
+		enabled = true;
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/SharedSettings.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/SharedSettings.java
@@ -19,10 +19,12 @@ public class SharedSettings {
 
 	private final QuarkusCompletionSettings completionSettings;
 	private final QuarkusHoverSettings hoverSettings;
+	private final QuarkusValidationSettings validationSettings;
 
 	public SharedSettings() {
 		this.completionSettings = new QuarkusCompletionSettings();
 		this.hoverSettings = new QuarkusHoverSettings();
+		this.validationSettings = new QuarkusValidationSettings();
 	}
 
 	/**
@@ -41,5 +43,14 @@ public class SharedSettings {
 	 */
 	public QuarkusHoverSettings getHoverSettings() {
 		return hoverSettings;
+	}
+
+	/**
+	 * Returns the validation settings.
+	 * 
+	 * @return the validation settings.
+	 */
+	public QuarkusValidationSettings getValidationSettings() {
+		return validationSettings;
 	}
 }

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/utils/ApplicationPropertiesDocumentUtils.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/utils/ApplicationPropertiesDocumentUtils.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+
+package com.redhat.quarkus.utils;
+
+import com.redhat.quarkus.ls.commons.BadLocationException;
+import com.redhat.quarkus.ls.commons.TextDocument;
+
+public class ApplicationPropertiesDocumentUtils {
+
+	/**
+	 * Returns the number of total lines in <code>document</code>
+	 * @param document the document of interest
+	 * @return the number of total lines in <code>document</code>
+	 */
+	public static int getTotalLines(TextDocument document) throws BadLocationException{
+		int length = document.getText().length();
+		int lastLineIndex = document.positionAt(length).getLine();
+		return lastLineIndex + 1;
+	}
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/diagnostics/ApplicationPropertiesDiagnosticsTest.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/diagnostics/ApplicationPropertiesDiagnosticsTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.diagnostics;
+
+import static com.redhat.quarkus.services.QuarkusAssert.d;
+import static com.redhat.quarkus.services.QuarkusAssert.te;
+import static com.redhat.quarkus.services.QuarkusAssert.ca;
+import static com.redhat.quarkus.services.QuarkusAssert.testDiagnosticsFor;
+import static com.redhat.quarkus.services.QuarkusAssert.testCodeActionsFor;
+
+import org.eclipse.lsp4j.Diagnostic;
+import org.junit.Test;
+
+/**
+ * Test diagnostics in 'application.properties' file.
+ *
+ */
+public class ApplicationPropertiesDiagnosticsTest {
+
+	@Test
+	public void testMissingEqualsSignOnlyKey() {
+		String content = "quarkus.application.name";
+
+		Diagnostic d = d(0, 0, 0, content.length(), "missing_equals_after_key");
+		testDiagnosticsFor(content, d);
+		testCodeActionsFor(content, d, ca(d, te(0, content.length(), 0, content.length(), " = ")));
+	}
+
+	@Test
+	public void testMissingEqualsSignComment() {
+		String content = "quarkus.application.name # ====";
+		Diagnostic d = d(0, 0, 0, content.length(), "missing_equals_after_key");
+		testDiagnosticsFor(content, d);
+	}
+
+	@Test
+	public void testMissingEqualsSignOnlyKeyMultipleLines() {
+		String key0 = "quarkus.application.name";
+		String key1 = "quarkus.application.version";
+		String key2 = "quarkus.datasource.background-validation-interval";
+		String key3 = "quarkus.datasource.idle-removal-interval";
+
+		String content =
+		key0 + System.lineSeparator() + 
+		key1 + System.lineSeparator() + 
+		key2 + System.lineSeparator() + 
+		key3;
+
+		Diagnostic d0 = d(0, 0, 0, key0.length(), "missing_equals_after_key");
+		Diagnostic d1 = d(1, 0, 1, key1.length(), "missing_equals_after_key");
+		Diagnostic d2 = d(2, 0, 2, key2.length(), "missing_equals_after_key");
+		Diagnostic d3 = d(3, 0, 3, key3.length(), "missing_equals_after_key");
+
+		testDiagnosticsFor(content, d0, d1, d2, d3);
+		testCodeActionsFor(content, d0, ca(d0, te(0, key0.length(), 0, key0.length(), " = ")));
+		testCodeActionsFor(content, d1, ca(d1, te(1, key1.length(), 1, key1.length(), " = ")));
+		testCodeActionsFor(content, d2, ca(d2, te(2, key2.length(), 2, key2.length(), " = ")));
+		testCodeActionsFor(content, d3, ca(d3, te(3, key3.length(), 3, key3.length(), " = ")));
+	}
+
+	@Test
+	public void testNoMissingEqualsSignEmptyFile() {
+		String content = "";
+		testDiagnosticsFor(content);
+	}
+
+	@Test
+	public void testNoMissingEqualsSignComment() {
+		String content = "# quarkus.application.name";
+		testDiagnosticsFor(content);
+	}
+
+
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesHoverTest.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesHoverTest.java
@@ -24,7 +24,7 @@ import com.redhat.quarkus.ls.commons.BadLocationException;
 public class ApplicationPropertiesHoverTest {
 
 	@Test
-	public void testQuarkusKeyHoverMarkdown() throws BadLocationException {
+	public void testKeyHoverMarkdown() throws BadLocationException {
 		String value = "quarkus.applica|tion.name = \"name\"";
 		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator()
 				+ "The name of the application.\n If not set, defaults to the name of the project."
@@ -34,7 +34,7 @@ public class ApplicationPropertiesHoverTest {
 	};
 
 	@Test
-	public void testQuarkusKeyHoverPlaintext() throws BadLocationException {
+	public void testKeyHoverPlaintext() throws BadLocationException {
 		String value = "quarkus.applica|tion.name = \"name\"";
 		String hoverLabel = "quarkus.application.name" + System.lineSeparator() + System.lineSeparator()
 				+ "The name of the application.\n If not set, defaults to the name of the project."
@@ -44,7 +44,7 @@ public class ApplicationPropertiesHoverTest {
 	};
 
 	@Test
-	public void testQuarkusKeyHoverNoSpaces() throws BadLocationException {
+	public void testKeyHoverNoSpaces() throws BadLocationException {
 		String value = "quarkus.applica|tion.name=\"name\"";
 		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator()
 				+ "The name of the application.\n If not set, defaults to the name of the project."
@@ -54,23 +54,15 @@ public class ApplicationPropertiesHoverTest {
 	};
 
 	@Test
-	public void testQuarkusKeyHoverOnEqualsSign() throws BadLocationException {
+	public void testNoKeyHoverOnEqualsSign() throws BadLocationException {
 		String value = "quarkus.application.name |= \"name\"";
-		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator()
-				+ "The name of the application.\n If not set, defaults to the name of the project."
-				+ System.lineSeparator() + System.lineSeparator()
-				+ " * Type: `java.lang.String`" + System.lineSeparator() + " * Phase: `buildtime`" + System.lineSeparator() + " * Location: `quarkus-core-deployment-0.19.1.jar`" + System.lineSeparator() + " * Source: `io.quarkus.deployment.ApplicationConfig#name`";
-		assertHoverMarkdown(value, hoverLabel, 0);
+		assertHoverMarkdown(value, null, null);
 	};
 
 	@Test
-	public void testQuarkusKeyHoverOnEqualsSignNoSpaces() throws BadLocationException {
+	public void testNoQuarkusKeyHoverOnEqualsSignNoSpaces() throws BadLocationException {
 		String value = "quarkus.application.name|=\"name\"";
-		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator()
-				+ "The name of the application.\n If not set, defaults to the name of the project."
-				+ System.lineSeparator() + System.lineSeparator()
-				+ " * Type: `java.lang.String`" + System.lineSeparator() + " * Phase: `buildtime`" + System.lineSeparator() + " * Location: `quarkus-core-deployment-0.19.1.jar`" + System.lineSeparator() + " * Source: `io.quarkus.deployment.ApplicationConfig#name`";
-		assertHoverMarkdown(value, hoverLabel, 0);
+		assertHoverMarkdown(value, null, null);
 	};
 
 }


### PR DESCRIPTION
Fixes #3 

### What was implemented
This PR introduces a new diagnostic with message: "Missing '=' after key" and code: "missing_equals_after_key".

The error range covers the whole line:
![image](https://user-images.githubusercontent.com/20326645/63118360-a4df1500-bf6b-11e9-8ab7-8968304f1c36.png)

There are multiple error ranges if there is more than one line with a missing equals sign:
![image](https://user-images.githubusercontent.com/20326645/63118406-bc1e0280-bf6b-11e9-90e1-ec0b38715f62.png)

Considers comments:
![image](https://user-images.githubusercontent.com/20326645/63123555-3d2ec700-bf77-11e9-8dfd-481c5f894150.png)

Code action in action:
![](https://raw.githubusercontent.com/xorye/gifs/master/quarkus-ls/PR/%233/key.gif?token=AE3CR5LBASRJZENC4SEK4X25L3RCM)

### What was not implemented
This PR does not provide functionality allowing the client to toggle on/off validation. Validation is on by default.
This PR does not create an extensions registry like lsp4xml. An extensions registry might be helpful for implementing code actions.
This PR does not contain a file that defines error codes for error diagnostics like lsp4xml. 
I will implement these depending on feedback.

### How this PR detects a missing equals sign
For every line in `application.properties`, I continually call `PropertiesScannerUtils.getTokenType()` to determine all the tokens in a particular line. If a line contains a `KEY` token but does not contain an `EQUALS` token, I create a diagnostic. This is done all in the [`QuarkusDiagnostics.java`](https://github.com/xorye/quarkus-ls/blob/fd83e4fe5e4af39c5ea20658dd613e622db3e9a7/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusDiagnostics.java) file.

### Notes about the code action
The current code action just adds an equals sign at the end of the line with the error. This is only useful in the case where the line only contains a key. If the line contains both key and a value, but no equals sign, the code action places the equals sign at the wrong place:
![](https://raw.githubusercontent.com/xorye/gifs/master/quarkus-ls/PR/%233/keyvalue.gif?token=AE3CR5LH2UNGEEN7HUENKZK5L3RCU)

Which is not what we want. If we wanted to place the equals sign in between the key and the value, we would have to determine which part is the key and which part is the value. 

However, it might just be easier for users if they added the missing equals sign themselves, since its very quick to do. A code action that places an equals sign at the wrong place, would only frustrate users.

Signed-off-by: David Kwon <dakwon@redhat.com>