### PR TITLE
Validate application.properties value type

### DIFF
--- a/quarkus.jdt/com.redhat.quarkus.jdt.core/src/main/java/com/redhat/quarkus/commons/ExtendedConfigDescriptionBuildItem.java
+++ b/quarkus.jdt/com.redhat.quarkus.jdt.core/src/main/java/com/redhat/quarkus/commons/ExtendedConfigDescriptionBuildItem.java
@@ -155,7 +155,42 @@ public class ExtendedConfigDescriptionBuildItem {
 	}
 
 	public boolean isBooleanType() {
-		return "boolean".equals(getType()) || "java.lang.Boolean".equals(getType());
+		return "boolean".equals(getType()) ||
+		"java.lang.Boolean".equals(getType()) ||
+		"java.util.Optional<java.lang.Boolean>".equals(getType());
+	}
+
+	public boolean isIntegerType() {
+		return "int".equals(getType()) ||
+		"java.lang.Integer".equals(getType()) ||
+		"java.util.OptionalInt".equals(getType()) ||
+		"java.util.Optional<java.lang.Integer>".equals(getType());
+	}
+
+	public boolean isFloatType() {
+		return "float".equals(getType()) ||
+		"java.lang.Float".equals(getType()) ||
+		"java.util.Optional<java.lang.Float>".equals(getType());
+	}
+
+	public boolean isLongType() {
+		return "long".equals(getType()) ||
+		"java.lang.Long".equals(getType()) ||
+		"java.util.OptionalLong".equals(getType()) ||
+		"java.util.Optional<java.lang.Long>".equals(getType());
+	}
+
+	public boolean isDoubleType() {
+		return "double".equals(getType()) ||
+		"java.lang.Double".equals(getType()) ||
+		"java.util.OptionalDouble".equals(getType()) ||
+		"java.util.Optional<java.lang.Double>".equals(getType());
+	}
+
+	public boolean isShortType() {
+		return "short".equals(getType()) ||
+		"java.lang.Short".equals(getType()) ||
+		"java.util.Optional<java.lang.Short>".equals(getType());
 	}
 
 	@Override

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/commons/ExtendedConfigDescriptionBuildItem.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/commons/ExtendedConfigDescriptionBuildItem.java
@@ -155,7 +155,42 @@ public class ExtendedConfigDescriptionBuildItem {
 	}
 
 	public boolean isBooleanType() {
-		return "boolean".equals(getType()) || "java.lang.Boolean".equals(getType());
+		return "boolean".equals(getType()) ||
+		"java.lang.Boolean".equals(getType()) ||
+		"java.util.Optional<java.lang.Boolean>".equals(getType());
+	}
+	
+	public boolean isIntegerType() {
+		return "int".equals(getType()) ||
+		"java.lang.Integer".equals(getType()) ||
+		"java.util.OptionalInt".equals(getType()) ||
+		"java.util.Optional<java.lang.Integer>".equals(getType());
+	}
+
+	public boolean isFloatType() {
+		return "float".equals(getType()) ||
+		"java.lang.Float".equals(getType()) ||
+		"java.util.Optional<java.lang.Float>".equals(getType());
+	}
+
+	public boolean isLongType() {
+		return "long".equals(getType()) ||
+		"java.lang.Long".equals(getType()) ||
+		"java.util.OptionalLong".equals(getType()) ||
+		"java.util.Optional<java.lang.Long>".equals(getType());
+	}
+
+	public boolean isDoubleType() {
+		return "double".equals(getType()) ||
+		"java.lang.Double".equals(getType()) ||
+		"java.util.OptionalDouble".equals(getType()) ||
+		"java.util.Optional<java.lang.Double>".equals(getType());
+	}
+
+	public boolean isShortType() {
+		return "short".equals(getType()) ||
+		"java.lang.Short".equals(getType()) ||
+		"java.util.Optional<java.lang.Short>".equals(getType());
 	}
 
 	@Override

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/model/Property.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/model/Property.java
@@ -142,11 +142,11 @@ public class Property extends Node {
 	 * @return the property value and null otherwise.
 	 */
 	public String getPropertyValue() {
-		Node value = getValue();
+		PropertyValue value = getValue();
 		if (value == null) {
 			return null;
 		}
-		return value.getText();
+		return value.getValue();
 	}
 
 	@Override

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/QuarkusValidationSettings.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/QuarkusValidationSettings.java
@@ -36,7 +36,7 @@ public class QuarkusValidationSettings {
 		DEFAULT_DUPLICATE = new QuarkusValidationTypeSettings();
 		DEFAULT_DUPLICATE.setSeverity(Severity.warning.name());
 		DEFAULT_VALUE = new QuarkusValidationTypeSettings();
-		DEFAULT_VALUE.setSeverity(Severity.warning.name());
+		DEFAULT_VALUE.setSeverity(Severity.error.name());
 		DEFAULT = new QuarkusValidationSettings();
 		DEFAULT.updateDefault();
 	}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/utils/QuarkusPropertiesUtils.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/utils/QuarkusPropertiesUtils.java
@@ -9,6 +9,9 @@
 *******************************************************************************/
 package com.redhat.quarkus.utils;
 
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.function.BiConsumer;
 


### PR DESCRIPTION
Fixes #33

This PR provides type validation for enums integer, boolean and float.

![image](https://user-images.githubusercontent.com/20326645/65168036-b6578900-da11-11e9-8b0a-8a5759e6fc36.png)

![image](https://user-images.githubusercontent.com/20326645/65168076-c4a5a500-da11-11e9-9b0a-8c338370c377.png)

![image](https://user-images.githubusercontent.com/20326645/65168001-a344b900-da11-11e9-8431-67562fa67cae.png)

@angelozerr , does the ExtendedConfigDescriptionBuildItem.java file from quarkus.ls and quarkus.jdt.core have to be the same? 





Signed-off-by: David Kwon <dakwon@redhat.com>