### PR TITLE
Change debug port for Quarkus language server

### DIFF
--- a/quarkus.ls/.vscode/launch.json
+++ b/quarkus.ls/.vscode/launch.json
@@ -8,7 +8,7 @@
 		"name": "Debug (Attach) - Remote",
 		"request": "attach",
 		"hostName": "localhost",
-		"port": 1054,
+		"port": 1064,
 		"projectName": "com.redhat.quarkus.ls"
 	}]
 }


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-quarkus/issues/35

The fix is two PRs. This one and https://github.com/redhat-developer/vscode-quarkus/pull/41

The port was changed from 1054 to 1064.

Signed-off-by: David Kwon <dakwon@redhat.com>