### PR TITLE
Add documentation for default profiles

### DIFF
--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusHover.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusHover.java
@@ -16,6 +16,7 @@ import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 
 import com.redhat.quarkus.commons.EnumItem;
 import com.redhat.quarkus.commons.ExtendedConfigDescriptionBuildItem;
@@ -26,6 +27,7 @@ import com.redhat.quarkus.model.PropertiesModel;
 import com.redhat.quarkus.model.Property;
 import com.redhat.quarkus.model.PropertyKey;
 import com.redhat.quarkus.model.PropertyValue;
+import com.redhat.quarkus.services.QuarkusModel;
 import com.redhat.quarkus.settings.QuarkusHoverSettings;
 import com.redhat.quarkus.utils.DocumentationUtils;
 import com.redhat.quarkus.utils.PositionUtils;
@@ -51,8 +53,10 @@ class QuarkusHover {
 			QuarkusHoverSettings hoverSettings) {
 
 		Node node = null;
+		int offset = -1;
 		try {
 			node = document.findNodeAt(position);
+			offset = document.offsetAt(position);
 		} catch (BadLocationException e) {
 			LOGGER.log(Level.SEVERE, "In QuarkusHover, position error", e);
 			return null;
@@ -70,25 +74,57 @@ class QuarkusHover {
 			// no hover documentation
 			return getPropertyValueHover(node, projectInfo, hoverSettings);
 		case PROPERTY_KEY:
-			// hover documentation on property key
-			return getPropertyKeyHover(node, projectInfo, hoverSettings);
+			PropertyKey key = (PropertyKey) node;
+			if (key.isBeforeProfile(offset)) {
+				// hover documentation on profile
+				return getProfileHover(key, hoverSettings);
+			} else {
+				// hover documentation on property key
+				return getPropertyKeyHover(key, projectInfo, hoverSettings);
+			}
+			
 		default:
 			return null;
 		}
 	}
 
 	/**
-	 * Returns the documentation hover for property key represented by the property
-	 * key <code>node</code>
+	 * Returns the documentation hover for the property key's profile, for the
+	 * property key represented by <code>key</code>
 	 * 
-	 * @param node          the property key node
+	 * Returns null if property key represented by <code>key</code> does not 
+	 * have a profile
+	 * 
+	 * @param key          the property key
+	 * @param hoverSettings the hover settings
+	 * @return the documentation hover for the property key's profile
+	 */
+	private static Hover getProfileHover(PropertyKey key, QuarkusHoverSettings hoverSettings) {
+		boolean markdownSupported = hoverSettings.isContentFormatSupported(MarkupKind.MARKDOWN);
+		for (EnumItem profile: QuarkusModel.DEFAULT_PROFILES) {
+			if (profile.getName().equals(key.getProfile())) {
+				MarkupContent markupContent = DocumentationUtils.getDocumentation(profile, markdownSupported);
+				Hover hover = new Hover();
+				hover.setContents(markupContent);
+				hover.setRange(getProfileHoverRange(key));
+				return hover;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the documentation hover for property key represented by the property
+	 * key <code>key</code>
+	 * 
+	 * @param key          the property key
+	 * @param offset        the hover offset
 	 * @param projectInfo   the Quarkus project information
 	 * @param hoverSettings the hover settings
 	 * @return the documentation hover for property key represented by token
 	 */
-	private static Hover getPropertyKeyHover(Node node, QuarkusProjectInfo projectInfo,
+	private static Hover getPropertyKeyHover(PropertyKey key, QuarkusProjectInfo projectInfo,
 			QuarkusHoverSettings hoverSettings) {
-		PropertyKey key = ((PropertyKey) node);
 		boolean markdownSupported = hoverSettings.isContentFormatSupported(MarkupKind.MARKDOWN);
 		// retrieve Quarkus property from the project information
 		String propertyName = key.getPropertyName();
@@ -100,7 +136,7 @@ class QuarkusHover {
 					markdownSupported);
 			Hover hover = new Hover();
 			hover.setContents(markupContent);
-			hover.setRange(PositionUtils.createRange(node));
+			hover.setRange(PositionUtils.createRange(key));
 			return hover;
 		}
 		return null;
@@ -136,5 +172,25 @@ class QuarkusHover {
 			return hover;
 		}
 		return null;
+	}
+
+	/**
+	 * Returns the hover range covering the %profilename in <code>key</code>
+	 * Returns range of <code>key</code> if <code>key</code> does not provide a profile
+	 * @param key the property key
+	 * @return the hover range covering the %profilename in <code>key</code>
+	 */
+	private static Range getProfileHoverRange(PropertyKey key) {
+		Range range = PositionUtils.createRange(key);
+		
+		if (key.getProfile() == null) {
+			return range;
+		}
+
+		String profile = key.getProfile();
+		Position endPosition = range.getEnd();
+		endPosition.setCharacter(range.getStart().getCharacter() + profile.length() + 1);
+		range.setEnd(endPosition);
+		return range;
 	}
 }

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusModel.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusModel.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.services;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.redhat.quarkus.commons.EnumItem;
+
+/**
+ * Maintains default profiles and boolean types.
+ */
+public class QuarkusModel {
+
+	private QuarkusModel() {
+	}
+
+	public static final List<EnumItem> DEFAULT_PROFILES = Arrays.asList(
+		new EnumItem("dev", "Profile activated when in development mode (quarkus:dev)."),
+		new EnumItem("prod", "The default profile when not running in development or test mode."),
+		new EnumItem("test", "Profile activated when running tests."));
+
+	public static final Collection<EnumItem> BOOLEAN_ENUMS = Arrays.asList(new EnumItem("false", null), new EnumItem("true", null));
+
+	public static List<String> getDefaultProfileNames() {
+		return DEFAULT_PROFILES.stream().map(EnumItem::getName).collect(Collectors.toList());
+	}
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/utils/DocumentationUtils.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/utils/DocumentationUtils.java
@@ -12,11 +12,12 @@ package com.redhat.quarkus.utils;
 
 import static com.redhat.quarkus.utils.QuarkusPropertiesUtils.formatPropertyForMarkdown;
 
-import org.eclipse.lsp4j.MarkupContent;
-import org.eclipse.lsp4j.MarkupKind;
-
 import com.redhat.quarkus.commons.EnumItem;
 import com.redhat.quarkus.commons.ExtendedConfigDescriptionBuildItem;
+
+import org.eclipse.lsp4j.MarkupContent;
+import org.eclipse.lsp4j.MarkupKind;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 /**
  * Utility for documentation.
@@ -142,4 +143,22 @@ public class DocumentationUtils {
 		return new MarkupContent(markdown ? MarkupKind.MARKDOWN : MarkupKind.PLAINTEXT, documentation.toString());
 	}
 
+	/**
+	 * Returns the documentation content of <code>documentation</code>.
+	 * Returns null if documentation content does not exist.
+	 * @param documentation contains documentation content
+	 * @return the documentation content of <code>documentation</code>.
+	 */
+	public static String getDocumentationTextFromEither(Either<String, MarkupContent> documentation) {
+
+		if (documentation == null) {
+			return null;
+		}
+
+		if (documentation.isRight()) {
+			return documentation.getRight().getValue();
+		}
+
+		return documentation.getLeft();
+	}
 }

--- a/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesCompletionTest.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesCompletionTest.java
@@ -119,27 +119,27 @@ public class ApplicationPropertiesCompletionTest {
 	}
 
 	@Test
-	public void completionOnProfil() throws BadLocationException {
+	public void completionOnProfile() throws BadLocationException {
 		String value = "%|";
-		testCompletionFor(value, true, 3, c("dev", "%dev", r(0, 0, 1)), //
-				c("prod", "%prod", r(0, 0, 1)), //
-				c("test", "%test", r(0, 0, 1)));
+		testCompletionFor(value, true, 3, c("dev", "%dev", r(0, 0, 1), "dev\n\nProfile activated when in development mode (quarkus:dev).\n"), //
+				c("prod", "%prod", r(0, 0, 1), "prod\n\nThe default profile when not running in development or test mode.\n"), //
+				c("test", "%test", r(0, 0, 1), "test\n\nProfile activated when running tests.\n"));
 
 		value = "%st|aging.";
 		testCompletionFor(value, true, 4, c("staging", "%staging", r(0, 0, 9)), //
-				c("dev", "%dev", r(0, 0, 9)), //
-				c("prod", "%prod", r(0, 0, 9)), //
-				c("test", "%test", r(0, 0, 9)));
+				c("dev", "%dev", r(0, 0, 9), "dev\n\nProfile activated when in development mode (quarkus:dev).\n"), //
+				c("prod", "%prod", r(0, 0, 9), "prod\n\nThe default profile when not running in development or test mode.\n"), //
+				c("test", "%test", r(0, 0, 9), "test\n\nProfile activated when running tests.\n"));
 
 		value = "%staging|.";
 		testCompletionFor(value, true, 4, c("staging", "%staging", r(0, 0, 9)), //
-				c("dev", "%dev", r(0, 0, 9)), //
-				c("prod", "%prod", r(0, 0, 9)), //
-				c("test", "%test", r(0, 0, 9)));
+				c("dev", "%dev", r(0, 0, 9), "dev\n\nProfile activated when in development mode (quarkus:dev).\n"), //
+				c("prod", "%prod", r(0, 0, 9), "prod\n\nThe default profile when not running in development or test mode.\n"), //
+				c("test", "%test", r(0, 0, 9), "test\n\nProfile activated when running tests.\n"));
 	}
 
 	@Test
-	public void completionAfterProfil() throws BadLocationException {
+	public void completionAfterProfile() throws BadLocationException {
 		String value = "%dev.|";
 		testCompletionFor(value, false, c("quarkus.http.cors", "%dev.quarkus.http.cors=false", r(0, 0, 5)));
 		testCompletionFor(value, true, c("quarkus.http.cors", "%dev.quarkus.http.cors=${1|false,true|}", r(0, 0, 5)));

--- a/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesHoverTest.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesHoverTest.java
@@ -91,13 +91,44 @@ public class ApplicationPropertiesHoverTest {
 	};
 
 	@Test
-	public void onlyProfile() throws BadLocationException {
+	public void testDefaultProfileHover() throws BadLocationException {
+		String value = "%d|ev.quarkus.log.syslog.async.overflow=DISCARD";
+		String hoverLabelMarkdown = "**dev**\n\nProfile activated when in development mode (quarkus:dev).\n";
+		assertHoverMarkdown(value, hoverLabelMarkdown, 0);
+	}
+
+	@Test
+	public void testDefaultProfileHoverSpacesInFront() throws BadLocationException {
+		String value = "        %d|ev.quarkus.log.syslog.async.overflow=DISCARD";
+		String hoverLabelMarkdown = "**dev**\n\nProfile activated when in development mode (quarkus:dev).\n";
+		assertHoverMarkdown(value, hoverLabelMarkdown, 8);
+	}
+
+	@Test
+	public void testOnlyDefaultProfile() throws BadLocationException {
 		String value = "%de|v";
+		String hoverLabelMarkdown = "**dev**\n\nProfile activated when in development mode (quarkus:dev).\n";
+		assertHoverMarkdown(value, hoverLabelMarkdown, 0);
+
+		value = "|%prod";
+		hoverLabelMarkdown = "**prod**\n\nThe default profile when not running in development or test mode.\n";
+		assertHoverMarkdown(value, hoverLabelMarkdown, 0);
+
+		value = "%test|";
+		hoverLabelMarkdown = "**test**\n\nProfile activated when running tests.\n";
+		assertHoverMarkdown(value, hoverLabelMarkdown, 0);
+	};
+
+	@Test
+	public void testOnlyNonDefaultProfile() throws BadLocationException {
+		String value = "%hel|lo";
 		String hoverLabel = null;
 		assertHoverMarkdown(value, hoverLabel, 0);
 
-		value = "%de|v.";
-		hoverLabel = null;
+		value = "%hello|";
+		assertHoverMarkdown(value, hoverLabel, 0);
+
+		value = "|%hello";
 		assertHoverMarkdown(value, hoverLabel, 0);
 	};
 

--- a/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/QuarkusAssert.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/QuarkusAssert.java
@@ -48,6 +48,7 @@ import com.redhat.quarkus.model.PropertiesModel;
 import com.redhat.quarkus.settings.QuarkusCompletionSettings;
 import com.redhat.quarkus.settings.QuarkusHoverSettings;
 import com.redhat.quarkus.settings.QuarkusValidationSettings;
+import com.redhat.quarkus.utils.DocumentationUtils;
 
 /**
  * Quarkus assert
@@ -165,20 +166,25 @@ public class QuarkusAssert {
 		}
 
 		if (expected.getDocumentation() != null) {
-			Assert.assertEquals(expected.getDocumentation(), match.getDocumentation());
+			Assert.assertEquals(DocumentationUtils.getDocumentationTextFromEither(expected.getDocumentation()), DocumentationUtils.getDocumentationTextFromEither(match.getDocumentation()));
 		}
 
 	}
 
 	public static CompletionItem c(String label, String newText, Range range) {
-		return c(label, new TextEdit(range, newText), null);
+		return c(label, newText, range, null);
 	}
 
-	private static CompletionItem c(String label, TextEdit textEdit, String filterText) {
+	public static CompletionItem c(String label, String newText, Range range, String documentation) {
+		return c(label, new TextEdit(range, newText), null, documentation != null ? Either.forLeft(documentation) : null);
+	}
+
+	private static CompletionItem c(String label, TextEdit textEdit, String filterText, Either<String, MarkupContent>  documentation) {
 		CompletionItem item = new CompletionItem();
 		item.setLabel(label);
 		item.setFilterText(filterText);
 		item.setTextEdit(textEdit);
+		item.setDocumentation(documentation);
 		return item;
 	}
 


### PR DESCRIPTION
Fixes #89 

![image](https://user-images.githubusercontent.com/20326645/66330225-f5387a80-e8fd-11e9-9394-197c01ed62a3.png)

This PR adds the documentation specified in #89, and does not use markdown rendering.

Signed-off-by: David Kwon <dakwon@redhat.com>