### PR TITLE
Add context to snippets

### DIFF
--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/resources/com/redhat/microprofile/snippets/mp-metrics.json
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/resources/com/redhat/microprofile/snippets/mp-metrics.json
@@ -10,7 +10,10 @@
       "\tdescription = \"${2:description}\"",
       ")"
     ],
-    "description": "An annotation that contains the metadata information when requesting a metric to be injected or produced. This annotation can be used on fields of type Meter, Timer, Counter, and Histogram. For Gauge, the @Metric annotation can only be used on producer methods/fields."
+    "description": "An annotation that contains the metadata information when requesting a metric to be injected or produced. This annotation can be used on fields of type Meter, Timer, Counter, and Histogram. For Gauge, the @Metric annotation can only be used on producer methods/fields.",
+    "context": {
+      "type": "org.eclipse.microprofile.metrics.annotation.Metric"
+    }
   },
   "@Counted": {
     "prefix": [
@@ -22,7 +25,10 @@
       "\tdescription = \"${2:description}\"",
       ")"
     ],
-    "description": "Denotes a counter, which counts the invocations of the annotated object."
+    "description": "Denotes a counter, which counts the invocations of the annotated object.",
+    "context": {
+      "type": "org.eclipse.microprofile.metrics.annotation.Counted"
+    }
   },
   "@Gauge": {
     "prefix": [
@@ -34,7 +40,10 @@
       "\tdescription = \"${2:description}\"",
       ")"
     ],
-    "description": "Denotes a gauge, which samples the value of the annotated object."
+    "description": "Denotes a gauge, which samples the value of the annotated object.",
+    "context": {
+      "type": "org.eclipse.microprofile.metrics.annotation.Gauge"
+    }
   },
   "@ConcurrentGauge": {
     "prefix": [
@@ -46,7 +55,10 @@
       "\tdescription = \"${2:description}\"",
       ")"
     ],
-    "description": "Denotes a gauge which counts the parallel invocations of the annotated object."
+    "description": "Denotes a gauge which counts the parallel invocations of the annotated object.",
+    "context": {
+      "type": "org.eclipse.microprofile.metrics.annotation.ConcurrentGauge"
+    }
   },
   "@Metered": {
     "prefix": [
@@ -58,7 +70,10 @@
       "\tdescription = \"${2:description}\"",
       ")"
     ],
-    "description": "Denotes a meter, which tracks the frequency of invocations of the annotated object."
+    "description": "Denotes a meter, which tracks the frequency of invocations of the annotated object.",
+    "context": {
+      "type": "org.eclipse.microprofile.metrics.annotation.Metered"
+    }
   },
   "@Timed": {
     "prefix": [
@@ -70,7 +85,25 @@
       "\tdescription = \"${2:description}\"",
       ")"
     ],
-    "description": "Denotes a timer, which tracks duration of the annotated object."
+    "description": "Denotes a timer, which tracks duration of the annotated object.",
+    "context": {
+      "type": "org.eclipse.microprofile.metrics.annotation.Timed"
+    }
+  },
+  "@SimplyTimed": {
+    "prefix": [
+      "@SimplyTimed"
+    ],
+    "body": [
+      "@SimplyTimed(",
+      "\tname = \"${1:name}\",",
+      "\tdescription = \"${2:description}\"",
+      ")"
+    ],
+    "description": "Denotes a simple timer, which tracks duration and invocations of the annotated object.",
+    "context": {
+      "type": "org.eclipse.microprofile.metrics.annotation.SimplyTimed"
+    }
   },
   "@RegistryType": {
     "prefix": [
@@ -79,6 +112,9 @@
     "body": [
       "@RegistryType(type=$1)"
     ],
-    "description": "Qualifies the scope of Metric Registry to inject when injecting a MetricRegistry."
+    "description": "Qualifies the scope of Metric Registry to inject when injecting a MetricRegistry.",
+    "context": {
+      "type": "org.eclipse.microprofile.metrics.annotation.RegistryType"
+    }
   }
 }

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/resources/com/redhat/microprofile/snippets/mp-openapi.json
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/resources/com/redhat/microprofile/snippets/mp-openapi.json
@@ -10,7 +10,10 @@
       "\tdescription = \"${2:description}\"",
       ")"
     ],
-    "description": "Describes an operation or typically a HTTP method against a specific path."
+    "description": "Describes an operation or typically a HTTP method against a specific path.",
+    "context": {
+    	"type": "org.eclipse.microprofile.openapi.annotations.Operation"
+    }
   },
   "@Content": {
     "prefix": [
@@ -19,7 +22,10 @@
     "body": [
       "@Content(mediaType = \"${1:text/plain}\")"
     ],
-    "description": "Provides media type"
+    "description": "Provides media type",
+    "context": {
+      "type": "org.eclipse.microprofile.openapi.annotations.Content"
+    }
   },
   "@Content with Schema": {
     "prefix": [
@@ -31,7 +37,10 @@
       "\tschema = $2",
       ")"
     ],
-    "description": "Provides schema and examples for a particular media type."
+    "description": "Provides schema and examples for a particular media type.",
+    "context": {
+      "type": "org.eclipse.microprofile.openapi.annotations.Content"
+    }
   },
   "@Schema with implementation": {
     "prefix": [
@@ -40,7 +49,10 @@
     "body": [
       "@Schema(implementation = $1)"
     ],
-    "description": "Allows the definition of input and output data types."
+    "description": "Allows the definition of input and output data types.",
+    "context": {
+      "type": "org.eclipse.microprofile.openapi.annotations.Schema"
+    }
   },
   "@Schema with type": {
     "prefix": [
@@ -49,7 +61,10 @@
     "body": [
       "@Schema(type = $1)"
     ],
-    "description": "Allows the definition of input and output data types."
+    "description": "Allows the definition of input and output data types.",
+    "context": {
+      "type": "org.eclipse.microprofile.openapi.annotations.Schema"
+    }
   },
   "@Schema with implementation and type": {
     "prefix": [
@@ -61,7 +76,10 @@
       "\ttype = $2",
       ")"
     ],
-    "description": "Allows the definition of input and output data types."
+    "description": "Allows the definition of input and output data types.",
+    "context": {
+      "type": "org.eclipse.microprofile.openapi.annotations.Schema"
+    }
   },
   "@Parameters": {
     "prefix": [
@@ -73,7 +91,10 @@
       "\t}",
       ")"
     ],
-    "description": "Encapsulates input parameters."
+    "description": "Encapsulates input parameters.",
+    "context": {
+      "type": "org.eclipse.microprofile.openapi.annotations.Parameters"
+    }
   },
   "@Parameter": {
     "prefix": [
@@ -87,7 +108,10 @@
       "\tschema = $4",
       ")"
     ],
-    "description": "Describes a single operation parameter."
+    "description": "Describes a single operation parameter.",
+    "context": {
+      "type": "org.eclipse.microprofile.openapi.annotations.Parameter"
+    }
   },
   "@APIResponses": {
     "prefix": [
@@ -99,7 +123,10 @@
       "\t}",
       ")"
     ],
-    "description": "A container for multiple responses from an API operation."
+    "description": "A container for multiple responses from an API operation.",
+    "context": {
+      "type": "org.eclipse.microprofile.openapi.annotations.APIResponses"
+    }
   },
   "@APIResponse": {
     "prefix": [
@@ -113,6 +140,9 @@
       "\tschema = $4",
       ")"
     ],
-    "description": "Describes a single response from an API operation."
+    "description": "Describes a single response from an API operation.",
+    "context": {
+      "type": "org.eclipse.microprofile.openapi.annotations.APIResponse"
+    }
   }
 }


### PR DESCRIPTION
Part of redhat-developer#265

Adds context `type` to be used when deciding if an annotation should be displayed