### PR TITLE
Go to definiton for enum value

### DIFF
--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/FakeJavaProject.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/FakeJavaProject.java
@@ -11,6 +11,7 @@ package com.redhat.microprofile.jdt.internal.core;
 
 import java.util.List;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
@@ -70,5 +71,9 @@ public class FakeJavaProject extends ExternalJavaProject {
 	@Override
 	public boolean exists() {
 		return rootProject.exists();
+	}
+	
+	public IJavaProject getRootProject() {
+		return rootProject;
 	}
 }

--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/ls/JDTUtilsLSImpl.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/ls/JDTUtilsLSImpl.java
@@ -22,6 +22,7 @@ import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IOpenable;
 import org.eclipse.jdt.core.ITypeRoot;
@@ -38,6 +39,7 @@ import org.eclipse.lsp4j.Range;
 
 import com.redhat.microprofile.commons.DocumentFormat;
 import com.redhat.microprofile.jdt.core.utils.IJDTUtils;
+import com.redhat.microprofile.jdt.internal.core.FakeJavaProject;
 
 /**
  * {@link IJDTUtils} implementation with JDT S {@link JDTUtils}.
@@ -114,9 +116,14 @@ public class JDTUtilsLSImpl implements IJDTUtils {
 
 	@Override
 	public void discoverSource(IClassFile classFile, IProgressMonitor progress) throws CoreException {
+		
+		IJavaProject javaProject = classFile.getJavaProject();
+		if (javaProject instanceof FakeJavaProject) {
+			javaProject = ((FakeJavaProject) javaProject).getRootProject();
+		}
 		// Try to download source if required
 		Optional<IBuildSupport> bs = JavaLanguageServerPlugin.getProjectsManager()
-				.getBuildSupport(classFile.getJavaProject().getProject());
+				.getBuildSupport(javaProject.getProject());
 		if (bs.isPresent()) {
 			bs.get().discoverSource(classFile, progress);
 		}

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesDefinitionTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesDefinitionTest.java
@@ -45,6 +45,30 @@ public class ApplicationPropertiesDefinitionTest {
 	}
 
 	@Test
+	public void definitionOnEnumValue() throws BadLocationException, InterruptedException, ExecutionException {
+		String value = "quarkus.log.syslog.async.overflow=BLO|CK";
+		testDefinitionFor(value, ll(
+				"jdt://contents/jboss-logmanager-embedded-1.0.4.jar/org.jboss.logmanager.handlers/AsyncHandler$OverflowAction.class?=abc/%5C/home%5C/dakwon%5C/.m2%5C/repository%5C/org%5C/jboss%5C/logmanager%5C/jboss-logmanager-embedded%5C/1.0.4%5C/jboss-logmanager-embedded-1.0.4.jar=/maven.pomderived=/true=/=/maven.pomderived=/true=/=/javadoc_location=/jar:file:%5C/home%5C/dakwon%5C/.m2%5C/repository%5C/org%5C/jboss%5C/logmanager%5C/jboss-logmanager-embedded%5C/1.0.4%5C/jboss-logmanager-embedded-1.0.4-javadoc.jar%5C!%5C/=/=/maven.groupId=/org.jboss.logmanager=/=/maven.artifactId=/jboss-logmanager-embedded=/=/maven.version=/1.0.4=/=/maven.scope=/compile=/%3Corg.jboss.logmanager.handlers(AsyncHandler$OverflowAction.class",
+				r(0, 34, 39), r(222, 8, 13)));
+	}
+
+	@Test
+	public void definitionOnOptionalEnumValue() throws BadLocationException, InterruptedException, ExecutionException {
+		String value = "quarkus.datasource.transaction-isolation-level=no|ne";
+		testDefinitionFor(value, ll(
+				"jdt://contents/agroal-api-1.5.jar/io.agroal.api.configuration/AgroalConnectionFactoryConfiguration$TransactionIsolation.class?=all-quarkus-extensions/%5C/home%5C/dakwon%5C/.m2%5C/repository%5C/io%5C/agroal%5C/agroal-api%5C/1.5%5C/agroal-api-1.5.jar=/maven.pomderived=/true=/=/maven.pomderived=/true=/=/maven.groupId=/io.agroal=/=/maven.artifactId=/agroal-api=/=/maven.version=/1.5=/=/maven.scope=/compile=/%3Cio.agroal.api.configuration(AgroalConnectionFactoryConfiguration$TransactionIsolation.class",
+				r(0, 47, 51), r(42, 19, 23)));
+	}
+
+	@Test
+	public void definitionOnMappedPropertyOptionalEnumValue() throws BadLocationException, InterruptedException, ExecutionException {
+		String value = "quarkus.datasource.key.transaction-isolation-level=no|ne";
+		testDefinitionFor(value, ll(
+				"jdt://contents/agroal-api-1.5.jar/io.agroal.api.configuration/AgroalConnectionFactoryConfiguration$TransactionIsolation.class?=all-quarkus-extensions/%5C/home%5C/dakwon%5C/.m2%5C/repository%5C/io%5C/agroal%5C/agroal-api%5C/1.5%5C/agroal-api-1.5.jar=/maven.pomderived=/true=/=/maven.pomderived=/true=/=/maven.groupId=/io.agroal=/=/maven.artifactId=/agroal-api=/=/maven.version=/1.5=/=/maven.scope=/compile=/%3Cio.agroal.api.configuration(AgroalConnectionFactoryConfiguration$TransactionIsolation.class",
+				r(0, 51, 55), r(42, 19, 23)));
+	}
+
+	@Test
 	public void noDefinitionOnKey() throws BadLocationException, InterruptedException, ExecutionException {
 		String value = "quarkus.datasource.driv|erXXXX";
 		testDefinitionFor(value);

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/services/all-quarkus-definitions.json
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/services/all-quarkus-definitions.json
@@ -7390,5 +7390,37 @@
                 }
             }
         }
+    },
+    {
+        "propertySource": "org.jboss.logmanager.handlers.AsyncHandler$OverflowAction#BLOCK",
+        "location": {
+            "uri": "jdt://contents/jboss-logmanager-embedded-1.0.4.jar/org.jboss.logmanager.handlers/AsyncHandler$OverflowAction.class?=abc/%5C/home%5C/dakwon%5C/.m2%5C/repository%5C/org%5C/jboss%5C/logmanager%5C/jboss-logmanager-embedded%5C/1.0.4%5C/jboss-logmanager-embedded-1.0.4.jar=/maven.pomderived=/true=/=/maven.pomderived=/true=/=/javadoc_location=/jar:file:%5C/home%5C/dakwon%5C/.m2%5C/repository%5C/org%5C/jboss%5C/logmanager%5C/jboss-logmanager-embedded%5C/1.0.4%5C/jboss-logmanager-embedded-1.0.4-javadoc.jar%5C!%5C/=/=/maven.groupId=/org.jboss.logmanager=/=/maven.artifactId=/jboss-logmanager-embedded=/=/maven.version=/1.0.4=/=/maven.scope=/compile=/%3Corg.jboss.logmanager.handlers(AsyncHandler$OverflowAction.class",
+            "range": {
+                "start": {
+                    "line": 222,
+                    "character": 8
+                },
+                "end": {
+                    "line": 222,
+                    "character": 13
+                }
+            }
+        }
+	},
+	{
+        "propertySource": "io.agroal.api.configuration.AgroalConnectionFactoryConfiguration.TransactionIsolation#NONE",
+        "location": {
+            "uri": "jdt://contents/agroal-api-1.5.jar/io.agroal.api.configuration/AgroalConnectionFactoryConfiguration$TransactionIsolation.class?=all-quarkus-extensions/%5C/home%5C/dakwon%5C/.m2%5C/repository%5C/io%5C/agroal%5C/agroal-api%5C/1.5%5C/agroal-api-1.5.jar=/maven.pomderived=/true=/=/maven.pomderived=/true=/=/maven.groupId=/io.agroal=/=/maven.artifactId=/agroal-api=/=/maven.version=/1.5=/=/maven.scope=/compile=/%3Cio.agroal.api.configuration(AgroalConnectionFactoryConfiguration$TransactionIsolation.class",
+            "range": {
+                "start": {
+                    "line": 42,
+                    "character": 19
+                },
+                "end": {
+                    "line": 42,
+                    "character": 23
+                }
+            }
+        }
     }
 ]


### PR DESCRIPTION
Fixes #162 

Enums (including java.util.Optional enums) work:
```
# works
quarkus.log.console.async.overflow=BLOCK
quarkus.datasource.transaction-isolation-level=read-uncommitted
quarkus.datasource.dd.transaction-isolation-level=none
quarkus.hibernate-search.elasticsearch.automatic-indexing.synchronization-strategy=queued
```

LIMITATION: 
However currently, go to definiton for logging level values and kubernetes enum values do not work.
```
# does not work
quarkus.log.level=WARNING
kubernetes.image-pull-policy=Always
```

Signed-off-by: David Kwon <dakwon@redhat.com>