### PR TITLE
Implement syntax error for application.properties missing equals sign

### DIFF
--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusValidator.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusValidator.java
@@ -85,7 +85,10 @@ class QuarkusValidator {
 			// The syntax validation must be ignored for this property name
 			return;
 		}
-		// TODO : validate if there are an assign '='
+		if (property.getDelimiterAssign() == null) {
+			addDiagnostic("Missing equals sign after '" + propertyName + "'", property.getKey(), severity,
+			ValidationType.syntax.name());
+		}
 	}
 
 	private void validateDuplicateProperty(String propertyName, Property property) {

--- a/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/settings/SettingsTest.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/settings/SettingsTest.java
@@ -73,6 +73,7 @@ public class SettingsTest {
 		// Validation
 		assertNotNull(settings.getValidation());
 		assertEquals("error", settings.getValidation().getUnknown().getSeverity());
+		assertEquals("error", settings.getValidation().getSyntax().getSeverity());
 	}
 
 	private static InitializeParams createInitializeParams(String json) {


### PR DESCRIPTION
Fixes #3 

This PR replaces #36 

The error range covers the property key:
![image](https://user-images.githubusercontent.com/20326645/64733431-c243c800-d4b2-11e9-8941-90e8d8286f19.png)

The error message:
```
Missing equals sign after 'quarkus.datasource.min-size'quarkus(syntax)
Missing equals sign after 'quarkus.hibernate-orm.log.sql'quarkus(syntax)
```

Signed-off-by: David Kwon <dakwon@redhat.com>