### PR TITLE
Implement duplicate properties warning

### DIFF
--- a/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/settings/SettingsTest.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/settings/SettingsTest.java
@@ -74,6 +74,7 @@ public class SettingsTest {
 		assertNotNull(settings.getValidation());
 		assertEquals("error", settings.getValidation().getUnknown().getSeverity());
 		assertEquals("error", settings.getValidation().getSyntax().getSeverity());
+		assertEquals("warning", settings.getValidation().getDuplicate().getSeverity());
 	}
 
 	private static InitializeParams createInitializeParams(String json) {


### PR DESCRIPTION
Fixes #27 

In this PR, only the duplicate property(s) have a warning range:
![image](https://user-images.githubusercontent.com/20326645/64816870-968a1600-d576-11e9-8e90-42d9a4590c2d.png)
 
@angelozerr , I'm not sure if this is what you meant storing the property in a set. Please let me know if I should change anything.

Signed-off-by: David Kwon <dakwon@redhat.com>