### PR TITLE
Accurate Assign start and end offsets

### DIFF
--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/PropertiesModel.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/PropertiesModel.java
@@ -110,6 +110,10 @@ public class PropertiesModel extends Node {
 		public void delimiterAssign(ParseContext context) {
 			Node assign = new Assign();
 			assign.setStart(context.getLocationOffset());
+
+			// assumption: delimiters are only one character long
+			assign.setEnd(context.getLocationOffset() + 1);
+
 			property.setDelimiterAssign(assign);
 		}
 

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/Property.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/Property.java
@@ -162,6 +162,9 @@ public class Property extends Node {
 		if (assign == null) {
 			return key;
 		}
+		if (assign.getStart() == offset) {
+			return assign;
+		}
 		if (offset >= assign.getStart()) {
 			Node value = getValue();
 			return value != null ? value : assign;

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/parser/PropertiesParser.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/parser/PropertiesParser.java
@@ -165,7 +165,7 @@ public class PropertiesParser implements ParseContext {
 		readString(StopReading.PropertyName);
 		handler.endPropertyName(this);
 		skipWhiteSpace();
-		if (!readChar('=') && !readChar(':')) {
+		if (current != '=' && current != ':') {
 //			final Location location = getLocation();
 //			ErrorEvent e = new ErrorEvent(location, location,
 //					"Equals sign '==' missing after property name '" + name + "'",
@@ -174,8 +174,11 @@ public class PropertiesParser implements ParseContext {
 			skipUntilEndOfLine();
 		} else {
 			handler.delimiterAssign(this);
-			// property value
+
+			// read the '=' or ':' sign
+			read();
 			skipWhiteSpace();
+
 			if (current != -1) {
 				handler.startPropertyValue(this);
 				readString(StopReading.PropertyValue);

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileCompletions.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileCompletions.java
@@ -351,7 +351,12 @@ class MicroProfileCompletions {
 		Range range = null;
 		try {
 			TextDocument doc = model.getDocument();
-			int startOffset = node.getStart();
+			int startOffset;
+			if (node.getNodeType() == NodeType.ASSIGN) {
+				startOffset = node.getEnd();
+			} else {
+				startOffset = node.getStart();
+			}
 			range = doc.lineRangeAt(startOffset);
 			range.setStart(doc.positionAt(startOffset));
 		} catch (BadLocationException e) {

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/parser/PropertiesModelTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/parser/PropertiesModelTest.java
@@ -35,10 +35,10 @@ public class PropertiesModelTest {
 		assertComments(comments, 1, 11, "# comment ");
 
 		Node firstPropertyNode = model.getChildren().get(1);
-		assertProperty(firstPropertyNode, 12, 13, "a", 15, 16, 17, "b");
+		assertProperty(firstPropertyNode, 12, 13, "a", 14, 16, 17, "b");
 
 		Node secondPropertyNode = model.getChildren().get(2);
-		assertProperty(secondPropertyNode, 19, 20, "c", 21, 21, 22, "d");
+		assertProperty(secondPropertyNode, 19, 20, "c", 20, 21, 22, "d");
 
 	}
 
@@ -60,7 +60,7 @@ public class PropertiesModelTest {
 		assertModel(model, text.length(), 1);
 
 		Node firstPropertyNode = model.getChildren().get(0);
-		assertProperty(firstPropertyNode, 0, 1, "a", 3, 4, 17, "value # value");
+		assertProperty(firstPropertyNode, 0, 1, "a", 2, 4, 17, "value # value");
 	}
 
 	@Test
@@ -70,7 +70,7 @@ public class PropertiesModelTest {
 		assertModel(model, text.length(), 1);
 
 		Node firstPropertyNode = model.getChildren().get(0);
-		assertProperty(firstPropertyNode, 1, 2, "a", 3, -1, -1, null);
+		assertProperty(firstPropertyNode, 1, 2, "a", 2, -1, -1, null);
 
 	}
 

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesHoverTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesHoverTest.java
@@ -32,7 +32,7 @@ public class ApplicationPropertiesHoverTest {
 
 	@Test
 	public void testQuarkusKeyHoverMarkdown() throws BadLocationException {
-		String value = "quarkus.applica|tion.name = \"name\"";
+		String value = "quarkus.applica|tion.name = name";
 		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator() + //
 				"The name of the application.\nIf not set, defaults to the name of the project (except for tests where it is not set at all)."
 				+ System.lineSeparator() + System.lineSeparator() + //
@@ -44,7 +44,7 @@ public class ApplicationPropertiesHoverTest {
 
 	@Test
 	public void testQuarkusKeyHoverPlaintext() throws BadLocationException {
-		String value = "quarkus.applica|tion.name = \"name\"";
+		String value = "quarkus.applica|tion.name = name";
 		String hoverLabel = "quarkus.application.name" + System.lineSeparator() + System.lineSeparator() + //
 				"The name of the application.\nIf not set, defaults to the name of the project (except for tests where it is not set at all)."
 				+ System.lineSeparator() + System.lineSeparator() + //
@@ -56,7 +56,7 @@ public class ApplicationPropertiesHoverTest {
 
 	@Test
 	public void testQuarkusKeyHoverNoSpaces() throws BadLocationException {
-		String value = "quarkus.applica|tion.name=\"name\"";
+		String value = "quarkus.applica|tion.name=name";
 		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator() + //
 				"The name of the application.\nIf not set, defaults to the name of the project (except for tests where it is not set at all)."
 				+ System.lineSeparator() + System.lineSeparator() + //
@@ -67,15 +67,16 @@ public class ApplicationPropertiesHoverTest {
 	};
 
 	@Test
-	public void testQuarkusKeyHoverOnEqualsSign() throws BadLocationException {
-		String value = "quarkus.application.name |= \"name\"";
-		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator() + //
-				"The name of the application.\nIf not set, defaults to the name of the project (except for tests where it is not set at all)."
-				+ System.lineSeparator() + System.lineSeparator() + //
-				" * Type: `java.util.Optional<java.lang.String>`" + System.lineSeparator() + //
-				" * Phase: `buildtime & runtime`" + System.lineSeparator() + //
-				" * Extension: `quarkus-core`";
-		assertHoverMarkdown(value, hoverLabel, 0);
+	public void testNoQuarkusKeyHoverOnEqualsSign() throws BadLocationException {
+		assertHoverMarkdown("quarkus.application.name |= name", null, 0);
+		assertHoverMarkdown("quarkus.application.name|=name", null, 0);
+		assertHoverMarkdown("quarkus.log.syslog.async.overflow|=DISCARD", null, 0);
+	};
+
+	@Test
+	public void testNoQuarkusValueHoverOnEqualsSign() throws BadLocationException {
+		assertHoverMarkdown("quarkus.log.syslog.async.overflow |= DISCARD", null, 0);
+		assertHoverMarkdown("quarkus.log.syslog.async.overflow|=DISCARD", null, 0);
 	};
 
 	@Test
@@ -83,18 +84,6 @@ public class ApplicationPropertiesHoverTest {
 		String value = "a=1\n" + //
 				"b=|";
 		assertHoverMarkdown(value, null, 0);
-	};
-
-	@Test
-	public void testQuarkusKeyHoverOnEqualsSignNoSpaces() throws BadLocationException {
-		String value = "quarkus.application.name|=\"name\"";
-		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator() + //
-				"The name of the application.\nIf not set, defaults to the name of the project (except for tests where it is not set at all)."
-				+ System.lineSeparator() + System.lineSeparator() + //
-				" * Type: `java.util.Optional<java.lang.String>`" + System.lineSeparator() + //
-				" * Phase: `buildtime & runtime`" + System.lineSeparator() + //
-				" * Extension: `quarkus-core`";
-		assertHoverMarkdown(value, hoverLabel, 0);
 	};
 
 	@Test
@@ -146,7 +135,7 @@ public class ApplicationPropertiesHoverTest {
 
 	@Test
 	public void testQuarkusKeyWithProfileHoverMarkdown() throws BadLocationException {
-		String value = "%dev.quarkus.applica|tion.name = \"name\"";
+		String value = "%dev.quarkus.applica|tion.name = name";
 		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator() + //
 				"The name of the application.\nIf not set, defaults to the name of the project (except for tests where it is not set at all)."
 				+ System.lineSeparator() + System.lineSeparator() + //


### PR DESCRIPTION
Fixes #172 by providing accurate start and end offsets for the `Assign` (equals sign) for the `PropertiesModel`.

For example, for this application.properites file:
```
quarkus.application.name = name
```
#### Before this PR:
PropertyKey
start: 0
end: 24

Assign
start: 26
end: -1

PropertyValue
start: 27
end: 31

#### After this PR:
PropertyKey
start: 0
end: 24

Assign
start: **25**
end: **26**

PropertyValue
start: 27
end: 31

Signed-off-by: David Kwon <dakwon@redhat.com>