### PR TITLE
Get javadoc from only META-INF/quarkus-javadoc.properties

### DIFF
--- a/quarkus.jdt/com.redhat.quarkus.jdt.core/src/main/java/com/redhat/quarkus/jdt/core/JDTQuarkusManager.java
+++ b/quarkus.jdt/com.redhat.quarkus.jdt.core/src/main/java/com/redhat/quarkus/jdt/core/JDTQuarkusManager.java
@@ -453,8 +453,9 @@ public class JDTQuarkusManager {
 	 */
 	private static String getJavadoc(IField field, Map<IPackageFragmentRoot, Properties> javadocCache,
 			IProgressMonitor monitor) throws JavaModelException {
+		// TODO: get Javadoc from source anad attached doc by processing Javadoc tag as markdown
 		// Try to get javadoc from sources
-		String javadoc = findJavadocFromSource(field);
+		/*String javadoc = findJavadocFromSource(field);
 		if (javadoc != null) {
 			return javadoc;
 		}
@@ -462,7 +463,7 @@ public class JDTQuarkusManager {
 		javadoc = field.getAttachedJavadoc(monitor);
 		if (javadoc != null) {
 			return javadoc;
-		}
+		}*/		
 		// Try to get the javadoc inside the META-INF/quarkus-javadoc.properties of the
 		// JAR
 		IPackageFragmentRoot packageRoot = (IPackageFragmentRoot) field.getAncestor(IJavaElement.PACKAGE_FRAGMENT_ROOT);


### PR DESCRIPTION
This PR fixes https://github.com/redhat-developer/quarkus-ls/issues/35

It extract Javadoc only from META-INF/quarkus-javadoc.properties and not from java sources or attached Javadoc. To have a best renderer in markdown it should be better to transform HTML Javadoc to markdown. See issue https://github.com/redhat-developer/quarkus-ls/issues/40

Signed-off-by: azerr <azerr@redhat.com>