### PR TITLE
Refactor unit test so that they can be reused

### DIFF
--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/META-INF/MANIFEST.MF
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/META-INF/MANIFEST.MF
@@ -37,3 +37,4 @@ Export-Package: com.redhat.microprofile.commons,
  io.quarkus.runtime.util
 Bundle-ClassPath: lib/snakeyaml-1.25.jar,
  .
+Eclipse-ExtensibleAPI: true

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/META-INF/MANIFEST.MF
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/META-INF/MANIFEST.MF
@@ -10,6 +10,5 @@ Require-Bundle: org.junit,
  org.apache.commons.lang3,
  org.eclipse.jdt.ls.core,
  com.google.guava,
- com.redhat.microprofile.jdt.quarkus,
  org.eclipse.lsp4j
 Import-Package: com.google.gson

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/pom.xml
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/pom.xml
@@ -12,6 +12,29 @@
 	<packaging>eclipse-test-plugin</packaging>
 	<name>quarkus.jdt.ls :: test</name>
 	<description>quarkus.jdt.ls Test Plugin</description>
+	
+	<build>
+	   <pluginManagement>
+	       <plugins>
+	           <plugin>
+	               <groupId>org.eclipse.tycho</groupId>
+	               <artifactId>target-platform-configuration</artifactId>
+	               <version>${tycho.version}</version>
+	               <configuration>
+	                   <dependency-resolution>
+	                       <extraRequirements>
+	                           <requirement>
+	                               <id>com.redhat.microprofile.jdt.quarkus</id>
+	                               <versionRange>0.0.0</versionRange>
+	                               <type>eclipse-plugin</type>
+	                           </requirement>
+	                       </extraRequirements>
+	                   </dependency-resolution>
+	               </configuration>
+	           </plugin>
+	       </plugins>
+	   </pluginManagement>
+	</build>
 	<profiles>
 		<profile>
 			<id>macosx-jvm-flags</id>

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/BasePropertiesManagerTest.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/BasePropertiesManagerTest.java
@@ -37,6 +37,7 @@ import com.redhat.microprofile.commons.ClasspathKind;
 import com.redhat.microprofile.commons.DocumentFormat;
 import com.redhat.microprofile.commons.MicroProfileProjectInfo;
 import com.redhat.microprofile.commons.MicroProfilePropertiesScope;
+import com.redhat.microprofile.jdt.core.utils.IJDTUtils;
 import com.redhat.microprofile.jdt.internal.core.JavaUtils;
 import com.redhat.microprofile.jdt.internal.core.JobHelpers;
 import com.redhat.microprofile.jdt.internal.core.ls.JDTUtilsLSImpl;
@@ -51,6 +52,8 @@ public class BasePropertiesManagerTest {
 
 	private static final Logger LOGGER = Logger.getLogger(BasePropertiesManagerTest.class.getSimpleName());
 	private static Level oldLevel;
+	
+	protected static IJDTUtils JDT_UTILS = JDTUtilsLSImpl.getInstance();
 
 	public enum MavenProjectName {
 
@@ -107,6 +110,10 @@ public class BasePropertiesManagerTest {
 	public static void tearDown() {
 		LOGGER.setLevel(oldLevel);
 	}
+	
+	protected static void setJDTUtils(IJDTUtils newUtils) {
+		JDT_UTILS = newUtils;
+	}
 
 	protected static MicroProfileProjectInfo getMicroProfileProjectInfoFromMavenProject(MavenProjectName mavenProject)
 			throws CoreException, Exception, JavaModelException {
@@ -118,7 +125,7 @@ public class BasePropertiesManagerTest {
 			List<MicroProfilePropertiesScope> scopes) throws CoreException, Exception, JavaModelException {
 		IJavaProject javaProject = loadMavenProject(mavenProject);
 		return PropertiesManager.getInstance().getMicroProfileProjectInfo(javaProject, scopes, ClasspathKind.SRC,
-				JDTUtilsLSImpl.getInstance(), DocumentFormat.Markdown, new NullProgressMonitor());
+				JDT_UTILS, DocumentFormat.Markdown, new NullProgressMonitor());
 	}
 
 	public static IJavaProject loadMavenProject(MavenProjectName mavenProject) throws CoreException, Exception {

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/GenerateAllPropertiesAndDefinition.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/GenerateAllPropertiesAndDefinition.java
@@ -41,7 +41,6 @@ import com.redhat.microprofile.commons.metadata.ItemHint;
 import com.redhat.microprofile.commons.metadata.ItemHint.ValueHint;
 import com.redhat.microprofile.commons.metadata.ItemMetadata;
 import com.redhat.microprofile.jdt.core.utils.IJDTUtils;
-import com.redhat.microprofile.jdt.internal.core.ls.JDTUtilsLSImpl;
 
 /**
  * Generator to generate JSON properties and definitions used for Junit test of
@@ -121,7 +120,7 @@ public class GenerateAllPropertiesAndDefinition extends BasePropertiesManagerTes
 	@Test
 	@Ignore
 	public void generateAllQuarkusExtensionProperties() throws JavaModelException, CoreException, Exception {
-		generateJsonFiles(MavenProjectName.all_quarkus_extensions, JDTUtilsLSImpl.getInstance(), false);
+		generateJsonFiles(MavenProjectName.all_quarkus_extensions, JDT_UTILS, false);
 	}
 
 	/**
@@ -151,7 +150,7 @@ public class GenerateAllPropertiesAndDefinition extends BasePropertiesManagerTes
 	@Ignore
 	public void generateAllQuarkusExtensionPropertiesAndDefinitions()
 			throws JavaModelException, CoreException, Exception {
-		generateJsonFiles(MavenProjectName.all_quarkus_extensions, JDTUtilsLSImpl.getInstance(), true);
+		generateJsonFiles(MavenProjectName.all_quarkus_extensions, JDT_UTILS, true);
 	}
 
 	private void generateJsonFiles(MavenProjectName mavenProject, IJDTUtils utils, boolean generateDefinition)

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/JavaHoverTest.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/JavaHoverTest.java
@@ -32,9 +32,7 @@ import org.junit.Test;
 import com.redhat.microprofile.commons.DocumentFormat;
 import com.redhat.microprofile.commons.MicroProfileJavaHoverParams;
 import com.redhat.microprofile.jdt.core.project.JDTMicroProfileProject;
-import com.redhat.microprofile.jdt.core.utils.IJDTUtils;
 import com.redhat.microprofile.jdt.internal.config.java.MicroProfileConfigHoverParticipant;
-import com.redhat.microprofile.jdt.internal.core.ls.JDTUtilsLSImpl;
 
 /**
  * JDT Quarkus manager test for hover in Java file.
@@ -44,7 +42,6 @@ import com.redhat.microprofile.jdt.internal.core.ls.JDTUtilsLSImpl;
 public class JavaHoverTest extends BasePropertiesManagerTest {
 
 	private static IJavaProject javaProject;
-	private static IJDTUtils utils;
 	private static String javaFileUri;
 
 	@BeforeClass
@@ -58,7 +55,6 @@ public class JavaHoverTest extends BasePropertiesManagerTest {
 		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/GreetingResource.java"));
 		javaFileUri = javaFile.getLocation().toFile().toURI().toString();
 
-		utils = JDTUtilsLSImpl.getInstance();
 	}
 
 	@Before
@@ -152,7 +148,7 @@ public class JavaHoverTest extends BasePropertiesManagerTest {
 		params.setPosition(hoverPosition);
 		params.setUri(javaFileUri);
 
-		return PropertiesManagerForJava.getInstance().hover(params, utils, new NullProgressMonitor());
+		return PropertiesManagerForJava.getInstance().hover(params, JDT_UTILS, new NullProgressMonitor());
 	}
 
 	private void assertHover(String expectedKey, String expectedValue, int expectedLine, int expectedStartOffset,

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/PropertiesManagerClassPathKindTest.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/PropertiesManagerClassPathKindTest.java
@@ -26,7 +26,6 @@ import com.redhat.microprofile.commons.ClasspathKind;
 import com.redhat.microprofile.commons.DocumentFormat;
 import com.redhat.microprofile.commons.MicroProfileProjectInfo;
 import com.redhat.microprofile.commons.MicroProfilePropertiesScope;
-import com.redhat.microprofile.jdt.internal.core.ls.JDTUtilsLSImpl;
 import com.redhat.microprofile.jdt.internal.core.utils.DependencyUtil;
 
 /**
@@ -51,7 +50,7 @@ public class PropertiesManagerClassPathKindTest extends BasePropertiesManagerTes
 		// not in classpath -> 0 quarkus properties
 		IFile fileFromNone = javaProject.getProject().getFile(new Path("application.properties"));
 		MicroProfileProjectInfo infoFromNone = PropertiesManager.getInstance().getMicroProfileProjectInfo(fileFromNone,
-				MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES, JDTUtilsLSImpl.getInstance(),
+				MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES, JDT_UTILS,
 				DocumentFormat.Markdown, new NullProgressMonitor());
 		Assert.assertEquals(ClasspathKind.NONE, infoFromNone.getClasspathKind());
 		Assert.assertEquals(0, infoFromNone.getProperties().size());
@@ -63,7 +62,7 @@ public class PropertiesManagerClassPathKindTest extends BasePropertiesManagerTes
 		// in /java/main/src classpath -> N quarkus properties
 		IFile fileFromSrc = javaProject.getProject().getFile(new Path("src/main/resources/application.properties"));
 		MicroProfileProjectInfo infoFromSrc = PropertiesManager.getInstance().getMicroProfileProjectInfo(fileFromSrc,
-				MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES, JDTUtilsLSImpl.getInstance(),
+				MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES, JDT_UTILS,
 				DocumentFormat.Markdown, new NullProgressMonitor());
 		Assert.assertEquals(ClasspathKind.SRC, infoFromSrc.getClasspathKind());
 		assertProperties(infoFromSrc, 185 /* properties from JAR */ + 3 /* properties from Java sources */,
@@ -98,7 +97,7 @@ public class PropertiesManagerClassPathKindTest extends BasePropertiesManagerTes
 
 		IFile filefromTest = javaProject.getProject().getFile(new Path("src/test/resources/application.properties"));
 		MicroProfileProjectInfo infoFromTest = PropertiesManager.getInstance().getMicroProfileProjectInfo(filefromTest,
-				MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES, JDTUtilsLSImpl.getInstance(),
+				MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES, JDT_UTILS,
 				DocumentFormat.Markdown, new NullProgressMonitor());
 		Assert.assertEquals(ClasspathKind.TEST, infoFromTest.getClasspathKind());
 		assertProperties(infoFromTest, 185 /* properties from JAR */ + 3 /* properties from JAR (test) */ + 3 /*

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/PropertiesManagerLocationTest.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/PropertiesManagerLocationTest.java
@@ -20,8 +20,6 @@ import org.eclipse.lsp4j.Location;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.redhat.microprofile.jdt.internal.core.ls.JDTUtilsLSImpl;
-
 /**
  * Test with find MicroProfile definition.
  * 
@@ -40,21 +38,21 @@ public class PropertiesManagerLocationTest extends BasePropertiesManagerTest {
 		// Test with JAR
 		// quarkus.datasource.url
 		Location location = PropertiesManager.getInstance().findPropertyLocation(javaProject,
-				"io.quarkus.reactive.pg.client.runtime.DataSourceConfig", "url", null, JDTUtilsLSImpl.getInstance(),
+				"io.quarkus.reactive.pg.client.runtime.DataSourceConfig", "url", null, JDT_UTILS,
 				new NullProgressMonitor());
 		Assert.assertNotNull("Definition from JAR", location);
 
 		// Test with deployment JAR
 		// quarkus.arc.auto-inject-fields
 		location = PropertiesManager.getInstance().findPropertyLocation(javaProject,
-				"io.quarkus.arc.deployment.ArcConfig", "autoInjectFields", null, JDTUtilsLSImpl.getInstance(),
+				"io.quarkus.arc.deployment.ArcConfig", "autoInjectFields", null, JDT_UTILS,
 				new NullProgressMonitor());
 		Assert.assertNotNull("Definition deployment from JAR", location);
 
 		// Test with Java sources
 		// myapp.schema.create
 		location = PropertiesManager.getInstance().findPropertyLocation(javaProject, "org.acme.vertx.FruitResource",
-				"schemaCreate", null, JDTUtilsLSImpl.getInstance(), new NullProgressMonitor());
+				"schemaCreate", null, JDT_UTILS, new NullProgressMonitor());
 		Assert.assertNotNull("Definition from Java Sources", location);
 	}
 
@@ -69,7 +67,7 @@ public class PropertiesManagerLocationTest extends BasePropertiesManagerTest {
 		// greetingInterface.name
 		Location location = PropertiesManager.getInstance().findPropertyLocation(javaProject,
 				"org.acme.config.IGreetingConfiguration", null, "getName()QOptional<QString;>;",
-				JDTUtilsLSImpl.getInstance(), new NullProgressMonitor());
+				JDT_UTILS, new NullProgressMonitor());
 		Assert.assertNotNull("Definition from IGreetingConfiguration#getName() method", location);
 	}
 

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/PropertiesManagerTest.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/PropertiesManagerTest.java
@@ -27,7 +27,6 @@ import com.redhat.microprofile.commons.DocumentFormat;
 import com.redhat.microprofile.commons.MicroProfileProjectInfo;
 import com.redhat.microprofile.commons.MicroProfileProjectInfoParams;
 import com.redhat.microprofile.commons.MicroProfilePropertiesScope;
-import com.redhat.microprofile.jdt.internal.core.ls.JDTUtilsLSImpl;
 
 /**
  * JDT Quarkus manager test.
@@ -46,7 +45,7 @@ public class PropertiesManagerTest extends BasePropertiesManagerTest {
 		MicroProfileProjectInfoParams params = new MicroProfileProjectInfoParams();
 		params.setUri("bad-uri");
 		MicroProfileProjectInfo info = PropertiesManager.getInstance().getMicroProfileProjectInfo(params,
-				JDTUtilsLSImpl.getInstance(), new NullProgressMonitor());
+				JDT_UTILS, new NullProgressMonitor());
 		Assert.assertNotNull("MicroProfileProjectInfo for 'bad-uri' should not be null", info);
 		Assert.assertTrue("MicroProfileProjectInfo for 'bad-uri' should not belong to an Eclipse project ",
 				info.getProjectURI().isEmpty());
@@ -71,7 +70,7 @@ public class PropertiesManagerTest extends BasePropertiesManagerTest {
 			throws Exception {
 		IJavaProject project = createJavaProject(projectName, classpath);
 		MicroProfileProjectInfo info = PropertiesManager.getInstance().getMicroProfileProjectInfo(project,
-				MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES, ClasspathKind.SRC, JDTUtilsLSImpl.getInstance(),
+				MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES, ClasspathKind.SRC, JDT_UTILS,
 				DocumentFormat.Markdown, new NullProgressMonitor());
 
 		assertProperties(info,

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/QuarkusConfigPropertiesTest.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/QuarkusConfigPropertiesTest.java
@@ -23,7 +23,6 @@ import com.redhat.microprofile.commons.DocumentFormat;
 import com.redhat.microprofile.commons.MicroProfileProjectInfo;
 import com.redhat.microprofile.commons.MicroProfilePropertiesScope;
 import com.redhat.microprofile.jdt.core.project.JDTMicroProfileProject;
-import com.redhat.microprofile.jdt.internal.core.ls.JDTUtilsLSImpl;
 
 /**
  * Test collection of Quarkus properties from @ConfigProperties
@@ -53,7 +52,7 @@ public class QuarkusConfigPropertiesTest extends BasePropertiesManagerTest {
 
 		MicroProfileProjectInfo infoFromJavaSources = PropertiesManager.getInstance().getMicroProfileProjectInfo(
 				javaProject, MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES, ClasspathKind.SRC,
-				JDTUtilsLSImpl.getInstance(), DocumentFormat.Markdown, new NullProgressMonitor());
+				JDT_UTILS, DocumentFormat.Markdown, new NullProgressMonitor());
 
 		int nbProperties = 0;
 
@@ -177,7 +176,7 @@ public class QuarkusConfigPropertiesTest extends BasePropertiesManagerTest {
 
 		MicroProfileProjectInfo infoFromJavaSources = PropertiesManager.getInstance().getMicroProfileProjectInfo(
 				javaProject, MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES, ClasspathKind.SRC,
-				JDTUtilsLSImpl.getInstance(), DocumentFormat.Markdown, new NullProgressMonitor());
+				JDT_UTILS, DocumentFormat.Markdown, new NullProgressMonitor());
 
 		int nbProperties = 0;
 

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/faulttolerance/MicroProfileFaultToleranceTest.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/faulttolerance/MicroProfileFaultToleranceTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import com.redhat.microprofile.commons.MicroProfileProjectInfo;
 import com.redhat.microprofile.commons.MicroProfilePropertiesScope;
 import com.redhat.microprofile.jdt.core.BasePropertiesManagerTest;
-import com.redhat.microprofile.jdt.core.BasePropertiesManagerTest.MavenProjectName;
 import com.redhat.microprofile.jdt.internal.faulttolerance.MicroProfileFaultToleranceConstants;
 
 /**

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/health/JavaDiagnosticsMicroProfileHealthTest.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/health/JavaDiagnosticsMicroProfileHealthTest.java
@@ -78,7 +78,7 @@ public class JavaDiagnosticsMicroProfileHealthTest extends BasePropertiesManager
 	@Test
 	public void HealthAnnotationMissing() throws Exception {
 		IJavaProject javaProject = loadMavenProject(MavenProjectName.microprofile_health_quickstart);
-		IJDTUtils utils = JDTUtilsLSImpl.getInstance();
+		IJDTUtils utils = JDT_UTILS;
 
 		MicroProfileJavaDiagnosticsParams diagnosticsParams = new MicroProfileJavaDiagnosticsParams();
 		IFile javaFile = javaProject.getProject()

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/health/JavaDiagnosticsMicroProfileHealthTest.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/health/JavaDiagnosticsMicroProfileHealthTest.java
@@ -34,7 +34,6 @@ import com.redhat.microprofile.commons.MicroProfileJavaCodeActionParams;
 import com.redhat.microprofile.commons.MicroProfileJavaDiagnosticsParams;
 import com.redhat.microprofile.jdt.core.BasePropertiesManagerTest;
 import com.redhat.microprofile.jdt.core.utils.IJDTUtils;
-import com.redhat.microprofile.jdt.internal.core.ls.JDTUtilsLSImpl;
 import com.redhat.microprofile.jdt.internal.health.MicroProfileHealthConstants;
 import com.redhat.microprofile.jdt.internal.health.java.MicroProfileHealthErrorCode;
 
@@ -49,7 +48,7 @@ public class JavaDiagnosticsMicroProfileHealthTest extends BasePropertiesManager
 	@Test
 	public void ImplementHealthCheck() throws Exception {
 		IJavaProject javaProject = loadMavenProject(MavenProjectName.microprofile_health_quickstart);
-		IJDTUtils utils = JDTUtilsLSImpl.getInstance();
+		IJDTUtils utils = JDT_UTILS;
 
 		MicroProfileJavaDiagnosticsParams diagnosticsParams = new MicroProfileJavaDiagnosticsParams();
 		IFile javaFile = javaProject.getProject()

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/jaxrs/JaxRsCodeLensTest.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/jaxrs/JaxRsCodeLensTest.java
@@ -27,7 +27,6 @@ import com.redhat.microprofile.jdt.core.BasePropertiesManagerTest;
 import com.redhat.microprofile.jdt.core.PropertiesManagerForJava;
 import com.redhat.microprofile.jdt.core.project.JDTMicroProfileProject;
 import com.redhat.microprofile.jdt.core.utils.IJDTUtils;
-import com.redhat.microprofile.jdt.internal.core.ls.JDTUtilsLSImpl;
 
 /**
  * JAX-RS URL Codelens test for Java file.
@@ -40,7 +39,7 @@ public class JaxRsCodeLensTest extends BasePropertiesManagerTest {
 	@Test
 	public void urlCodeLensProperties() throws Exception {
 		IJavaProject javaProject = loadMavenProject(MavenProjectName.hibernate_orm_resteasy);
-		IJDTUtils utils = JDTUtilsLSImpl.getInstance();
+		IJDTUtils utils = JDT_UTILS;
 
 		MicroProfileJavaCodeLensParams params = new MicroProfileJavaCodeLensParams();
 		params.setCheckServerAvailable(false);
@@ -74,7 +73,7 @@ public class JaxRsCodeLensTest extends BasePropertiesManagerTest {
 	@Test
 	public void urlCodeLensYaml() throws Exception {
 		IJavaProject javaProject = loadMavenProject(MavenProjectName.hibernate_orm_resteasy_yaml);
-		IJDTUtils utils = JDTUtilsLSImpl.getInstance();
+		IJDTUtils utils = JDT_UTILS;
 
 		MicroProfileJavaCodeLensParams params = new MicroProfileJavaCodeLensParams();
 		params.setCheckServerAvailable(false);

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/restclient/JavaCodeLensMicroProfileRestClientTest.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/restclient/JavaCodeLensMicroProfileRestClientTest.java
@@ -28,7 +28,6 @@ import com.redhat.microprofile.jdt.core.BasePropertiesManagerTest;
 import com.redhat.microprofile.jdt.core.PropertiesManagerForJava;
 import com.redhat.microprofile.jdt.core.project.JDTMicroProfileProject;
 import com.redhat.microprofile.jdt.core.utils.IJDTUtils;
-import com.redhat.microprofile.jdt.internal.core.ls.JDTUtilsLSImpl;
 
 /**
  * MicroProfile RestClient URL Codelens test for Java file.
@@ -41,7 +40,7 @@ public class JavaCodeLensMicroProfileRestClientTest extends BasePropertiesManage
 	@Test
 	public void urlCodeLensProperties() throws Exception {
 		IJavaProject javaProject = loadMavenProject(MavenProjectName.rest_client_quickstart);
-		IJDTUtils utils = JDTUtilsLSImpl.getInstance();
+		IJDTUtils utils = JDT_UTILS;
 
 		// Initialize file
 		initConfigFile(javaProject);
@@ -80,7 +79,7 @@ public class JavaCodeLensMicroProfileRestClientTest extends BasePropertiesManage
 	@Test
 	public void urlCodeLensPropertiesWithAnnotationBaseUri() throws Exception {
 		IJavaProject javaProject = loadMavenProject(MavenProjectName.rest_client_quickstart);
-		IJDTUtils utils = JDTUtilsLSImpl.getInstance();
+		IJDTUtils utils = JDT_UTILS;
 
 		// Initialize file
 		initConfigFile(javaProject);
@@ -113,7 +112,7 @@ public class JavaCodeLensMicroProfileRestClientTest extends BasePropertiesManage
 	@Test
 	public void urlCodeLensYaml() throws Exception {
 		IJavaProject javaProject = loadMavenProject(MavenProjectName.rest_client_quickstart);
-		IJDTUtils utils = JDTUtilsLSImpl.getInstance();
+		IJDTUtils utils = JDT_UTILS;
 
 		// Initialize file
 		initConfigFile(javaProject);

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/restclient/JavaDiagnosticsMicroProfileRestClientTest.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/restclient/JavaDiagnosticsMicroProfileRestClientTest.java
@@ -26,7 +26,6 @@ import com.redhat.microprofile.commons.DocumentFormat;
 import com.redhat.microprofile.commons.MicroProfileJavaDiagnosticsParams;
 import com.redhat.microprofile.jdt.core.BasePropertiesManagerTest;
 import com.redhat.microprofile.jdt.core.utils.IJDTUtils;
-import com.redhat.microprofile.jdt.internal.core.ls.JDTUtilsLSImpl;
 import com.redhat.microprofile.jdt.internal.restclient.MicroProfileRestClientConstants;
 
 /**
@@ -40,7 +39,7 @@ public class JavaDiagnosticsMicroProfileRestClientTest extends BasePropertiesMan
 	@Test
 	public void restClientDiagnostics() throws Exception {
 		IJavaProject javaProject = loadMavenProject(MavenProjectName.rest_client_quickstart);
-		IJDTUtils utils = JDTUtilsLSImpl.getInstance();
+		IJDTUtils utils = JDT_UTILS;
 
 		MicroProfileJavaDiagnosticsParams params = new MicroProfileJavaDiagnosticsParams();
 		IFile javaFile = javaProject.getProject().getFile(new Path("src/main/java/org/acme/restclient/Fields.java"));

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/internal/core/utils/JDTQuarkusUtilsTest.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/internal/core/utils/JDTQuarkusUtilsTest.java
@@ -9,9 +9,6 @@
 *******************************************************************************/
 package com.redhat.microprofile.jdt.internal.core.utils;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 import com.redhat.microprofile.jdt.core.utils.JDTMicroProfileUtils;
 
 //import com.redhat.microprofile.jdt.internal.quarkus.JDTQuarkusUtils;


### PR DESCRIPTION
- Add Eclipse-ExtensibleAPI to jdt.core so that Eclipse understands it will be extended by test fragment
- Add to remove the jdt.quarkus dependency from the test dependency as it cause cyclic loop in Eclise
- Add jdt.quarkus to the test jdt.test runtime
- Update tests to use static variable

Signed-off-by: Jeff MAURY <jmaury@redhat.com>