### PR TITLE
Parse PropertyValue when spanning multiple lines

### DIFF
--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/Node.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/Node.java
@@ -81,7 +81,7 @@ public abstract class Node {
 		if (start == -1 || end == -1) {
 			return null;
 		}
-		return getOwnerModel().getText(start, end);
+		return getOwnerModel().getText(start, end).replace("\\\n", "");
 	}
 
 	/**

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/Node.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/Node.java
@@ -81,7 +81,21 @@ public abstract class Node {
 		if (start == -1 || end == -1) {
 			return null;
 		}
-		return getOwnerModel().getText(start, end).replace("\\\n", "");
+		return getOwnerModel().getText(start, end, false);
+	}
+
+	/**
+	 * Returns the text of the node
+	 * 
+	 * @param skipMultiLine determines whether or not new lines characters and backslashes
+	 * should be preserved for multi line text values
+	 * @return the text of the node
+	 */
+	public String getText(boolean skipMultiLine) {
+		if (start == -1 || end == -1) {
+			return null;
+		}
+		return getOwnerModel().getText(start, end, skipMultiLine);
 	}
 
 	/**

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/PropertiesModel.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/PropertiesModel.java
@@ -164,8 +164,48 @@ public class PropertiesModel extends Node {
 		return model;
 	}
 
-	public String getText(int start, int end) {
-		return document.getText().substring(start, end);
+	/**
+	 * Returns the text from the <code>start</code> offset (inclusive) to the <code>end</code>
+	 * offset (exclusive).
+	 * 
+	 * @param start         the start offset
+	 * @param end           the end offset
+	 * @param skipMultiLine determines whether or not new lines characters and backslashes
+	 * should be preserved for multi line text values
+	 * @return the text from the <code>start</code> offset (inclusive) to the <code>end</code>
+	 * offset (exclusive).
+	 */
+	public String getText(int start, int end, boolean skipMultiLine) {
+		String text = document.getText();
+		if (!skipMultiLine) {
+			return text.substring(start, end);
+		}
+
+		StringBuilder sb = new StringBuilder();
+		int i = start;
+		boolean trimLeading = false;
+		while (i < end) {
+			char curr = text.charAt(i);
+			if (curr == '\\') {
+				if (i < end - 1 && text.charAt(i + 1) == '\n') {
+					i += 2;
+					trimLeading = true;
+					continue;
+				} else if (i < end - 2 && text.charAt(i + 1) == '\r' && text.charAt(i + 2) == '\n') {
+					i += 3;
+					trimLeading = true;
+					continue;
+				}
+			}
+
+			if (!trimLeading || !Character.isWhitespace(curr)) {
+				trimLeading = false;
+				sb.append(curr);
+			} 
+			
+			i++;
+		}
+		return sb.toString();
 	}
 
 	public int offsetAt(Position position) throws BadLocationException {

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/Property.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/Property.java
@@ -98,10 +98,18 @@ public class Property extends Node {
 	 * Returns the property name without the profile of the property key and null
 	 * otherwise.
 	 * 
+	 * For multiline property names, this method returns the property name
+	 * with the backslashes and newlines removed.
+	 * 
 	 * <ul>
 	 * <li>'%dev.' will return null.</li>
 	 * <li>'%dev.key' will return 'key'.</li>
 	 * <li>'key' will return 'key'.</li>
+	 * <li>
+	 *   'key1.\
+	 *    key2.\
+	 *    key3' will return 'key1.key2.key3'
+	 * </li>
 	 * </ul>
 	 * 
 	 * @return the property name without the profile of the property key and null
@@ -119,10 +127,18 @@ public class Property extends Node {
 	 * Returns the property name with the profile of the property key and null
 	 * otherwise.
 	 * 
+	 * For multiline property names, this method returns the property name
+	 * with the profile, with backslashes and newlines removed.
+	 * 
 	 * <ul>
 	 * <li>'%dev.' will return '%dev.'.</li>
 	 * <li>'%dev.key' will return '%dev.key'.</li>
 	 * <li>'key' will return 'key'.</li>
+	 * <li>
+	 *   '%dev.\'
+	 *   'key1.\
+	 *    key2' will return '%dev.key1.key2'
+	 * </li>
 	 * </ul>
 	 * 
 	 * @return the property name with the profile of the property key and null
@@ -138,6 +154,9 @@ public class Property extends Node {
 
 	/**
 	 * Returns the property value and null otherwise.
+	 * 
+	 * For multiline property values, this method returns the property value
+	 * with backslashes and newlines removed.
 	 * 
 	 * @return the property value and null otherwise.
 	 */

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/PropertyKey.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/PropertyKey.java
@@ -45,10 +45,18 @@ public class PropertyKey extends Node {
 	 * Returns the property name without the profile of the property key and null
 	 * otherwise.
 	 * 
+	 * For multiline property names, this method returns the property name
+	 * with the backslashes and newlines removed.
+	 * 
 	 * <ul>
 	 * <li>'%dev.' will return null.</li>
 	 * <li>'%dev.key' will return 'key'.</li>
 	 * <li>'key' will return 'key'.</li>
+	 * <li>
+	 *   'key1.\
+	 *    key2.\
+	 *    key3' will return 'key1.key2.key3'
+	 * </li>
 	 * </ul>
 	 * 
 	 * @return the property name without the profile of the property key and null
@@ -59,29 +67,36 @@ public class PropertyKey extends Node {
 		if (profileEndOffset != -1) {
 			int end = getEnd();
 			if (profileEndOffset < end) {
-				String fulltext = getOwnerModel().getText();
-				return fulltext.substring(profileEndOffset + 1, end);
+				return getOwnerModel().getText(profileEndOffset + 1, end, true);
 			}
 			return null;
 		}
-		return getText();
+		return getText(true);
 	}
 
 	/**
 	 * Returns the property name with the profile of the property key and null
 	 * otherwise.
 	 * 
+	 * For multiline property names, this method returns the property name
+	 * with the profile, with backslashes and newlines removed.
+	 * 
 	 * <ul>
 	 * <li>'%dev.' will return '%dev.'.</li>
 	 * <li>'%dev.key' will return '%dev.key'.</li>
 	 * <li>'key' will return 'key'.</li>
+	 * <li>
+	 *   '%dev.\'
+	 *   'key1.\
+	 *    key2' will return '%dev.key1.key2'
+	 * </li>
 	 * </ul>
 	 * 
 	 * @return the property name with the profile of the property key and null
 	 *         otherwise.
 	 */
 	public String getPropertyNameWithProfile() {
-		return getText();
+		return getText(true);
 	}
 
 	/**

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/PropertyValue.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/PropertyValue.java
@@ -25,10 +25,13 @@ public class PropertyValue extends Node {
 	/**
 	 * Returns the property value and null otherwise.
 	 * 
+	 * For multiline property values, this method returns the property value
+	 * with backslashes and newlines removed.
+	 * 
 	 * @return the property value and null otherwise
 	 */
 	public String getValue() {
-		String text = getText();
+		String text = getText(true);
 		return text != null ? text.trim() : null;
 	}
 

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/parser/PropertiesHandler.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/parser/PropertiesHandler.java
@@ -121,5 +121,4 @@ public interface PropertiesHandler {
 	void blankLine(ParseContext context);
 
 	void delimiterAssign(ParseContext context);
-
 }

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/parser/PropertiesParser.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/model/parser/PropertiesParser.java
@@ -290,7 +290,7 @@ public class PropertiesParser implements ParseContext {
 	 */
 	private boolean continueReadPropertyKey() {
 		readString(StopReading.PropertyName);
-		if (last != '\\') {
+		if (last != '\\' || isWhiteSpace(current)) {
 			handler.endPropertyName(this);
 			return true;
 		}

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileFormatter.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileFormatter.java
@@ -172,7 +172,7 @@ class MicroProfileFormatter {
 			if (insertSpaces) {
 				formattedContent.append(" ");
 			}
-			formattedContent.append(property.getValue().getValue());
+			formattedContent.append(property.getValue().getText().trim());
 		}
 
 		if (keyExists || delimiterExists || valueExists) {

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileSymbolsProvider.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileSymbolsProvider.java
@@ -116,7 +116,7 @@ class MicroProfileSymbolsProvider {
 		if (key == null) {
 			return null;
 		}
-		return key.getText();
+		return key.getPropertyNameWithProfile();
 	}
 
 	private static Range getSymbolRange(Property property) {

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/parser/PropertiesModelTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/parser/PropertiesModelTest.java
@@ -12,9 +12,6 @@ package com.redhat.microprofile.parser;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
-
 import com.redhat.microprofile.model.Node;
 import com.redhat.microprofile.model.PropertiesModel;
 import com.redhat.microprofile.model.Property;
@@ -38,10 +35,10 @@ public class PropertiesModelTest {
 		assertComments(comments, 1, 11, "# comment ");
 
 		Node firstPropertyNode = model.getChildren().get(1);
-		assertProperty(firstPropertyNode, 12, 13, "a", 14, 16, 17, "b");
+		assertProperty(firstPropertyNode, 12, 17, 12, 13, "a", 14, 16, 17, "b");
 
 		Node secondPropertyNode = model.getChildren().get(2);
-		assertProperty(secondPropertyNode, 19, 20, "c", 20, 21, 22, "d");
+		assertProperty(secondPropertyNode, 19, 22, 19, 20, "c", 20, 21, 22, "d");
 
 	}
 
@@ -52,8 +49,7 @@ public class PropertiesModelTest {
 		assertModel(model, text.length(), 1);
 
 		Node firstPropertyNode = model.getChildren().get(0);
-		assertProperty(firstPropertyNode, 1, 2, "a", -1, -1, -1, null);
-
+		assertProperty(firstPropertyNode, 1, 2, 1, 2, "a", -1, -1, -1, null);
 	}
 
 	@Test
@@ -63,7 +59,7 @@ public class PropertiesModelTest {
 		assertModel(model, text.length(), 1);
 
 		Node firstPropertyNode = model.getChildren().get(0);
-		assertProperty(firstPropertyNode, 0, 1, "a", 2, 4, 17, "value # value");
+		assertProperty(firstPropertyNode, 0, 17, 0, 1, "a", 2, 4, 17, "value # value");
 	}
 
 	@Test
@@ -73,8 +69,7 @@ public class PropertiesModelTest {
 		assertModel(model, text.length(), 1);
 
 		Node firstPropertyNode = model.getChildren().get(0);
-		assertProperty(firstPropertyNode, 1, 2, "a", 2, -1, -1, null);
-
+		assertProperty(firstPropertyNode, 1, 3, 1, 2, "a", 2, -1, -1, null);
 	}
 
 	@Test
@@ -85,7 +80,7 @@ public class PropertiesModelTest {
 		PropertiesModel model = PropertiesModel.parse(text, "application.properties");
 		assertModel(model, text.length(), 1);
 		Node property = model.getChildren().get(0);
-		assertProperty(property, 0, 28, "quarkus.application.name", 28, 29, 33,
+		assertProperty(property, 0, 33, 0, 28, "quarkus.application.name", 28, 29, 33,
 				"name");
 	}
 
@@ -102,16 +97,37 @@ public class PropertiesModelTest {
 		assertModel(model, text.length(), 2);
 
 		Node firstProperty = model.getChildren().get(0);
-		assertProperty(firstProperty, 0, 32, "mp.openapi.schema.java.util.Date", 33, 35, 181, 
+		assertProperty(firstProperty, 0, 181, 0, 32, "mp.openapi.schema.java.util.Date", 33, 35, 181, 
 				"{ " +
-				"  \"name\": \"EpochMillis\" " +
-				"  \"type\": \"number\", " +
-				"  \"format\": \"int64\", " +
-				"  \"description\": \"Milliseconds since January 1, 1970, 00:00:00 GMT\" " +
+				"\"name\": \"EpochMillis\" " +
+				"\"type\": \"number\", " +
+				"\"format\": \"int64\", " +
+				"\"description\": \"Milliseconds since January 1, 1970, 00:00:00 GMT\" " +
 				"}");
 		Node secondProperty = model.getChildren().get(1);
-		assertProperty(secondProperty, 182, 199, "quarkus.http.port", 199, 200, 204,
+		assertProperty(secondProperty, 182, 204, 182, 199, "quarkus.http.port", 199, 200, 204,
 				"9090");
+	}
+
+	@Test
+	public void parseMultiPropertyValueLeadingSpaces() {
+		String text = "a = hello \\" + "\n" +
+				"how \\" + "\n" +
+				"are \\" + "\n" +
+				"you?";
+		PropertiesModel model = PropertiesModel.parse(text, "application.properties");
+		Node property = model.getChildren().get(0);
+		assertProperty(property, 0, 28, 0, 1, "a", 2, 4, 28,
+				"hello how are you?");
+
+		text = "a = hello \\" + "\n" +
+				"      how \\" + "\n" +
+				"   are \\" + "\n" +
+				"      you?";
+		model = PropertiesModel.parse(text, "application.properties");
+		property = model.getChildren().get(0);
+		assertProperty(property, 0, 43, 0, 1, "a", 2, 4, 43,
+				"hello how are you?");
 	}
 
 	@Test
@@ -129,16 +145,56 @@ public class PropertiesModelTest {
 		assertModel(model, text.length(), 2);
 
 		Node firstProperty = model.getChildren().get(0);
-		assertProperty(firstProperty, 0, 36, "mp.openapi.schema.java.util.Date", 37, 39, 185,
+		assertProperty(firstProperty, 0, 185, 0, 36, "mp.openapi.schema.java.util.Date", 37, 39, 185,
 				"{ " +
-				"  \"name\": \"EpochMillis\" " +
-				"  \"type\": \"number\", " +
-				"  \"format\": \"int64\", " +
-				"  \"description\": \"Milliseconds since January 1, 1970, 00:00:00 GMT\" " +
+				"\"name\": \"EpochMillis\" " +
+				"\"type\": \"number\", " +
+				"\"format\": \"int64\", " +
+				"\"description\": \"Milliseconds since January 1, 1970, 00:00:00 GMT\" " +
 				"}");
 		Node secondProperty = model.getChildren().get(1);
-		assertProperty(secondProperty, 186, 203, "quarkus.http.port", 203, 204, 208,
+		assertProperty(secondProperty, 186, 208, 186, 203, "quarkus.http.port", 203, 204, 208,
 				"9090");
+	}
+
+	@Test
+	public void parseSpaceAfterBackSlash() {
+		// in the case where spaces follow the backslash,
+		// the next line is treated as a new property key
+		String text = "greeting.\\ \r\n" +
+				"             message = hello\r\n" +
+				"greeting.name = quarkus";
+		PropertiesModel model = PropertiesModel.parse(text, "application.properties");
+		assertModel(model, text.length(), 3);
+
+		Node property = model.getChildren().get(0);
+		assertProperty(property, 0, 11, 0, 10, "greeting.\\", -1, -1, -1, null);
+
+		property = model.getChildren().get(1);
+		assertProperty(property, 26, 41, 26, 33, "message", 34, 36, 41, "hello");
+
+		property = model.getChildren().get(2);
+		assertProperty(property, 43, 66, 43, 56, "greeting.name", 57, 59, 66, "quarkus");
+	}
+
+	@Test
+	public void parseSpaceAfterBackSlash2() {
+		// in the case where spaces follow the backslash,
+		// the next line is treated as a new property key
+		String text = "quarkus\\  " + "\n" +
+			".application\\ " + "\n" +
+			".name=name";
+		PropertiesModel model = PropertiesModel.parse(text, "application.properties");
+		assertModel(model, text.length(), 3);
+
+		Node property = model.getChildren().get(0);
+		assertProperty(property, 0, 10, 0, 8, "quarkus\\", -1, -1, -1, null);
+
+		property = model.getChildren().get(1);
+		assertProperty(property, 11, 25, 11, 24, ".application\\", -1, -1, -1, null);
+
+		property = model.getChildren().get(2);
+		assertProperty(property, 26, 36, 26, 31, ".name", 31, 32, 36, "name");
 	}
 
 	@Test
@@ -149,14 +205,14 @@ public class PropertiesModelTest {
 		PropertiesModel model = PropertiesModel.parse(text, "application.properties");
 		assertModel(model, text.length(), 1);
 		Node property = model.getChildren().get(0);
-		assertProperty(property, 0, 27, "mp.opentracing.server.skip\\", -1, -1, -1, null);
+		assertProperty(property, 0, 27, 0, 27, "mp.opentracing.server.skip\\", -1, -1, -1, null);
 
 		// end property value with backslash
 		text = "mp.opentracing.server.skip-pattern=\\";
 		model = PropertiesModel.parse(text, "application.properties");
 		assertModel(model, text.length(), 1);
 		property = model.getChildren().get(0);
-		assertProperty(property, 0, 34, "mp.opentracing.server.skip-pattern", 34, 35, 36, "\\");
+		assertProperty(property, 0, 36, 0, 34, "mp.opentracing.server.skip-pattern", 34, 35, 36, "\\");
 	}
 
 	private static void assertComments(Node comments, int expectedStart, int expectedEnd, String expectedText) {
@@ -170,19 +226,16 @@ public class PropertiesModelTest {
 	 * NOTE: <code>expectedDelimiterAssign</code> is the start offset of the delimiter.
 	 * The assumption is that the delimiter is only one character long.
 	 */
-	private static void assertProperty(Node propertyNode, int expectedStartKey, int expectedEndKey,
-			String expectedTextKey, int expectedDelimiterAssign, int expectedStartValue, int expectedEndValue,
+	private static void assertProperty(Node propertyNode, int expectedStart, int expectedEnd,
+			int expectedStartKey, int expectedEndKey, String expectedTextKey,
+			int expectedDelimiterAssign, int expectedStartValue, int expectedEndValue,
 			String expectedTextValue) {
 		Assert.assertEquals(propertyNode.getNodeType(), NodeType.PROPERTY);
 		Property property = (Property) propertyNode;
 
 		// assert Property offsets
-		if (expectedStartKey != -1) {
-			
-			Assert.assertEquals(expectedStartKey, property.getStart());
-			int expectedEnd = Collections.max(Arrays.asList(expectedEndKey, expectedDelimiterAssign + 1, expectedEndValue));
-			Assert.assertEquals(expectedEnd, property.getEnd());
-		}
+		Assert.assertEquals(expectedStart, property.getStart());
+		Assert.assertEquals(expectedEnd, property.getEnd());
 
 		// assert PropertyKey offsets
 		Node propertyKey = property.getKey();
@@ -192,7 +245,7 @@ public class PropertiesModelTest {
 			Assert.assertNotNull(propertyKey);
 			Assert.assertEquals(expectedStartKey, propertyKey.getStart());
 			Assert.assertEquals(expectedEndKey, propertyKey.getEnd());
-			Assert.assertEquals(expectedTextKey, propertyKey.getText());
+			Assert.assertEquals(expectedTextKey, propertyKey.getText(true));
 		}
 
 		// assert delimiter offsets
@@ -212,16 +265,19 @@ public class PropertiesModelTest {
 			Assert.assertNotNull(propertyValue);
 			Assert.assertEquals(expectedStartValue, propertyValue.getStart());
 			Assert.assertEquals(expectedEndValue, propertyValue.getEnd());
-			Assert.assertEquals(expectedTextValue, propertyValue.getText());
+			Assert.assertEquals(expectedTextValue, propertyValue.getText(true));
 		}
 
 	}
 
 	private static void assertModel(Node model, int expectedEnd, int expectedChildren) {
-		Assert.assertEquals(model.getNodeType(), NodeType.DOCUMENT);
-		Assert.assertEquals(model.getStart(), 0);
-		Assert.assertEquals(model.getEnd(), expectedEnd);
-		Assert.assertEquals(model.getChildren().size(), expectedChildren);
+		NodeType expectedNodeType = NodeType.DOCUMENT;
+		int expectedStart = 0;
+
+		Assert.assertEquals(expectedNodeType, model.getNodeType());
+		Assert.assertEquals(expectedStart, model.getStart());
+		Assert.assertEquals(expectedEnd, model.getEnd());
+		Assert.assertEquals(expectedChildren, model.getChildren().size());
 	}
 
 }

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/parser/PropertiesModelTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/parser/PropertiesModelTest.java
@@ -12,6 +12,9 @@ package com.redhat.microprofile.parser;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
+
 import com.redhat.microprofile.model.Node;
 import com.redhat.microprofile.model.PropertiesModel;
 import com.redhat.microprofile.model.Property;
@@ -74,6 +77,88 @@ public class PropertiesModelTest {
 
 	}
 
+	@Test
+	public void parseMultiPropertyKey() {
+		String text = "quarkus\\" + "\n" +
+			".application\\" + "\n" +
+			".name=name";
+		PropertiesModel model = PropertiesModel.parse(text, "application.properties");
+		assertModel(model, text.length(), 1);
+		Node property = model.getChildren().get(0);
+		assertProperty(property, 0, 28, "quarkus.application.name", 28, 29, 33,
+				"name");
+	}
+
+	@Test
+	public void parseMultiPropertyValue() {
+		String text = "mp.openapi.schema.java.util.Date = { \\" + "\n" +
+			"  \"name\": \"EpochMillis\" \\" + "\n" +
+			"  \"type\": \"number\", \\" + "\n" +
+			"  \"format\": \"int64\", \\" + "\n" +
+			"  \"description\": \"Milliseconds since January 1, 1970, 00:00:00 GMT\" \\" + "\n" +
+			"}" + "\n" +
+			"quarkus.http.port=9090";
+		PropertiesModel model = PropertiesModel.parse(text, "application.properties");
+		assertModel(model, text.length(), 2);
+
+		Node firstProperty = model.getChildren().get(0);
+		assertProperty(firstProperty, 0, 32, "mp.openapi.schema.java.util.Date", 33, 35, 181, 
+				"{ " +
+				"  \"name\": \"EpochMillis\" " +
+				"  \"type\": \"number\", " +
+				"  \"format\": \"int64\", " +
+				"  \"description\": \"Milliseconds since January 1, 1970, 00:00:00 GMT\" " +
+				"}");
+		Node secondProperty = model.getChildren().get(1);
+		assertProperty(secondProperty, 182, 199, "quarkus.http.port", 199, 200, 204,
+				"9090");
+	}
+
+	@Test
+	public void parseMultiPropertyKeyAndValue() {
+		String text = "mp\\" + "\n" +
+				".openapi\\" + "\n" +
+				".schema.java.util.Date = { \\" + "\n" +
+				"  \"name\": \"EpochMillis\" \\" + "\n" +
+				"  \"type\": \"number\", \\" + "\n" +
+				"  \"format\": \"int64\", \\" + "\n" +
+				"  \"description\": \"Milliseconds since January 1, 1970, 00:00:00 GMT\" \\" + "\n" +
+				"}" + "\n" +
+				"quarkus.http.port=9090";
+		PropertiesModel model = PropertiesModel.parse(text, "application.properties");
+		assertModel(model, text.length(), 2);
+
+		Node firstProperty = model.getChildren().get(0);
+		assertProperty(firstProperty, 0, 36, "mp.openapi.schema.java.util.Date", 37, 39, 185,
+				"{ " +
+				"  \"name\": \"EpochMillis\" " +
+				"  \"type\": \"number\", " +
+				"  \"format\": \"int64\", " +
+				"  \"description\": \"Milliseconds since January 1, 1970, 00:00:00 GMT\" " +
+				"}");
+		Node secondProperty = model.getChildren().get(1);
+		assertProperty(secondProperty, 186, 203, "quarkus.http.port", 203, 204, 208,
+				"9090");
+	}
+
+	@Test
+	public void parseEndWithBackSlash() {
+
+		// end property key with backslash
+		String text = "mp.opentracing.server.skip\\";
+		PropertiesModel model = PropertiesModel.parse(text, "application.properties");
+		assertModel(model, text.length(), 1);
+		Node property = model.getChildren().get(0);
+		assertProperty(property, 0, 27, "mp.opentracing.server.skip\\", -1, -1, -1, null);
+
+		// end property value with backslash
+		text = "mp.opentracing.server.skip-pattern=\\";
+		model = PropertiesModel.parse(text, "application.properties");
+		assertModel(model, text.length(), 1);
+		property = model.getChildren().get(0);
+		assertProperty(property, 0, 34, "mp.opentracing.server.skip-pattern", 34, 35, 36, "\\");
+	}
+
 	private static void assertComments(Node comments, int expectedStart, int expectedEnd, String expectedText) {
 		Assert.assertEquals(comments.getNodeType(), NodeType.COMMENTS);
 		Assert.assertEquals(expectedText, comments.getText());
@@ -81,12 +166,25 @@ public class PropertiesModelTest {
 		Assert.assertEquals(expectedEnd, comments.getEnd());
 	}
 
+	/**
+	 * NOTE: <code>expectedDelimiterAssign</code> is the start offset of the delimiter.
+	 * The assumption is that the delimiter is only one character long.
+	 */
 	private static void assertProperty(Node propertyNode, int expectedStartKey, int expectedEndKey,
-			String expectedTextKey, int expectedDelemiterAssign, int expectedStartValue, int expectedEndValue,
+			String expectedTextKey, int expectedDelimiterAssign, int expectedStartValue, int expectedEndValue,
 			String expectedTextValue) {
 		Assert.assertEquals(propertyNode.getNodeType(), NodeType.PROPERTY);
 		Property property = (Property) propertyNode;
 
+		// assert Property offsets
+		if (expectedStartKey != -1) {
+			
+			Assert.assertEquals(expectedStartKey, property.getStart());
+			int expectedEnd = Collections.max(Arrays.asList(expectedEndKey, expectedDelimiterAssign + 1, expectedEndValue));
+			Assert.assertEquals(expectedEnd, property.getEnd());
+		}
+
+		// assert PropertyKey offsets
 		Node propertyKey = property.getKey();
 		if (expectedStartKey == -1) {
 			Assert.assertNull(propertyKey);
@@ -97,14 +195,16 @@ public class PropertiesModelTest {
 			Assert.assertEquals(expectedTextKey, propertyKey.getText());
 		}
 
+		// assert delimiter offsets
 		Node delemiterAssign = property.getDelimiterAssign();
-		if (expectedDelemiterAssign == -1) {
+		if (expectedDelimiterAssign == -1) {
 			Assert.assertNull(delemiterAssign);
 		} else {
 			Assert.assertNotNull(delemiterAssign);
-			Assert.assertEquals(expectedDelemiterAssign, delemiterAssign.getStart());
+			Assert.assertEquals(expectedDelimiterAssign, delemiterAssign.getStart());
 		}
 
+		// assert PropertyValue offsets
 		Node propertyValue = property.getValue();
 		if (expectedStartValue == -1) {
 			Assert.assertNull(propertyValue);

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesCompletionTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesCompletionTest.java
@@ -200,6 +200,28 @@ public class ApplicationPropertiesCompletionTest {
 	}
 
 	@Test
+	public void noCompletionForExistingPropertiesWithProfile() throws BadLocationException {
+
+		String value = "%prod.quarkus.application.name=name\n" +
+				"%prod.|";
+
+		MicroProfileProjectInfo projectInfo = new MicroProfileProjectInfo();
+		List<ItemMetadata> properties = new ArrayList<ItemMetadata>();
+
+		ItemMetadata p1 = new ItemMetadata();
+		p1.setName("quarkus.http.cors");
+		properties.add(p1);
+		ItemMetadata p2 = new ItemMetadata();
+		p2.setName("quarkus.application.name");
+		properties.add(p2);
+
+		projectInfo.setProperties(properties);
+
+		testCompletionFor(value, false, null, 1, projectInfo,
+				c("quarkus.http.cors", "%prod.quarkus.http.cors=", r(1, 0, 6)));
+	}
+
+	@Test
 	public void completionForExistingPropertiesDifferentProfile() throws BadLocationException {
 
 		String value = "|";

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesDiagnosticsTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesDiagnosticsTest.java
@@ -547,4 +547,25 @@ public class ApplicationPropertiesDiagnosticsTest {
 				d(0, 35, 36, "Illegal repetition\n{\n",
 						DiagnosticSeverity.Error, ValidationType.value));
 	}
+
+	@Test
+	public void validateMultilineKey() {
+		String value = "quarkus.\\\n" +
+		"application.\\\n" +
+		"name=name";
+		MicroProfileValidationSettings settings = new MicroProfileValidationSettings();
+		testDiagnosticsFor(value, getDefaultMicroProfileProjectInfo(), settings);
+
+		value = "quarkus.\\\r\n" +
+		"application.\\\r\n" +
+		"name=name";
+		testDiagnosticsFor(value, getDefaultMicroProfileProjectInfo(), settings);
+
+		value = "qu.\\\n" +
+		"application.\\\n" +
+		"name=name";
+		testDiagnosticsFor(value, getDefaultMicroProfileProjectInfo(), settings, //
+				d(0, 0, 2, 4, "Unknown property 'qu.application.name'",
+						DiagnosticSeverity.Warning, ValidationType.unknown));
+	}
 }

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesFormatterTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesFormatterTest.java
@@ -171,4 +171,20 @@ public class ApplicationPropertiesFormatterTest {
 				"quarkus.application.version=1.0"; // <-- formatted
 		assertRangeFormat(value, expected, false);
 	};
+
+	@Test
+	public void testMultiLineKeyAndValue() throws BadLocationException {
+		String value = "quarkus.\\\n" +
+		"application.\\\n" +
+		"name=my\\\n" +
+		"application\\\n" +
+		"name   ";
+
+		String expected = "quarkus.\\\n" +
+		"application.\\\n" +
+		"name=my\\\n" +
+		"application\\\n" +
+		"name";
+		assertFormat(value, expected, false);
+	}
 }

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesSymbolsTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesSymbolsTest.java
@@ -93,4 +93,15 @@ public class ApplicationPropertiesSymbolsTest {
 												)))))) //
 		);
 	};
+
+	@Test
+	public void multiLineKeyValueSymbols() throws BadLocationException {
+		String value = "quarkus.\\\n" + //
+				"application.name = quarkus \\\n" + //
+				"application \\\n" + //
+				"name";
+		testSymbolInformationsFor(value, //
+				s("quarkus.application.name", SymbolKind.Property, "application.properties", r(0, 0, 3, 4))
+		);
+	};
 }


### PR DESCRIPTION
This PR updates the properties model parser to support multi-line values.

Before this PR:
![image](https://user-images.githubusercontent.com/20326645/76870835-a5f95d00-6840-11ea-8969-d2c2f9dd867b.png)
Before this PR, since multi-line values were not supported, the second and third lines were being parsed as property keys, causing the 'unknown property' diagnostics.


After this PR:
![image](https://user-images.githubusercontent.com/20326645/76870992-e062fa00-6840-11ea-9f0e-935e907faf11.png)


Example content used in the images:
```
# Configuration file
# key = value
quarkus.application.name= quarkus \
    application \
    name
```

Signed-off-by: David Kwon <dakwon@redhat.com>