### PR TITLE
Have profile completion not overwrite the whole line

### DIFF
--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesCompletionTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesCompletionTest.java
@@ -143,25 +143,49 @@ public class ApplicationPropertiesCompletionTest {
 						+ "The default profile when not running in development or test mode." + System.lineSeparator()), //
 				c("test", "%test", r(0, 0, 1), "test" + System.lineSeparator() + System.lineSeparator()
 						+ "Profile activated when running tests." + System.lineSeparator()));
-
-		value = "%st|aging.";
-		testCompletionFor(value, true, 4, c("staging", "%staging", r(0, 0, 9)), //
-				c("dev", "%dev", r(0, 0, 9),
+		
+		value = "%st|\n" + //
+				"%staging.property=123";
+		testCompletionFor(value, true, 4, c("staging", "%staging", r(0, 0, 3)), //
+				c("dev", "%dev", r(0, 0, 3),
 						"dev" + System.lineSeparator() + System.lineSeparator()
 								+ "Profile activated when in development mode (quarkus:dev)." + System.lineSeparator()), //
-				c("prod", "%prod", r(0, 0, 9), "prod" + System.lineSeparator() + System.lineSeparator()
+				c("prod", "%prod", r(0, 0, 3), "prod" + System.lineSeparator() + System.lineSeparator()
 						+ "The default profile when not running in development or test mode." + System.lineSeparator()), //
-				c("test", "%test", r(0, 0, 9), "test" + System.lineSeparator() + System.lineSeparator()
+				c("test", "%test", r(0, 0, 3), "test" + System.lineSeparator() + System.lineSeparator()
 						+ "Profile activated when running tests." + System.lineSeparator()));
 
 		value = "%staging|.";
-		testCompletionFor(value, true, 4, c("staging", "%staging", r(0, 0, 9)), //
-				c("dev", "%dev", r(0, 0, 9),
+		testCompletionFor(value, true, 3,
+				c("dev", "%dev", r(0, 0, 8),
 						"dev" + System.lineSeparator() + System.lineSeparator()
 								+ "Profile activated when in development mode (quarkus:dev)." + System.lineSeparator()), //
-				c("prod", "%prod", r(0, 0, 9), "prod" + System.lineSeparator() + System.lineSeparator()
+				c("prod", "%prod", r(0, 0, 8), "prod" + System.lineSeparator() + System.lineSeparator()
 						+ "The default profile when not running in development or test mode." + System.lineSeparator()), //
-				c("test", "%test", r(0, 0, 9), "test" + System.lineSeparator() + System.lineSeparator()
+				c("test", "%test", r(0, 0, 8), "test" + System.lineSeparator() + System.lineSeparator()
+						+ "Profile activated when running tests." + System.lineSeparator()));
+	}
+
+	@Test
+	public void completionOnProfileWithPropertyName() throws BadLocationException {
+		String value = "%pr|quarkus.application.name";
+		testCompletionFor(value, true, 3,
+				c("dev", "%dev.", r(0, 0, 3),
+						"dev" + System.lineSeparator() + System.lineSeparator()
+								+ "Profile activated when in development mode (quarkus:dev)." + System.lineSeparator()), //
+				c("prod", "%prod.", r(0, 0, 3), "prod" + System.lineSeparator() + System.lineSeparator()
+						+ "The default profile when not running in development or test mode." + System.lineSeparator()), //
+				c("test", "%test.", r(0, 0, 3), "test" + System.lineSeparator() + System.lineSeparator()
+						+ "Profile activated when running tests." + System.lineSeparator()));
+
+		value = "%d|.quarkus.application.name";
+		testCompletionFor(value, true, 3,
+				c("dev", "%dev", r(0, 0, 2),
+						"dev" + System.lineSeparator() + System.lineSeparator()
+								+ "Profile activated when in development mode (quarkus:dev)." + System.lineSeparator()), //
+				c("prod", "%prod", r(0, 0, 2), "prod" + System.lineSeparator() + System.lineSeparator()
+						+ "The default profile when not running in development or test mode." + System.lineSeparator()), //
+				c("test", "%test", r(0, 0, 2), "test" + System.lineSeparator() + System.lineSeparator()
 						+ "Profile activated when running tests." + System.lineSeparator()));
 	}
 


### PR DESCRIPTION
Fixes #161

With this PR, the profile completion text edits cover everything from the start of the line up to the offset that completion was invoked on, therefore the property key and values (if they exist), become untouched.

Before this PR:
![demo gif 1](https://raw.githubusercontent.com/xorye/gifs/master/new_issues/profile_completion/master1.gif?token=AE3CR5IL3RV27SJSLE6XX6K6QJDGQ)
![demo gif 1](https://raw.githubusercontent.com/xorye/gifs/master/new_issues/profile_completion/master2.gif?token=AE3CR5PLMYL4TCTB6EWZRQK6QJDGU)

After this PR:
![demo gif 3](https://raw.githubusercontent.com/xorye/gifs/master/new_issues/profile_completion/pr1.gif?token=AE3CR5NRVE42VCXZGM3XBNK6QJDJG)
![demo gif 4](https://raw.githubusercontent.com/xorye/gifs/master/new_issues/profile_completion/pr2.gif?token=AE3CR5NVLA52UMVC3R4RT2S6QJDJA)

Signed-off-by: David Kwon <dakwon@redhat.com>