### PR TITLE
Add CHANGELOG.md, update README.md

### DIFF
--- a/quarkus.ls/CHANGELOG.md
+++ b/quarkus.ls/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Quarkus Language Server Changelog
+
+## 0.0.2-SNAPSHOT (October 17, 2019)
+
+### Enhancements
+
+ * Improve documentation for default profiles. See [#89](https://github.com/redhat-developer/quarkus-ls/issues/89)
+ * Validate application.properties: type value. See [#33](https://github.com/redhat-developer/quarkus-ls/issues/33)
+ * Support for `textDocument/formatting` and `textDocument/rangeFormatting`. See [#24](https://github.com/redhat-developer/quarkus-ls/issues/24)
+ * Validate application.properties: required properties. See [#21](https://github.com/redhat-developer/quarkus-ls/issues/21)
+ * Support for `textDocument/definition` for Java fields which have Config* annotation. See [#4](https://github.com/redhat-developer/quarkus-ls/issues/4)
+
+### Bug Fixes
+
+ * Fix duplicate completion options for ConfigProperty. See [#101](https://github.com/redhat-developer/quarkus-ls/issues/101)
+ * Fix issue where boolean completion for optional boolean value was not working. See [#88](https://github.com/redhat-developer/quarkus-ls/issues/88)
+ * Fix issue where PropertiesModel start offset is -1. See [#51](https://github.com/redhat-developer/quarkus-ls/issues/51)
+ * Ignore/include properties in application.properties depending on test scope. See [#5](https://github.com/redhat-developer/quarkus-ls/issues/5)
+
+### Others
+
+ * Update lsp4j version to 0.8.1. See [#107](https://github.com/redhat-developer/quarkus-ls/pull/107)
+ * Freeze API for enumeration (String -> EnumItem). See [#99](https://github.com/redhat-developer/quarkus-ls/issues/99)
+ * Add quarkus-ls README. See [#46](https://github.com/redhat-developer/quarkus-ls/issues/46)

--- a/quarkus.ls/README.md
+++ b/quarkus.ls/README.md
@@ -21,6 +21,8 @@ Features
 * [textDocument/completion](https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_completion)
 * [textDocument/definition](https://microsoft.github.io/language-server-protocol/specifications/specification-3-14#textDocument_definition)
 * [textDocument/documentSymbol](https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_documentSymbol)
+* [textDocument/formatting](https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_formatting)
+* [textDocument/rangeFormatting](https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_rangeFormatting)
 * [textDocument/hover](https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_hover)
 * [textDocument/publishDiagnostics](https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_publishDiagnostics)
 


### PR DESCRIPTION
This PR adds a changelog that contains finished issues specific to the quarkus-ls.

The list of issues for the changelog were the issues from quarkus-ls that had a milestone of "1.1.0"

![image](https://user-images.githubusercontent.com/20326645/66949793-22370c80-f025-11e9-97aa-ce4892fcedbf.png)


Signed-off-by: David Kwon <dakwon@redhat.com>