### PR TITLE
Implement code action for missing required

### DIFF
--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/QuarkusTextDocumentService.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/QuarkusTextDocumentService.java
@@ -292,7 +292,7 @@ public class QuarkusTextDocumentService implements TextDocumentService {
 	 * given function.
 	 * 
 	 * @param <R>
-	 * @param documentIdentifier the document indetifier.
+	 * @param documentIdentifier the document identifier.
 	 * @param code               a bi function that accepts a {@link CancelChecker}
 	 *                           and parsed {@link PropertiesModel} and returns the
 	 *                           to be computed value
@@ -309,7 +309,7 @@ public class QuarkusTextDocumentService implements TextDocumentService {
 	 * given function.
 	 * 
 	 * @param <R>
-	 * @param documentIdentifier the document indetifier.
+	 * @param documentIdentifier the document identifier.
 	 * @param code               a bi function that accepts a {@link CancelChecker}
 	 *                           and parsed {@link PropertiesModel} and returns the
 	 *                           to be computed value

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/commons/CodeActionFactory.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/commons/CodeActionFactory.java
@@ -12,6 +12,7 @@ package com.redhat.quarkus.ls.commons;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
@@ -56,9 +57,24 @@ public class CodeActionFactory {
 	 */
 	public static CodeAction insert(String title, Position position, String insertText, TextDocumentItem document,
 			Diagnostic diagnostic) {
+		return insert(title, position, insertText, document, Arrays.asList(diagnostic));
+	}
+
+	/**
+	 * Create a CodeAction to insert a new content at the end of the given range.
+	 * 
+	 * @param title
+	 * @param range
+	 * @param insertText
+	 * @param document
+	 * @param diagnostics
+	 * @return
+	 */
+	public static CodeAction insert(String title, Position position, String insertText, TextDocumentItem document,
+			List<Diagnostic> diagnostics) {
 		CodeAction insertContentAction = new CodeAction(title);
 		insertContentAction.setKind(CodeActionKind.QuickFix);
-		insertContentAction.setDiagnostics(Arrays.asList(diagnostic));
+		insertContentAction.setDiagnostics(diagnostics);
 		TextEdit edit = new TextEdit(new Range(position, position), insertText);
 		VersionedTextDocumentIdentifier versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier(
 				document.getUri(), document.getVersion());

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusValidator.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusValidator.java
@@ -271,7 +271,7 @@ class QuarkusValidator {
 
 		for (Property property: propertyList) {
 			addDiagnostic("Missing required property value for '" + propertyName + "'", property, severity,
-					ValidationType.required.name());
+					ValidationType.requiredValue.name());
 		}
 	}
 

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/ValidationType.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/ValidationType.java
@@ -17,5 +17,5 @@ package com.redhat.quarkus.services;
  */
 public enum ValidationType {
 
-	syntax, unknown, duplicate, value, required;
+	syntax, unknown, duplicate, value, required, requiredValue;
 }

--- a/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesCodeActionsTest.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesCodeActionsTest.java
@@ -39,7 +39,7 @@ public class ApplicationPropertiesCodeActionsTest {
 				ValidationType.unknown);
 		testDiagnosticsFor(value, d);
 		testCodeActionsFor(value, d,
-				ca("Did you mean 'quarkus.application.name' ?", d, te(1, 0, 1, 23, "quarkus.application.name")));
+				ca("Did you mean 'quarkus.application.name' ?", te(1, 0, 1, 23, "quarkus.application.name"), d));
 	};
 
 }

--- a/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesRequiredCodeActionTest.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesRequiredCodeActionTest.java
@@ -1,0 +1,221 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.services;
+
+import static com.redhat.quarkus.services.QuarkusAssert.ca;
+import static com.redhat.quarkus.services.QuarkusAssert.d;
+import static com.redhat.quarkus.services.QuarkusAssert.te;
+import static com.redhat.quarkus.services.QuarkusAssert.testCodeActionsFor;
+import static com.redhat.quarkus.services.QuarkusAssert.testDiagnosticsFor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.redhat.quarkus.commons.ExtendedConfigDescriptionBuildItem;
+import com.redhat.quarkus.commons.QuarkusProjectInfo;
+import com.redhat.quarkus.ls.commons.BadLocationException;
+import com.redhat.quarkus.settings.QuarkusFormattingSettings;
+import com.redhat.quarkus.settings.QuarkusValidationSettings;
+import com.redhat.quarkus.settings.QuarkusValidationTypeSettings;
+
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test with the required code actions in 'application.properties' file.
+ * 
+ *
+ */
+public class ApplicationPropertiesRequiredCodeActionTest {
+
+	private static QuarkusProjectInfo projectInfo;
+	private static QuarkusValidationSettings validationSettings;
+
+	@BeforeClass
+	public static void setUp() throws Exception {
+		projectInfo = new QuarkusProjectInfo();
+		validationSettings = new QuarkusValidationSettings();
+		List<ExtendedConfigDescriptionBuildItem> properties = new ArrayList<ExtendedConfigDescriptionBuildItem>();
+		ExtendedConfigDescriptionBuildItem p1 = new ExtendedConfigDescriptionBuildItem();
+		p1.setPropertyName("quarkus.required.property");
+		p1.setRequired(true);
+		properties.add(p1);
+		ExtendedConfigDescriptionBuildItem p2 = new ExtendedConfigDescriptionBuildItem();
+		p2.setPropertyName("quarkus.second.required.property");
+		p2.setRequired(true);
+		properties.add(p2);
+		ExtendedConfigDescriptionBuildItem p3 = new ExtendedConfigDescriptionBuildItem();
+		p3.setPropertyName("quarkus.third.required.property");
+		p3.setRequired(true);
+		properties.add(p3);
+		ExtendedConfigDescriptionBuildItem p4 = new ExtendedConfigDescriptionBuildItem();
+		p4.setPropertyName("quarkus.optional.property");
+		p4.setRequired(false);
+		properties.add(p4);
+		projectInfo.setProperties(properties);
+
+		QuarkusValidationTypeSettings error = new QuarkusValidationTypeSettings();
+		error.setSeverity("warning");
+		validationSettings.setRequired(error);
+	}
+
+	@Test
+	public void testOneMissingPropertyCodeAction() throws BadLocationException {
+
+		String value = "quarkus.optional.property=hello\n" + //
+			"quarkus.second.required.property=hello\n" + //
+			"quarkus.third.required.property=hello";
+
+		Diagnostic d = d(0, 0, 2, 37, "Missing required property 'quarkus.required.property'", DiagnosticSeverity.Warning,
+				ValidationType.required);
+
+		testDiagnosticsFor(value, projectInfo, validationSettings, d);
+		testCodeActionsFor(value, d, projectInfo,
+				ca("Add all missing required properties?", te(2, 37, 2, 37, "\nquarkus.required.property="), d));
+	}
+
+	@Test
+	public void testOneMissingPropertyCodeActionDelimeter() throws BadLocationException {
+
+		String value = "quarkus.optional.property=hello\r\n" + //
+			"quarkus.second.required.property=hello\r\n" + //
+			"quarkus.third.required.property=hello";
+
+		Diagnostic d = d(0, 0, 2, 37, "Missing required property 'quarkus.required.property'", DiagnosticSeverity.Warning,
+				ValidationType.required);
+
+		testDiagnosticsFor(value, projectInfo, validationSettings, d);
+		testCodeActionsFor(value, d, projectInfo,
+				ca("Add all missing required properties?", te(2, 37, 2, 37, "\r\nquarkus.required.property="), d));
+	}
+
+	@Test
+	public void testMissingPropertyCodeAction() throws BadLocationException {
+
+		String value = "quarkus.optional.property=hello\n" + //
+			"quarkus.third.required.property=hello";
+
+		Diagnostic d1 = d(0, 0, 1, 37, "Missing required property 'quarkus.required.property'", DiagnosticSeverity.Warning,
+				ValidationType.required);
+		Diagnostic d2 = d(0, 0, 1, 37, "Missing required property 'quarkus.second.required.property'", DiagnosticSeverity.Warning,
+				ValidationType.required);
+
+		List<Diagnostic> d = new ArrayList<>();
+		d.add(d1);
+		d.add(d2);
+
+		testDiagnosticsFor(value, projectInfo, validationSettings, d1, d2);
+		testCodeActionsFor(value, d, d.get(0).getRange(), projectInfo,
+				ca("Add all missing required properties?", te(1, 37, 1, 37, "\nquarkus.required.property=\nquarkus.second.required.property="), d));
+	}
+
+	@Test
+	public void testMissingPropertyTrailingWhitespaceCodeAction() throws BadLocationException {
+
+		String value = "quarkus.optional.property=hello\n" + //
+			"quarkus.third.required.property=hello\n      \n     \n     ";
+
+		Diagnostic d1 = d(0, 0, 4, 5, "Missing required property 'quarkus.required.property'", DiagnosticSeverity.Warning,
+				ValidationType.required);
+		Diagnostic d2 = d(0, 0, 4, 5, "Missing required property 'quarkus.second.required.property'", DiagnosticSeverity.Warning,
+				ValidationType.required);
+
+		List<Diagnostic> d = new ArrayList<>();
+		d.add(d1);
+		d.add(d2);
+
+		testDiagnosticsFor(value, projectInfo, validationSettings, d1, d2);
+		testCodeActionsFor(value, d, d.get(0).getRange(), projectInfo,
+				ca("Add all missing required properties?", te(1, 37, 1, 37, "\nquarkus.required.property=\nquarkus.second.required.property="), d1, d2));
+	}
+
+	@Test
+	public void testMissingPropertyWhitepspaceCodeAction() throws BadLocationException {
+
+		String value = "     \n      \n     \n      \n     \n     ";
+
+
+		Diagnostic d1 = d(0, 0, 5, 5, "Missing required property 'quarkus.required.property'", DiagnosticSeverity.Warning,
+				ValidationType.required);
+		Diagnostic d2 = d(0, 0, 5, 5, "Missing required property 'quarkus.second.required.property'", DiagnosticSeverity.Warning,
+				ValidationType.required);
+		Diagnostic d3 = d(0, 0, 5, 5, "Missing required property 'quarkus.third.required.property'", DiagnosticSeverity.Warning,
+				ValidationType.required);
+
+		List<Diagnostic> d = new ArrayList<>();
+		d.add(d1);
+		d.add(d2);
+		d.add(d3);
+		testDiagnosticsFor(value, projectInfo, validationSettings, d1, d2, d3);
+		testCodeActionsFor(value, d, d.get(0).getRange(), projectInfo,
+				ca("Add all missing required properties?", te(0, 0, 0, 0, "quarkus.required.property=\nquarkus.second.required.property=\nquarkus.third.required.property="), d1, d2, d3));
+	}
+
+	@Test
+	public void testMissingPropertyEmptyFileCodeAction() throws BadLocationException {
+
+		String value = "";
+
+		Diagnostic d1 = d(0, 0, 0, 0, "Missing required property 'quarkus.required.property'", DiagnosticSeverity.Warning,
+				ValidationType.required);
+		Diagnostic d2 = d(0, 0, 0, 0, "Missing required property 'quarkus.second.required.property'", DiagnosticSeverity.Warning,
+				ValidationType.required);
+		Diagnostic d3 = d(0, 0, 0, 0, "Missing required property 'quarkus.third.required.property'", DiagnosticSeverity.Warning,
+				ValidationType.required);
+
+		List<Diagnostic> d = new ArrayList<>();
+		d.add(d1);
+		d.add(d2);
+		d.add(d3);
+
+		String lineSeparator = System.lineSeparator();
+		
+		testDiagnosticsFor(value, projectInfo, validationSettings, d1, d2, d3);
+		testCodeActionsFor(value, d, d.get(0).getRange(), projectInfo,
+				ca("Add all missing required properties?", te(0, 0, 0, 0, "quarkus.required.property=" + //
+						lineSeparator + //
+						"quarkus.second.required.property=" + //
+						lineSeparator + //
+						"quarkus.third.required.property="), d1, d2, d3));
+	}
+
+	@Test
+	public void testMissingPropertySpacesCodeAction() throws BadLocationException {
+
+		String value = "";
+
+		Diagnostic d1 = d(0, 0, 0, 0, "Missing required property 'quarkus.required.property'", DiagnosticSeverity.Warning,
+				ValidationType.required);
+		Diagnostic d2 = d(0, 0, 0, 0, "Missing required property 'quarkus.second.required.property'", DiagnosticSeverity.Warning,
+				ValidationType.required);
+		Diagnostic d3 = d(0, 0, 0, 0, "Missing required property 'quarkus.third.required.property'", DiagnosticSeverity.Warning,
+				ValidationType.required);
+
+		List<Diagnostic> d = new ArrayList<>();
+		d.add(d1);
+		d.add(d2);
+		d.add(d3);
+
+		QuarkusFormattingSettings quarkusFormattingSettings = new QuarkusFormattingSettings();
+		quarkusFormattingSettings.setSurroundEqualsWithSpaces(true);
+
+		String lineSeparator = System.lineSeparator();
+		
+		testDiagnosticsFor(value, projectInfo, validationSettings, d1, d2, d3);
+		testCodeActionsFor(value, d, d.get(0).getRange(), projectInfo, quarkusFormattingSettings,
+				ca("Add all missing required properties?", te(0, 0, 0, 0, "quarkus.required.property = " + //
+						lineSeparator + //
+						"quarkus.second.required.property = " + //
+						lineSeparator + //
+						"quarkus.third.required.property = "), d1, d2, d3));
+	}
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesRequiredDiagnosticsTest.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesRequiredDiagnosticsTest.java
@@ -86,7 +86,7 @@ public class ApplicationPropertiesRequiredDiagnosticsTest {
 			"quarkus.second.optional.property=hello";
 		
 		testDiagnosticsFor(value, projectInfo, settings,
-		d(1, 0, 29, "Missing required property value for 'quarkus.required.property'", DiagnosticSeverity.Error, ValidationType.required));
+		d(1, 0, 29, "Missing required property value for 'quarkus.required.property'", DiagnosticSeverity.Error, ValidationType.requiredValue));
 	}
 
 	@Test
@@ -100,8 +100,8 @@ public class ApplicationPropertiesRequiredDiagnosticsTest {
 		testDiagnosticsFor(value, projectInfo, settings,
 		d(1, 0, 25, "Duplicate property 'quarkus.required.property'", DiagnosticSeverity.Warning, ValidationType.duplicate),
 		d(2, 0, 25, "Duplicate property 'quarkus.required.property'", DiagnosticSeverity.Warning, ValidationType.duplicate),
-		d(1, 0, 29, "Missing required property value for 'quarkus.required.property'", DiagnosticSeverity.Error, ValidationType.required),
-		d(2, 0, 29, "Missing required property value for 'quarkus.required.property'", DiagnosticSeverity.Error, ValidationType.required));
+		d(1, 0, 29, "Missing required property value for 'quarkus.required.property'", DiagnosticSeverity.Error, ValidationType.requiredValue),
+		d(2, 0, 29, "Missing required property value for 'quarkus.required.property'", DiagnosticSeverity.Error, ValidationType.requiredValue));
 	}
 
 	@Test

--- a/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/QuarkusAssert.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/QuarkusAssert.java
@@ -414,20 +414,35 @@ public class QuarkusAssert {
 	// ------------------- CodeAction assert
 
 	public static void testCodeActionsFor(String value, Diagnostic diagnostic, CodeAction... expected) {
-		testCodeActionsFor(value, diagnostic, getDefaultQuarkusProjectInfo(), expected);
+		testCodeActionsFor(value, diagnostic, getDefaultQuarkusProjectInfo(), new QuarkusFormattingSettings(), expected);
 	}
 
 	public static void testCodeActionsFor(String value, Diagnostic diagnostic, QuarkusProjectInfo projectInfo,
 			CodeAction... expected) {
+		testCodeActionsFor(value, Collections.singletonList(diagnostic), diagnostic.getRange(), projectInfo, new QuarkusFormattingSettings(),
+				expected);
+	}
+
+	public static void testCodeActionsFor(String value, Diagnostic diagnostic, QuarkusProjectInfo projectInfo,
+			QuarkusFormattingSettings formattingSettings, CodeAction... expected) {
+		testCodeActionsFor(value, Collections.singletonList(diagnostic), diagnostic.getRange(), projectInfo, formattingSettings, expected);
+	}
+
+	public static void testCodeActionsFor(String value, List<Diagnostic> diagnostics, Range range, QuarkusProjectInfo projectInfo,
+			CodeAction... expected) {
+		testCodeActionsFor(value, diagnostics, range, projectInfo, new QuarkusFormattingSettings(), expected);
+	}
+
+	public static void testCodeActionsFor(String value, List<Diagnostic> diagnostics, Range range, QuarkusProjectInfo projectInfo,
+			QuarkusFormattingSettings formattingSettings, CodeAction... expected) {
 		PropertiesModel model = parse(value, null);
 		QuarkusLanguageService languageService = new QuarkusLanguageService();
 
 		CodeActionContext context = new CodeActionContext();
-		context.setDiagnostics(Arrays.asList(diagnostic));
-		Range range = diagnostic.getRange();
+		context.setDiagnostics(diagnostics);
 
 		List<CodeAction> actual = languageService.doCodeActions(context, range, model, projectInfo,
-				new QuarkusFormattingSettings());
+				formattingSettings);
 		assertCodeActions(actual, expected);
 	}
 
@@ -449,10 +464,18 @@ public class QuarkusAssert {
 		Assert.assertArrayEquals(expected, actual.toArray());
 	}
 
-	public static CodeAction ca(String title, Diagnostic d, TextEdit te) {
+	public static CodeAction ca(String title, TextEdit te, Diagnostic... d) {
+		List<Diagnostic> diagnostics = new ArrayList<>();
+		for (int i = 0; i < d.length; i++) {
+			diagnostics.add(d[i]);
+		}
+		return ca(title, te, diagnostics);
+	}
+
+	public static CodeAction ca(String title, TextEdit te, List<Diagnostic> diagnostics) {
 		CodeAction codeAction = new CodeAction();
 		codeAction.setTitle(title);
-		codeAction.setDiagnostics(Arrays.asList(d));
+		codeAction.setDiagnostics(diagnostics);
 
 		VersionedTextDocumentIdentifier versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier(
 				"application.properties", 0);


### PR DESCRIPTION
Fixes #111

To test this PR, change the required validation severity to "error" or "warning". 
![image](https://user-images.githubusercontent.com/20326645/67870370-1d825600-fb05-11e9-932b-710dc34a936d.png)

Here is a quick demo:
![code action demo](https://raw.githubusercontent.com/xorye/gifs/master/quarkus-ls/PR/%23111/codeaction.gif?token=AE3CR5J5VWYOIV75GALGM2S5YLRHG)

The errors after the code actions are "Missing value" errors.
The spacing on the equals sign is dependent on the user's formatting setting.

It would be great if the "Add all missing required properties" code action was the first code action in the list of code actions that VS Code provided in that gif, however the order of code actions in the `codeActions` list [here](https://github.com/xorye/quarkus-ls/blob/4f33ef1abd5d521407a382f3b7be69018e6aa11b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusCodeActions.java#L61) doesn't seem to correspond with the order of code actions presented in VS Code.