### PR TITLE
Fix NPE in CompletableFuture on LSP requests

### DIFF
--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/ls/MicroProfileDelegateCommandHandler.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/ls/MicroProfileDelegateCommandHandler.java
@@ -127,6 +127,15 @@ public class MicroProfileDelegateCommandHandler implements IDelegateCommandHandl
 		} catch (InterruptedException e) {
 			LOGGER.log(Level.WARNING, "Error while joining MicroProfile properties collector job", e);
 		}
+		
+		Exception jobException = (Exception) job.getResult().getException();
+		if (jobException != null) {
+			if (jobException.getCause() != null) {
+				throw (Exception) jobException.getCause();
+			}
+			throw jobException;
+		};
+		
 		return projectInfo[0];
 	}
 

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/ApplicationPropertiesTextDocumentService.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/ApplicationPropertiesTextDocumentService.java
@@ -172,7 +172,7 @@ public class ApplicationPropertiesTextDocumentService extends AbstractTextDocume
 		MicroProfileProjectInfoParams projectInfoParams = createProjectInfoParams(params.getTextDocument());
 		return getProjectInfoCache().getProjectInfo(projectInfoParams).thenComposeAsync(projectInfo -> {
 			if (projectInfo.getProperties().isEmpty()) {
-				return null;
+				return CompletableFuture.completedFuture(null);
 			}
 			// then get the Properties model document
 			return getPropertiesModel(params.getTextDocument(), (cancelChecker, document) -> {
@@ -213,7 +213,7 @@ public class ApplicationPropertiesTextDocumentService extends AbstractTextDocume
 		MicroProfileProjectInfoParams projectInfoParams = createProjectInfoParams(params.getTextDocument());
 		return getProjectInfoCache().getProjectInfo(projectInfoParams).thenComposeAsync(projectInfo -> {
 			if (projectInfo.getProperties().isEmpty()) {
-				return null;
+				return CompletableFuture.completedFuture(null);
 			}
 			// then get the Properties model document
 			return getDocument(params.getTextDocument().getUri()).getModel().thenComposeAsync(document -> {
@@ -243,7 +243,7 @@ public class ApplicationPropertiesTextDocumentService extends AbstractTextDocume
 		MicroProfileProjectInfoParams projectInfoParams = createProjectInfoParams(params.getTextDocument());
 		return getProjectInfoCache().getProjectInfo(projectInfoParams).thenComposeAsync(projectInfo -> {
 			if (projectInfo.getProperties().isEmpty()) {
-				return null;
+				return CompletableFuture.completedFuture(null);
 			}
 			// then get the Properties model document
 			return getPropertiesModel(params.getTextDocument(), (cancelChecker, document) -> {
@@ -280,7 +280,7 @@ public class ApplicationPropertiesTextDocumentService extends AbstractTextDocume
 		MicroProfileProjectInfoParams projectInfoParams = createProjectInfoParams(document.getUri());
 		getProjectInfoCache().getProjectInfo(projectInfoParams).thenComposeAsync(projectInfo -> {
 			if (projectInfo.getProperties().isEmpty()) {
-				return null;
+				return CompletableFuture.completedFuture(null);
 			}
 			// then get the Properties model document
 			return getPropertiesModel(document, (cancelChecker, model) -> {

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/MicroProfileProjectInfoCache.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/MicroProfileProjectInfoCache.java
@@ -11,6 +11,7 @@ package com.redhat.microprofile.ls;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -18,6 +19,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import com.redhat.microprofile.commons.MicroProfileProjectInfo;
@@ -38,9 +40,20 @@ import com.redhat.microprofile.ls.api.MicroProfileProjectInfoProvider;
  */
 class MicroProfileProjectInfoCache {
 
+	private static final Logger LOGGER = Logger.getLogger(MicroProfileProjectInfoCache.class.getName());
+
 	private final Map<String /* application.properties URI */, CompletableFuture<MicroProfileProjectInfo>> cache;
 
 	private final MicroProfileProjectInfoProvider provider;
+
+	private static final MicroProfileProjectInfo EMPTY_PROJECT_INFO;
+	
+	static {
+		EMPTY_PROJECT_INFO = new MicroProfileProjectInfo();
+		EMPTY_PROJECT_INFO.setProperties(Collections.emptyList());
+		EMPTY_PROJECT_INFO.setHints(Collections.emptyList());
+		EMPTY_PROJECT_INFO.setProjectURI("");
+	}
 
 	/**
 	 * Computed metadata build from dynamic properties and a given hint value.
@@ -194,7 +207,10 @@ class MicroProfileProjectInfoCache {
 			// not found in the cache, load the project info from the JDT LS Extension
 			params.setScopes(MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES);
 			CompletableFuture<MicroProfileProjectInfo> future = provider.getProjectInfo(params). //
-					thenApply(info -> new MicroProfileProjectInfoWrapper(info));
+					exceptionally(ex-> {
+						LOGGER.warning(String.format("Cannot find MicroProfileProjectInfo for '%s'", params.getUri()));
+						return new MicroProfileProjectInfoWrapper(EMPTY_PROJECT_INFO);
+					}).thenApply(info -> new MicroProfileProjectInfoWrapper(info));
 			// cache the future.
 			cache.put(params.getUri(), future);
 			return future;

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/ls/MicroProfileProjectInfoCacheTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/ls/MicroProfileProjectInfoCacheTest.java
@@ -61,6 +61,16 @@ public class MicroProfileProjectInfoCacheTest {
 		}
 	}
 
+	static class MicroProfileProjectInfoProviderThrowException implements MicroProfileProjectInfoProvider {
+
+		@Override
+		public CompletableFuture<MicroProfileProjectInfo> getProjectInfo(MicroProfileProjectInfoParams params) {
+			CompletableFuture<MicroProfileProjectInfo> completableFuture = new CompletableFuture<>();
+			completableFuture.completeExceptionally(new UnsupportedOperationException());
+			return completableFuture;
+		}
+	}
+
 	@Test
 	public void getProjectInfoCache() throws InterruptedException, ExecutionException {
 		MicroProfileProjectInfoProviderTracker tracker = new MicroProfileProjectInfoProviderTracker();
@@ -101,5 +111,14 @@ public class MicroProfileProjectInfoCacheTest {
 				request1.get() == request4.get());
 		Assert.assertEquals("Number of call of getProjectInfo after propertiesChanged", 2, tracker.getInstanceCount());
 
+	}
+
+	@Test 
+	public void getProjectInfoCacheProviderException() throws InterruptedException, ExecutionException {
+		MicroProfileProjectInfoProviderThrowException provider = new MicroProfileProjectInfoProviderThrowException();
+		MicroProfileProjectInfoCache cache = new MicroProfileProjectInfoCache(provider);
+		MicroProfileProjectInfoParams params = new MicroProfileProjectInfoParams("application.properties");
+		CompletableFuture<MicroProfileProjectInfo> request = cache.getProjectInfo(params);
+		request.get();
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-quarkus/issues/185

I added this to the jdt.ls extension here : 
https://github.com/xorye/quarkus-ls/blob/277f609b0bbb07b4900aa354a6ba99a69331ad27/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/ls/MicroProfileDelegateCommandHandler.java#L132-L134

because the original exception here: https://github.com/redhat-developer/quarkus-ls/blob/master/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/PropertiesManager.java#L88

was being thrown while inside of a Java Job. Because of that, the `exceptionally` stage wasn't being reached on the client side here:
https://github.com/xorye/quarkus-ls/blob/277f609b0bbb07b4900aa354a6ba99a69331ad27/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/MicroProfileProjectInfoCache.java#L209-L212

Signed-off-by: David Kwon <dakwon@redhat.com>