### PR TITLE
Implement code action to add unknown property to exclude array

### DIFF
--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/QuarkusLanguageServer.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/QuarkusLanguageServer.java
@@ -15,18 +15,10 @@ import static org.eclipse.lsp4j.jsonrpc.CompletableFutures.computeAsync;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
 
-import org.eclipse.lsp4j.InitializeParams;
-import org.eclipse.lsp4j.InitializeResult;
-import org.eclipse.lsp4j.InitializedParams;
-import org.eclipse.lsp4j.ServerCapabilities;
-import org.eclipse.lsp4j.services.LanguageClient;
-import org.eclipse.lsp4j.services.LanguageServer;
-import org.eclipse.lsp4j.services.TextDocumentService;
-import org.eclipse.lsp4j.services.WorkspaceService;
-
 import com.redhat.quarkus.commons.QuarkusPropertiesChangeEvent;
 import com.redhat.quarkus.ls.api.QuarkusLanguageClientAPI;
 import com.redhat.quarkus.ls.api.QuarkusLanguageServerAPI;
+import com.redhat.quarkus.ls.commons.client.ExtendedClientCapabilities;
 import com.redhat.quarkus.ls.commons.ParentProcessWatcher.ProcessLanguageServer;
 import com.redhat.quarkus.services.QuarkusLanguageService;
 import com.redhat.quarkus.settings.AllQuarkusSettings;
@@ -35,8 +27,18 @@ import com.redhat.quarkus.settings.QuarkusFormattingSettings;
 import com.redhat.quarkus.settings.QuarkusGeneralClientSettings;
 import com.redhat.quarkus.settings.QuarkusSymbolSettings;
 import com.redhat.quarkus.settings.QuarkusValidationSettings;
+import com.redhat.quarkus.settings.capabilities.InitializationOptionsExtendedClientCapabilities;
 import com.redhat.quarkus.settings.capabilities.QuarkusCapabilityManager;
 import com.redhat.quarkus.settings.capabilities.ServerCapabilitiesInitializer;
+
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.InitializedParams;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.eclipse.lsp4j.services.TextDocumentService;
+import org.eclipse.lsp4j.services.WorkspaceService;
 
 /**
  * Quarkus language server.
@@ -66,11 +68,12 @@ public class QuarkusLanguageServer implements LanguageServer, ProcessLanguageSer
 
 		this.parentProcessId = params.getProcessId();
 
-		capabilityManager.setClientCapabilities(params.getCapabilities());
+		ExtendedClientCapabilities extendedClientCapabilities = InitializationOptionsExtendedClientCapabilities
+				.getExtendedClientCapabilities(params);
+		capabilityManager.setClientCapabilities(params.getCapabilities(), extendedClientCapabilities);
 		updateSettings(InitializationOptionsSettings.getSettings(params));
 
-		textDocumentService.updateClientCapabilities(params.getCapabilities());
-
+		textDocumentService.updateClientCapabilities(params.getCapabilities(), extendedClientCapabilities);
 		ServerCapabilities serverCapabilities = ServerCapabilitiesInitializer
 				.getNonDynamicServerCapabilities(capabilityManager.getClientCapabilities());
 

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/QuarkusTextDocumentService.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/QuarkusTextDocumentService.java
@@ -48,6 +48,7 @@ import org.eclipse.lsp4j.services.TextDocumentService;
 
 import com.redhat.quarkus.commons.QuarkusProjectInfoParams;
 import com.redhat.quarkus.commons.QuarkusPropertiesChangeEvent;
+import com.redhat.quarkus.ls.commons.client.ExtendedClientCapabilities;
 import com.redhat.quarkus.ls.commons.ModelTextDocument;
 import com.redhat.quarkus.ls.commons.ModelTextDocuments;
 import com.redhat.quarkus.model.PropertiesModel;
@@ -87,8 +88,10 @@ public class QuarkusTextDocumentService implements TextDocumentService {
 	 * Update shared settings from the client capabilities.
 	 * 
 	 * @param capabilities the client capabilities
+	 * @param extendedClientCapabilities the extended client capabilities
 	 */
-	public void updateClientCapabilities(ClientCapabilities capabilities) {
+	public void updateClientCapabilities(ClientCapabilities capabilities,
+			ExtendedClientCapabilities extendedClientCapabilities) {
 		TextDocumentClientCapabilities textDocumentClientCapabilities = capabilities.getTextDocument();
 		if (textDocumentClientCapabilities != null) {
 			sharedSettings.getCompletionSettings().setCapabilities(textDocumentClientCapabilities.getCompletion());
@@ -99,6 +102,10 @@ public class QuarkusTextDocumentService implements TextDocumentService {
 			definitionLinkSupport = textDocumentClientCapabilities.getDefinition() != null
 					&& textDocumentClientCapabilities.getDefinition().getLinkSupport() != null
 					&& textDocumentClientCapabilities.getDefinition().getLinkSupport();
+		}
+
+		if (extendedClientCapabilities != null) {
+			sharedSettings.getCommandCapabilities().setCapabilities(extendedClientCapabilities.getCommands());
 		}
 	}
 
@@ -232,7 +239,8 @@ public class QuarkusTextDocumentService implements TextDocumentService {
 			return getPropertiesModel(params.getTextDocument(), (cancelChecker, document) -> {
 				return getQuarkusLanguageService()
 						.doCodeActions(params.getContext(), params.getRange(), document, projectInfo,
-								sharedSettings.getFormattingSettings()) //
+								sharedSettings.getFormattingSettings(),
+								sharedSettings.getCommandCapabilities()) //
 						.stream() //
 						.map(ca -> {
 							Either<Command, CodeAction> e = Either.forRight(ca);

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/api/QuarkusLanguageServerAPI.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/api/QuarkusLanguageServerAPI.java
@@ -35,4 +35,6 @@ public interface QuarkusLanguageServerAPI extends LanguageServer {
 	 */
 	@JsonNotification("quarkus/quarkusPropertiesChanged")
 	void quarkusPropertiesChanged(QuarkusPropertiesChangeEvent event);
+
+	
 }

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/commons/client/CommandCapabilities.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/commons/client/CommandCapabilities.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.ls.commons.client;
+
+import org.eclipse.lsp4j.DynamicRegistrationCapabilities;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Extended capabilities for client commands.
+ * 
+ * @author Angelo ZERR
+ */
+@SuppressWarnings("all")
+public class CommandCapabilities extends DynamicRegistrationCapabilities {
+	/**
+	 * Specific capabilities for the `CommandKind` in the `textDocument/commands`
+	 * request.
+	 */
+	private CommandKindCapabilities commandsKind;
+
+	public CommandCapabilities() {
+	}
+
+	public CommandCapabilities(final Boolean dynamicRegistration) {
+		super(dynamicRegistration);
+	}
+
+	public CommandCapabilities(final CommandKindCapabilities commandsKind) {
+		this.commandsKind = commandsKind;
+	}
+
+	public CommandCapabilities(final CommandKindCapabilities commandsKind,
+			final Boolean dynamicRegistration) {
+		super(dynamicRegistration);
+		this.commandsKind = commandsKind;
+	}
+
+	public boolean isSupported(String command) {
+		return commandsKind.getValueSet().contains(command);
+	}
+
+	/**
+	 * Specific capabilities for the `CommandKind` in the `textDocument/commands`
+	 * request.
+	 */
+	@Pure
+	public CommandKindCapabilities getCommandKind() {
+		return this.commandsKind;
+	}
+
+	/**
+	 * Specific capabilities for the `CommandKind` in the `textDocument/commands`
+	 * request.
+	 */
+	public void setCommandKind(final CommandKindCapabilities commandsKind) {
+		this.commandsKind = commandsKind;
+	}
+
+	@Override
+	@Pure
+	public String toString() {
+		ToStringBuilder b = new ToStringBuilder(this);
+		b.add("commandsKind", this.commandsKind);
+		b.add("dynamicRegistration", getDynamicRegistration());
+		return b.toString();
+	}
+
+	@Override
+	@Pure
+	public boolean equals(final Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		if (!super.equals(obj))
+			return false;
+		CommandCapabilities other = (CommandCapabilities) obj;
+		if (this.commandsKind == null) {
+			if (other.commandsKind != null)
+				return false;
+		} else if (!this.commandsKind.equals(other.commandsKind))
+			return false;
+		return true;
+	}
+
+	@Override
+	@Pure
+	public int hashCode() {
+		return 31 * super.hashCode() + ((this.commandsKind == null) ? 0 : this.commandsKind.hashCode());
+	}
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/commons/client/CommandKind.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/commons/client/CommandKind.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.ls.commons.client;
+
+/**
+ * Commonly used client commands
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class CommandKind {
+
+	private CommandKind() {
+	}
+
+	/**
+	 * Client command to open references
+	 */
+	public static final String COMMAND_REFERENCES = "quarkus.command.references";
+
+	/**
+	 * Client command to open implementations
+	 */
+	public static final String COMMAND_IMPLEMENTATIONS = "quarkus.command.implementations";
+
+	/**
+	 * Client command to open URI
+	 */
+	public static final String COMMAND_OPEN_URI = "quarkus.command.open.uri";
+
+	/**
+	 * Client command to update client configuration settings
+	 */
+	public static final String COMMAND_CONFIGURATION_UPDATE = "quarkus.command.configuration.update";
+
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/commons/client/CommandKindCapabilities.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/commons/client/CommandKindCapabilities.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.ls.commons.client;
+
+import java.util.List;
+
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Specific capabilities for the `CommandKind`.
+ * 
+ * @see https://github.com/microsoft/language-server-protocol/issues/788
+ */
+@SuppressWarnings("all")
+public class CommandKindCapabilities {
+	/**
+	 * The commands kind values the client supports. When this property exists the
+	 * client also guarantees that it will handle values outside its set gracefully
+	 * and falls back to a default value when unknown.
+	 * 
+	 * If this property is not present the client only supports the commands kinds
+	 * from `File` to `Array` as defined in the initial version of the protocol.
+	 */
+	private List<String> valueSet;
+
+	public CommandKindCapabilities() {
+	}
+
+	public CommandKindCapabilities(final List<String> valueSet) {
+		this.valueSet = valueSet;
+	}
+
+	/**
+	 * The commands kind values the client supports. When this property exists the
+	 * client also guarantees that it will handle values outside its set gracefully
+	 * and falls back to a default value when unknown.
+	 * 
+	 * If this property is not present the client only supports the commands kinds
+	 * from `File` to `Array` as defined in the initial version of the protocol.
+	 */
+	@Pure
+	public List<String> getValueSet() {
+		return this.valueSet;
+	}
+
+	/**
+	 * The commands kind values the client supports. When this property exists the
+	 * client also guarantees that it will handle values outside its set gracefully
+	 * and falls back to a default value when unknown.
+	 * 
+	 * If this property is not present the client only supports the commands kinds
+	 * from `File` to `Array` as defined in the initial version of the protocol.
+	 */
+	public void setValueSet(final List<String> valueSet) {
+		this.valueSet = valueSet;
+	}
+
+	@Override
+	@Pure
+	public String toString() {
+		ToStringBuilder b = new ToStringBuilder(this);
+		b.add("valueSet", this.valueSet);
+		return b.toString();
+	}
+
+	@Override
+	@Pure
+	public boolean equals(final Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		CommandKindCapabilities other = (CommandKindCapabilities) obj;
+		if (this.valueSet == null) {
+			if (other.valueSet != null)
+				return false;
+		} else if (!this.valueSet.equals(other.valueSet))
+			return false;
+		return true;
+	}
+
+	@Override
+	@Pure
+	public int hashCode() {
+		return 31 * 1 + ((this.valueSet == null) ? 0 : this.valueSet.hashCode());
+	}
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/commons/client/ConfigurationItemEdit.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/commons/client/ConfigurationItemEdit.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.ls.commons.client;
+
+import org.eclipse.lsp4j.ConfigurationItem;
+
+
+/**
+ * Class representing a change to a client's config.
+ */
+public class ConfigurationItemEdit extends ConfigurationItem {
+	private ConfigurationItemEditType editType;
+	private Object value;
+
+	/**
+	 * 
+	 * @param section   config section to change
+	 * @param operation type of change
+	 * @param value     the value for the change
+	 */
+	public ConfigurationItemEdit(String section, ConfigurationItemEditType editType, Object value) {
+		super.setSection(section);
+		this.editType = editType;
+		this.value = value;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		ConfigurationItemEdit other = (ConfigurationItemEdit) obj;
+		if (editType == null) {
+			if (other.editType != null)
+				return false;
+		} else if (!editType.equals(other.editType))
+			return false;
+		if (value == null) {
+			if (other.value != null)
+				return false;
+		} else if (!value.equals(other.value))
+			return false;
+		return true;
+	}
+	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + ((editType == null) ? 0 : editType.hashCode());
+		result = prime * result + ((value == null) ? 0 : value.hashCode());
+		return result;
+	}
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/commons/client/ConfigurationItemEditType.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/commons/client/ConfigurationItemEditType.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.ls.commons.client;
+
+/**
+ * Configuration item edit type.
+ * Represents a configuration edit operation
+ */
+public enum ConfigurationItemEditType {
+	add,
+	delete,
+	update
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/commons/client/ExtendedClientCapabilities.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/commons/client/ExtendedClientCapabilities.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.ls.commons.client;
+
+import com.redhat.quarkus.ls.commons.client.CommandCapabilities;
+
+/**
+ * Extended client capabilities not defined by the LSP.
+ * 
+ * @author Angelo ZERR
+ */
+public class ExtendedClientCapabilities {
+
+	private CommandCapabilities commands;
+
+	public CommandCapabilities getCommands() {
+		return commands;
+	}
+
+	public void setCommands(CommandCapabilities commands) {
+		this.commands = commands;
+	}
+
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusLanguageService.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusLanguageService.java
@@ -12,6 +12,15 @@ package com.redhat.quarkus.services;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import com.redhat.quarkus.commons.QuarkusProjectInfo;
+import com.redhat.quarkus.ls.api.QuarkusPropertyDefinitionProvider;
+import com.redhat.quarkus.model.PropertiesModel;
+import com.redhat.quarkus.settings.QuarkusCommandCapabilities;
+import com.redhat.quarkus.settings.QuarkusCompletionSettings;
+import com.redhat.quarkus.settings.QuarkusFormattingSettings;
+import com.redhat.quarkus.settings.QuarkusHoverSettings;
+import com.redhat.quarkus.settings.QuarkusValidationSettings;
+
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.CompletionList;
@@ -27,15 +36,7 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
-import com.redhat.quarkus.commons.QuarkusProjectInfo;
-import com.redhat.quarkus.ls.api.QuarkusPropertyDefinitionProvider;
-import com.redhat.quarkus.model.PropertiesModel;
 import com.redhat.quarkus.model.values.ValuesRulesManager;
-import com.redhat.quarkus.settings.QuarkusCompletionSettings;
-import com.redhat.quarkus.settings.QuarkusFormattingSettings;
-import com.redhat.quarkus.settings.QuarkusHoverSettings;
-import com.redhat.quarkus.settings.QuarkusValidationSettings;
-
 /**
  * The Quarkus language service.
  * 
@@ -189,16 +190,17 @@ public class QuarkusLanguageService {
 	 * <code>document</code> by using the given Quarkus properties metadata
 	 * <code>projectInfo</code>.
 	 * 
-	 * @param context            the code action context
-	 * @param range              the range
-	 * @param document           the properties model.
-	 * @param projectInfo        the Quarkus properties
-	 * @param formattingSettings the formatting settings.
+	 * @param context             the code action context
+	 * @param range               the range
+	 * @param document            the properties model.
+	 * @param projectInfo         the Quarkus properties
+	 * @param formattingSettings  the formatting settings.
+	 * @param commandCapabilities the command capabilities
 	 * @return the result of the code actions.
 	 */
 	public List<CodeAction> doCodeActions(CodeActionContext context, Range range, PropertiesModel document,
-			QuarkusProjectInfo projectInfo, QuarkusFormattingSettings formattingSettings) {
-		return codeActions.doCodeActions(context, range, document, projectInfo, getValuesRulesManager(), formattingSettings);
+			QuarkusProjectInfo projectInfo, QuarkusFormattingSettings formattingSettings, QuarkusCommandCapabilities commandCapabilities) {
+		return codeActions.doCodeActions(context, range, document, projectInfo, getValuesRulesManager(), formattingSettings, commandCapabilities);
 	}
 
 	/**

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/QuarkusCommandCapabilities.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/QuarkusCommandCapabilities.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.settings;
+
+import com.redhat.quarkus.ls.commons.client.CommandCapabilities;
+
+/**
+ * A wrapper around LSP {@link CommandCapabilities}.
+ */
+public class QuarkusCommandCapabilities {
+	private CommandCapabilities capabilities;
+
+	public void setCapabilities(CommandCapabilities capabilities) {
+		this.capabilities = capabilities;
+	}
+
+	public CommandCapabilities getCapabilities() {
+		return capabilities;
+	}
+	
+	/**
+	 * Returns <code>true</code> if the client supports the <code>commandKind</code>
+	 * command. Otherwise, returns <code>false</code>.
+	 * 
+	 * See {@link com.redhat.quarkus.ls.client.CommandKind}
+	 *
+	 * @param commandKind the command kind to check for
+	 * @return <code>true</code> if the client supports the <code>commandKind</code>
+	 *         commandKind. Otherwise, returns <code>false</code>
+	 */
+	public boolean isCommandSupported(String commandKind) {
+		return capabilities != null && capabilities.isSupported(commandKind);
+	}
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/SharedSettings.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/SharedSettings.java
@@ -22,6 +22,7 @@ public class SharedSettings {
 	private final QuarkusSymbolSettings symbolSettings;
 	private final QuarkusValidationSettings validationSettings;
 	private final QuarkusFormattingSettings formattingSettings;
+	private final QuarkusCommandCapabilities commandCapabilities;
 
 	public SharedSettings() {
 		this.completionSettings = new QuarkusCompletionSettings();
@@ -29,6 +30,7 @@ public class SharedSettings {
 		this.symbolSettings = new QuarkusSymbolSettings();
 		this.validationSettings = new QuarkusValidationSettings();
 		this.formattingSettings = new QuarkusFormattingSettings();
+		this.commandCapabilities = new QuarkusCommandCapabilities();
 	}
 
 	/**
@@ -74,5 +76,14 @@ public class SharedSettings {
 	 */
 	public QuarkusFormattingSettings getFormattingSettings() {
 		return formattingSettings;
+	}
+
+	/**
+	 * Returns the command capabilities.
+	 * 
+	 * @return the command capabilities.
+	 */
+	public QuarkusCommandCapabilities getCommandCapabilities() {
+		return commandCapabilities;
 	}
 }

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/capabilities/ClientCapabilitiesWrapper.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/capabilities/ClientCapabilitiesWrapper.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package com.redhat.quarkus.settings.capabilities;
 
+import com.redhat.quarkus.ls.commons.client.ExtendedClientCapabilities;
+
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.DynamicRegistrationCapabilities;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
@@ -20,13 +22,16 @@ public class ClientCapabilitiesWrapper {
 
 	private ClientCapabilities capabilities;
 
+	private final ExtendedClientCapabilities extendedCapabilities;
+
 	public ClientCapabilitiesWrapper() {
-		this(new ClientCapabilities());
+		this(new ClientCapabilities(), null);
 	}
 
-	public ClientCapabilitiesWrapper(ClientCapabilities capabilities) {
+	public ClientCapabilitiesWrapper(ClientCapabilities capabilities, ExtendedClientCapabilities extendedCapabilities) {
 		this.capabilities = capabilities;
 		this.v3Supported = capabilities != null ? capabilities.getTextDocument() != null : false;
+		this.extendedCapabilities = extendedCapabilities;
 	}
 
 	/**
@@ -71,5 +76,9 @@ public class ClientCapabilitiesWrapper {
 
 	public TextDocumentClientCapabilities getTextDocument() {
 		return this.capabilities.getTextDocument();
+	}
+
+	public ExtendedClientCapabilities getExtendedCapabilities() {
+		return extendedCapabilities;
 	}
 }

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/capabilities/InitializationOptionsExtendedClientCapabilities.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/capabilities/InitializationOptionsExtendedClientCapabilities.java
@@ -1,0 +1,74 @@
+/**
+ *  Copyright (c) 2018 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v20.html
+ *
+ *  Contributors:
+ *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ */
+
+package com.redhat.quarkus.settings.capabilities;
+
+import com.redhat.quarkus.ls.commons.client.ExtendedClientCapabilities;
+import com.redhat.quarkus.utils.JSONUtility;
+
+import org.eclipse.lsp4j.InitializeParams;
+
+
+/**
+ * Represents all extended client capabilities sent from the server
+ * 
+ * <pre>
+ * "extendedClientCapabilities": {
+		"commands": {
+			"commandsKind": {
+				"valueSet": [
+					"quarkus.command.configuration.update"
+				]
+			}
+		}
+	}
+ * </pre>
+ */
+public class InitializationOptionsExtendedClientCapabilities {
+
+	private ExtendedClientCapabilities extendedClientCapabilities;
+
+	public ExtendedClientCapabilities getExtendedClientCapabilities() {
+		return extendedClientCapabilities;
+	}
+
+	public void setExtendedClientCapabilities(ExtendedClientCapabilities extendedClientCapabilities) {
+		this.extendedClientCapabilities = extendedClientCapabilities;
+	}
+
+	/**
+	 * Returns the "settings" section of
+	 * {@link InitializeParams#getInitializationOptions()}.
+	 * 
+	 * Here a sample of initializationOptions
+	 * 
+	 * <pre>
+	 * "extendedClientCapabilities": {
+			"commands": {
+				"commandsKind": {
+					"valueSet": [
+						"quarkus.command.configuration.update"
+					]
+				}
+			}
+		}
+	 * </pre>
+	 * 
+	 * @param initializeParams
+	 * @return the "extendedClientCapabilities" section of
+	 *         {@link InitializeParams#getInitializationOptions()}.
+	 */
+	public static ExtendedClientCapabilities getExtendedClientCapabilities(InitializeParams initializeParams) {
+		InitializationOptionsExtendedClientCapabilities root = JSONUtility.toModel(
+				initializeParams.getInitializationOptions(), InitializationOptionsExtendedClientCapabilities.class);
+		return root != null ? root.getExtendedClientCapabilities() : null;
+	}
+}

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/capabilities/QuarkusCapabilityManager.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/capabilities/QuarkusCapabilityManager.java
@@ -27,6 +27,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.redhat.quarkus.ls.commons.client.ExtendedClientCapabilities;
+
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.Registration;
 import org.eclipse.lsp4j.RegistrationParams;
@@ -76,8 +78,8 @@ public class QuarkusCapabilityManager {
 		}
 	}
 
-	public void setClientCapabilities(ClientCapabilities clientCapabilities) {
-		this.clientWrapper = new ClientCapabilitiesWrapper(clientCapabilities);
+	public void setClientCapabilities(ClientCapabilities clientCapabilities, ExtendedClientCapabilities extendedClientCapabilities) {
+		this.clientWrapper = new ClientCapabilitiesWrapper(clientCapabilities, extendedClientCapabilities);
 	}
 
 	public ClientCapabilitiesWrapper getClientCapabilities() {

--- a/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesCodeActionsTest.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesCodeActionsTest.java
@@ -15,11 +15,17 @@ import static com.redhat.quarkus.services.QuarkusAssert.te;
 import static com.redhat.quarkus.services.QuarkusAssert.testCodeActionsFor;
 import static com.redhat.quarkus.services.QuarkusAssert.testDiagnosticsFor;
 
+import java.util.Arrays;
+
+import com.redhat.quarkus.ls.commons.BadLocationException;
+import com.redhat.quarkus.ls.commons.client.CommandKind;
+import com.redhat.quarkus.ls.commons.client.ConfigurationItemEdit;
+import com.redhat.quarkus.ls.commons.client.ConfigurationItemEditType;
+
+import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.Test;
-
-import com.redhat.quarkus.ls.commons.BadLocationException;
 
 /**
  * Test with code actions in 'application.properties' file.
@@ -38,9 +44,16 @@ public class ApplicationPropertiesCodeActionsTest {
 		Diagnostic d = d(1, 0, 23, "Unknown property 'quarkus.application.nme'", DiagnosticSeverity.Warning,
 				ValidationType.unknown);
 
+		ConfigurationItemEdit configItemEdit = new ConfigurationItemEdit("quarkus.tools.validation.unknown.excluded",
+				ConfigurationItemEditType.add, "quarkus.application.nme");
+
+		Command command = new Command("Add quarkus.application.nme to unknown excluded array",
+				CommandKind.COMMAND_CONFIGURATION_UPDATE, Arrays.asList(configItemEdit));
+
 		testDiagnosticsFor(value, d);
 		testCodeActionsFor(value, d,
-				ca("Did you mean 'quarkus.application.name' ?", te(1, 0, 1, 23, "quarkus.application.name"), d));
+				ca("Did you mean 'quarkus.application.name' ?", te(1, 0, 1, 23, "quarkus.application.name"), d),
+				ca("Exclude 'quarkus.application.nme' from unknown property validation?", command, d));
 	};
 
 	@Test

--- a/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesRequiredCodeActionTest.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesRequiredCodeActionTest.java
@@ -115,7 +115,7 @@ public class ApplicationPropertiesRequiredCodeActionTest {
 
 		testDiagnosticsFor(value, projectInfo, validationSettings, d1, d2);
 		testCodeActionsFor(value, d, d.get(0).getRange(), projectInfo,
-				ca("Add all missing required properties?", te(1, 37, 1, 37, "\nquarkus.required.property=\nquarkus.second.required.property="), d));
+				ca("Add all missing required properties?", te(1, 37, 1, 37, "\nquarkus.required.property=\nquarkus.second.required.property="), d1, d2));
 	}
 
 	@Test

--- a/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/settings/capabilities/QuarkusCapabilitiesTest.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/settings/capabilities/QuarkusCapabilitiesTest.java
@@ -120,7 +120,7 @@ public class QuarkusCapabilitiesTest {
 	private void setAndInitializeCapabilities() {
 		clientCapabilities.setTextDocument(textDocument);
 		clientCapabilities.setWorkspace(workspace);
-		manager.setClientCapabilities(clientCapabilities);
+		manager.setClientCapabilities(clientCapabilities, null);
 		manager.initializeCapabilities();
 		capabilityIDs = manager.getRegisteredCapabilities();
 	}


### PR DESCRIPTION
Fixes #81 

I have a few comments about this PR:

To test this PR, this PR: https://github.com/redhat-developer/vscode-quarkus/pull/152 from vscode-quarkus is needed.

In this PR, the extended capability that deals with whether or not the client is able to update their settings was named [`ExtendedClientSettingsUpdateCapabilities`](https://github.com/xorye/quarkus-ls/blob/81codeaction_unknown/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/client/ExtendedClientSettingsUpdateCapabilities.java).

For the client to register the capability, the client must have their initialization options like so:
```
      initializationOptions: {
        extendedClientCapabilities: {
          clientSettingsUpdate: { supported: true }
        }
      }
```
The PR from vscode-quarkus mentioned above, already does this.

The command that quarkus-ls sends to vscode-quarkus was named `quarkus/clientSettingsUpdate`, which is a command that vscode-quarkus registers. Then, quarkus-ls would pass in 2 arguments to the  `quarkus/clientSettingsUpdate` command, the first argument being `validationUnknownExcluded` and the second argument being the property name. The first argument tells vscode-quarkus which setting to update.

Maybe it's better to only have a command called something like  `quarkus/addToUnknownValidationExcluded` that only deals with adding to the unknown validation excluded array? 

Also, is it a good idea to add a method in [`CodeActionFactory`](https://github.com/xorye/quarkus-ls/blob/81codeaction_unknown/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/commons/CodeActionFactory.java) that creates code actions with commands? Currently, `CodeActionFactory` only has methods for insert, remove and replace, but no command.



Signed-off-by: David Kwon <dakwon@redhat.com>