### PR TITLE
Use formattingSettings to determine spacing for completion

### DIFF
--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/ApplicationPropertiesTextDocumentService.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/ls/ApplicationPropertiesTextDocumentService.java
@@ -140,7 +140,8 @@ public class ApplicationPropertiesTextDocumentService extends AbstractTextDocume
 				// then return completion by using the Quarkus project information and the
 				// Properties model document
 				CompletionList list = getQuarkusLanguageService().doComplete(document, params.getPosition(),
-						projectInfo, sharedSettings.getCompletionSettings(), null);
+						projectInfo, sharedSettings.getCompletionSettings(), sharedSettings.getFormattingSettings(),
+						null);
 				return Either.forRight(list);
 			});
 		});

--- a/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusLanguageService.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/services/QuarkusLanguageService.java
@@ -80,9 +80,10 @@ public class QuarkusLanguageService {
 	 * @return completion list for the given position
 	 */
 	public CompletionList doComplete(PropertiesModel document, Position position, QuarkusProjectInfo projectInfo,
-			QuarkusCompletionSettings completionSettings, CancelChecker cancelChecker) {
+			QuarkusCompletionSettings completionSettings, QuarkusFormattingSettings formattingSettings,
+			CancelChecker cancelChecker) {
 		return completions.doComplete(document, position, projectInfo, getValuesRulesManager(), completionSettings,
-				cancelChecker);
+				formattingSettings, cancelChecker);
 	}
 
 	/**

--- a/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesCompletionTest.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/ApplicationPropertiesCompletionTest.java
@@ -230,4 +230,11 @@ public class ApplicationPropertiesCompletionTest {
 		testCompletionFor(value, true, c("OFF", "OFF", r(0, 23, 24)), c("SEVERE", "SEVERE", r(0, 23, 24)));
 	}
 
+	@Test
+	public void completionSpacingSurroundingEquals() throws BadLocationException {
+		String value = "|";
+		testCompletionFor(value, false, true, c("quarkus.http.cors", "quarkus.http.cors = false", r(0, 0, 0)));
+		testCompletionFor(value, true, true, c("quarkus.http.cors", "quarkus.http.cors = ${1|false,true|}", r(0, 0, 0)));
+	}
+
 }

--- a/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/QuarkusAssert.java
+++ b/quarkus.ls/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/services/QuarkusAssert.java
@@ -95,18 +95,39 @@ public class QuarkusAssert {
 
 	// ------------------- Completion assert
 
+	public static void testCompletionFor(String value, boolean snippetSupport, Integer expectedCount)
+			throws BadLocationException {
+		testCompletionFor(value, snippetSupport, false, expectedCount);
+	}
+
 	public static void testCompletionFor(String value, boolean snippetSupport, CompletionItem... expectedItems)
 			throws BadLocationException {
-		testCompletionFor(value, snippetSupport, null, expectedItems);
+		testCompletionFor(value, snippetSupport, false, null, expectedItems);
+	}
+
+	public static void testCompletionFor(String value, boolean snippetSupport, boolean insertSpacing, CompletionItem... expectedItems)
+			throws BadLocationException {
+		testCompletionFor(value, snippetSupport, insertSpacing, null, expectedItems);
 	}
 
 	public static void testCompletionFor(String value, boolean snippetSupport, Integer expectedCount,
 			CompletionItem... expectedItems) throws BadLocationException {
-		testCompletionFor(value, snippetSupport, null, expectedCount, getDefaultQuarkusProjectInfo(), expectedItems);
+		testCompletionFor(value, snippetSupport, false, null, expectedCount, getDefaultQuarkusProjectInfo(), expectedItems);
+	}
+
+	public static void testCompletionFor(String value, boolean snippetSupport, boolean insertSpacing,
+			Integer expectedCount, CompletionItem... expectedItems) throws BadLocationException {
+		testCompletionFor(value, snippetSupport, insertSpacing, null, expectedCount, getDefaultQuarkusProjectInfo(), expectedItems);
 	}
 
 	public static void testCompletionFor(String value, boolean snippetSupport, String fileURI, Integer expectedCount,
 			QuarkusProjectInfo projectInfo, CompletionItem... expectedItems) throws BadLocationException {
+		testCompletionFor(value, snippetSupport, false, null, expectedCount, projectInfo, expectedItems);
+	}
+
+	public static void testCompletionFor(String value, boolean snippetSupport, boolean insertSpacing,
+			String fileURI, Integer expectedCount, QuarkusProjectInfo projectInfo, 
+			CompletionItem... expectedItems) throws BadLocationException {
 		int offset = value.indexOf('|');
 		value = value.substring(0, offset) + value.substring(offset + 1);
 
@@ -120,8 +141,11 @@ public class QuarkusAssert {
 		CompletionCapabilities completionCapabilities = new CompletionCapabilities(completionItemCapabilities);
 		completionSettings.setCapabilities(completionCapabilities);
 
+		QuarkusFormattingSettings formattingSettings = new QuarkusFormattingSettings();
+		formattingSettings.setSurroundEqualsWithSpaces(insertSpacing);
+
 		QuarkusLanguageService languageService = new QuarkusLanguageService();
-		CompletionList list = languageService.doComplete(model, position, projectInfo, completionSettings, () -> {
+		CompletionList list = languageService.doComplete(model, position, projectInfo, completionSettings, formattingSettings, () -> {
 		});
 
 		assertCompletions(list, expectedCount, expectedItems);


### PR DESCRIPTION
This PR adds spaces surrounding the equals sign during completion, if the **Quarkus > Tools > Formatting > Surround Equals With Spaces** setting is enabled.

To test this PR, in vscode-quarkus, enable the **Quarkus > Tools > Formatting > Surround Equals With Spaces** setting, and invoke completion in `application.properties` and hit Enter on any completion option.

Before this PR: 
![image](https://user-images.githubusercontent.com/20326645/69673127-a094be80-1067-11ea-85cc-544c359f53c3.png)

After this PR:
![image](https://user-images.githubusercontent.com/20326645/69673188-c7eb8b80-1067-11ea-993a-b46a975fa0da.png)

Signed-off-by: David Kwon <dakwon@redhat.com>