### PR TITLE
Properties support for @ConfigProperty on method parameters

### DIFF
--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/AbstractPropertiesProvider.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/AbstractPropertiesProvider.java
@@ -103,11 +103,11 @@ public abstract class AbstractPropertiesProvider implements IPropertiesProvider 
 	 * @param sourceType    the source type (class or interface) of the property.
 	 * @param sourceField   the source field (field name) and null otherwise.
 	 * @param sourceMethod  the source method (signature method) and null otherwise.
-	 * @param defaultValue  the default vaue and null otherwise.
+	 * @param defaultValue  the default value and null otherwise.
 	 * @param extensionName the extension name and null otherwise.
 	 * @param binary        true if the property comes from a JAR and false
 	 *                      otherwise.
-	 * @param phase         teh Quarkus config phase.
+	 * @param phase         the Quarkus config phase.
 	 * @return the item metadata.
 	 */
 	protected ItemMetadata addItemMetadata(IPropertiesCollector collector, String name, String type, String description,
@@ -127,7 +127,7 @@ public abstract class AbstractPropertiesProvider implements IPropertiesProvider 
 	 * @param sourceType    the source type (class or interface) of the property.
 	 * @param sourceField   the source field (field name) and null otherwise.
 	 * @param sourceMethod  the source method (signature method) and null otherwise.
-	 * @param defaultValue  the default vaue and null otherwise.
+	 * @param defaultValue  the default value and null otherwise.
 	 * @param extensionName the extension name and null otherwise.
 	 * @param binary        true if the property comes from a JAR and false
 	 *                      otherwise.

--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/PropertiesManager.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/PropertiesManager.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
@@ -509,10 +510,13 @@ public class PropertiesManager {
 				// Method signature has been generated with JDT API, so we are sure that we have
 				// a ')' character.
 				int endBracketIndex = sourceMethod.indexOf(')');
-				String methodSignature = sourceMethod.substring(startBracketIndex + 1, endBracketIndex);
+				String methodSignature = sourceMethod.substring(startBracketIndex, endBracketIndex + 1);
 				String[] paramTypes = methodSignature.isEmpty() ? CharOperation.NO_STRINGS
 						: Signature.getParameterTypes(methodSignature);
-				return JavaModelUtil.findMethod(methodName, paramTypes, false, type);
+				
+				// try findMethod for non constructor. If result is null, findMethod for constructor
+				IMethod method = JavaModelUtil.findMethod(methodName, paramTypes, false, type);
+				return method != null ? method : JavaModelUtil.findMethod(methodName, paramTypes, true, type);
 			}
 			return type;
 		} finally {

--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/utils/JDTTypeUtils.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/utils/JDTTypeUtils.java
@@ -14,7 +14,9 @@ import java.util.List;
 
 import org.eclipse.jdt.core.IField;
 import org.eclipse.jdt.core.IJarEntryResource;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.ILocalVariable;
 import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IMemberValuePair;
 import org.eclipse.jdt.core.IMethod;
@@ -42,6 +44,51 @@ public class JDTTypeUtils {
 		}
 	}
 
+	/**
+	 * Returns the resolved type name of the
+	 * <code>javaElement</code> and null otherwise
+	 * 
+	 * @param javaElement the Java element
+	 * @return the resolved type name of the
+	 * <code>javaElement</code> and null otherwise
+	 */
+	public static String getResolvedTypeName(IJavaElement javaElement) {
+		switch (javaElement.getElementType()) {
+		case IJavaElement.LOCAL_VARIABLE:
+			return getResolvedTypeName((ILocalVariable) javaElement);
+		case IJavaElement.FIELD:
+			return getResolvedTypeName((IField) javaElement);
+		default:
+			return null;
+		}
+	}
+
+	/**
+	 * Returns the resolved type name of the given
+	 * <code>localVar</code> and null otherwise
+	 * 
+	 * @param localVar the local variable
+	 * @return the resolved type name of the given
+	 * <code>localVar</code> and null otherwise
+	 */
+	public static String getResolvedTypeName(ILocalVariable localVar) {
+		try {
+			String signature = localVar.getTypeSignature().replace("/", ".");
+			IType primaryType = localVar.getTypeRoot().findPrimaryType();
+			return JavaModelUtil.getResolvedTypeName(signature, primaryType);
+		} catch (JavaModelException e) {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns the resolved type name of the
+	 * given <code>field</code> and null otherwise
+	 * 
+	 * @param field the field
+	 * @return the resolved type name of the
+	 * given <code>field</code> and null otherwise
+	 */
 	public static String getResolvedTypeName(IField field) {
 		try {
 			String signature = field.getTypeSignature();
@@ -52,6 +99,14 @@ public class JDTTypeUtils {
 		}
 	}
 
+	/**
+	 * Returns the resolved return type name of the
+	 * given <code>method</code> and null otherwise
+	 * 
+	 * @param method the method
+	 * @return the resolved return type name of the
+	 * given <code>method</code> and null otherwise
+	 */
 	public static String getResolvedResultTypeName(IMethod method) {
 		try {
 			String signature = method.getReturnType();
@@ -97,11 +152,74 @@ public class JDTTypeUtils {
 		return type != null ? type.getFullyQualifiedName('.') : typeName;
 	}
 
+	/**
+	 * Returns true if the given <code>javaElement</code>
+	 * is from a Java binary, and false otherwise
+	 * 
+	 * @param javaElement the Java element
+	 * @return true if the given <code>javaElement</code>
+	 * is from a Java binary, and false otherwise
+	 */
+	public static boolean isBinary(IJavaElement javaElement) {
+		if (javaElement instanceof IMember) {
+			return ((IMember) javaElement).isBinary();
+		} else if (javaElement instanceof ILocalVariable) {
+			return isBinary(((ILocalVariable) javaElement).getDeclaringMember());
+		}
+		return false;
+	}
+
+	/**
+	 * Returns the source type of the given
+	 * <code>javaElement</code> and null otherwise
+	 * 
+	 * @param javaElement the Java element
+	 * @return the source type of the <code>javaElement</code>
+	 */
+	public static String getSourceType(IJavaElement javaElement) {
+		switch (javaElement.getElementType()) {
+		case IJavaElement.LOCAL_VARIABLE:
+			return getSourceType((ILocalVariable) javaElement);
+		case IJavaElement.FIELD:
+			return getSourceType((IField) javaElement);
+		case IJavaElement.METHOD:
+			return getSourceType((IMethod) javaElement);
+		default:
+			return null;
+		}
+	}
+
+	/**
+	 * Returns the source type of the given local
+	 * variable <code>member</code> and null otherwise
+	 * 
+	 * @param member the local variable to get the source type from
+	 * @return the source type of the given local
+	 * variable <code>member</code> and null otherwise
+	 */
+	public static String getSourceType(ILocalVariable member) {
+		return getSourceType(member.getDeclaringMember());
+	}
+
+	/**
+	 * Returns the source type of the given <code>member</code>
+	 * and null otherwise
+	 * 
+	 * @param member the member
+	 * @return the source type of the given <code>member</code>
+	 * and null otherwise
+	 */
 	public static String getSourceType(IMember member) {
 		return getPropertyType(member.getDeclaringType(), null);
 	}
 
-	public static String getSourceField(IField field) {
+	/**
+	 * Returns the source field of the given <code>field</code>
+	 * 
+	 * @param field the field
+	 * @return the source field of the given <code>field</code>
+	 */
+	public static String getSourceField(IJavaElement field) {
 		return field.getElementName();
 	}
 

--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/config/properties/MicroProfileConfigPropertyProvider.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/config/properties/MicroProfileConfigPropertyProvider.java
@@ -18,11 +18,15 @@ import static com.redhat.microprofile.jdt.core.utils.JDTTypeUtils.getPropertyTyp
 import static com.redhat.microprofile.jdt.core.utils.JDTTypeUtils.getResolvedTypeName;
 import static com.redhat.microprofile.jdt.core.utils.JDTTypeUtils.getSourceField;
 import static com.redhat.microprofile.jdt.core.utils.JDTTypeUtils.getSourceType;
+import static com.redhat.microprofile.jdt.core.utils.JDTTypeUtils.getSourceMethod;
+import static com.redhat.microprofile.jdt.core.utils.JDTTypeUtils.isBinary;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IAnnotation;
-import org.eclipse.jdt.core.IField;
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.ILocalVariable;
+import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 
@@ -51,29 +55,40 @@ public class MicroProfileConfigPropertyProvider extends AbstractAnnotationTypeRe
 	@Override
 	protected void processAnnotation(IJavaElement javaElement, IAnnotation configPropertyAnnotation,
 			String annotationName, SearchContext context, IProgressMonitor monitor) throws JavaModelException {
-		if (javaElement.getElementType() == IJavaElement.FIELD) {
+		if (javaElement.getElementType() == IJavaElement.FIELD
+				|| javaElement.getElementType() == IJavaElement.LOCAL_VARIABLE) {
 			IPropertiesCollector collector = context.getCollector();
 			String name = getAnnotationMemberValue(configPropertyAnnotation,
 					MicroProfileConfigConstants.CONFIG_PROPERTY_ANNOTATION_NAME);
 			if (name != null && !name.isEmpty()) {
-				IField field = (IField) javaElement;
-				String fieldTypeName = getResolvedTypeName(field);
-				IType fieldClass = findType(field.getJavaProject(), fieldTypeName);
-
-				String type = getPropertyType(fieldClass, fieldTypeName);
+				IJavaProject javaProject = javaElement.getJavaProject();
+				String varTypeName = getResolvedTypeName(javaElement);
+				IType varType = findType(javaProject, varTypeName);
+				String type = getPropertyType(varType, varTypeName);
 				String description = null;
-				String sourceType = getSourceType(field);
-				String sourceField = getSourceField(field);
+				String sourceType = getSourceType(javaElement);
+				String sourceField = null;
+				String sourceMethod = null;
+				
 				String defaultValue = getAnnotationMemberValue(configPropertyAnnotation,
 						MicroProfileConfigConstants.CONFIG_PROPERTY_ANNOTATION_DEFAULT_VALUE);
 				String extensionName = null;
+				
+				if (javaElement.getElementType() == IJavaElement.FIELD) {
+					sourceField = getSourceField(javaElement);
+				} else if (javaElement.getElementType() == IJavaElement.LOCAL_VARIABLE) {
+					ILocalVariable localVariable = (ILocalVariable) javaElement;
+					IMethod method = (IMethod) localVariable.getDeclaringMember();
+					sourceMethod = getSourceMethod(method);
+				}
 
 				// Enumerations
-				IType enclosedType = getEnclosedType(fieldClass, type, field.getJavaProject());
+				IType enclosedType = getEnclosedType(varType, type, javaProject);
 				super.updateHint(collector, enclosedType);
 
-				addItemMetadata(collector, name, type, description, sourceType, sourceField, null, defaultValue,
-						extensionName, field.isBinary());
+				boolean binary = isBinary(javaElement);
+				addItemMetadata(collector, name, type, description, sourceType, sourceField, sourceMethod, defaultValue,
+						extensionName, binary);
 			}
 		}
 	}

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/projects/maven/config-quickstart/.classpath
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/projects/maven/config-quickstart/.classpath
@@ -44,11 +44,11 @@
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
 		<attributes>
-			<attribute name="ignore_optional_problems" value="true"/>
-			<attribute name="test" value="true"/>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
 			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/projects/maven/config-quickstart/src/main/java/org/acme/config/GreetingConstructorResource.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/projects/maven/config-quickstart/src/main/java/org/acme/config/GreetingConstructorResource.java
@@ -1,0 +1,38 @@
+package org.acme.config;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("/greeting/constructor")
+public class GreetingConstructorResource {
+  
+    String message;
+   
+    String suffix;
+
+    Optional<String> name;
+
+    @Inject
+    public GreetingConstructorResource(
+            @ConfigProperty(name = "greeting.constructor.message") String message,
+            @ConfigProperty(name = "greeting.constructor.suffix" , defaultValue="!") String suffix,
+            @ConfigProperty(name = "greeting.constructor.name") Optional<String> name) {
+
+        this.message = message;
+        this.suffix = suffix;
+        this.name = name;
+    } 
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return message + " " + name.orElse("world") + suffix;
+    }
+}

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/projects/maven/config-quickstart/src/main/java/org/acme/config/GreetingMethodResource.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/projects/maven/config-quickstart/src/main/java/org/acme/config/GreetingMethodResource.java
@@ -1,0 +1,42 @@
+package org.acme.config;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("/greeting/method") 
+public class GreetingMethodResource {
+  
+    String message;
+   
+    String suffix;
+
+    Optional<String> name;
+
+    @Inject
+    public void setMessage(@ConfigProperty(name = "greeting.method.message") String message) {
+        this.message = message;
+    }
+
+    @Inject
+    public void setSuffix(@ConfigProperty(name = "greeting.method.suffix" , defaultValue="!") String suffix) {
+        this.suffix = suffix;
+    }
+
+    @Inject
+    public void setName(@ConfigProperty(name = "greeting.method.name") Optional<String> name) {
+        this.name = name;
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return message + " " + name.orElse("world") + suffix;
+    }
+}

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/ConfigItemIntBoolDefaultValueTest.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/ConfigItemIntBoolDefaultValueTest.java
@@ -31,7 +31,7 @@ public class ConfigItemIntBoolDefaultValueTest extends BasePropertiesManagerTest
 		String intDefault = "0";
 
 		assertProperties(infoFromClasspath, 185 /* properties from JAR */ + //
-				3 /* properties from Java sources with ConfigProperty */ + //
+				9 /* properties from Java sources with ConfigProperty */ + //
 				2 /* properties from Java sources with ConfigRoot */,
 				
 				// @ConfigItem(name = ConfigItem.PARENT)
@@ -144,7 +144,33 @@ public class ConfigItemIntBoolDefaultValueTest extends BasePropertiesManagerTest
 				// public boolean clustered;
 				p("quarkus-vertx-core", "quarkus.vertx.cluster.clustered", "boolean",
 						"Enables or disables the clustering.", true,
-						"io.quarkus.vertx.core.runtime.config.ClusterConfiguration", "clustered", null, CONFIG_PHASE_RUN_TIME, booleanDefault));
+						"io.quarkus.vertx.core.runtime.config.ClusterConfiguration", "clustered", null, CONFIG_PHASE_RUN_TIME, booleanDefault),
+	
+				// GreetingConstructorResource(
+				// 		@ConfigProperty(name = "greeting.constructor.message") String message,
+				//		@ConfigProperty(name = "greeting.constructor.suffix" , defaultValue="!") String suffix,
+				//		@ConfigProperty(name = "greeting.constructor.name") Optional<String> name)
+				p(null, "greeting.constructor.message", "java.lang.String", null, false, "org.acme.config.GreetingConstructorResource",
+						null, "GreetingConstructorResource(QString;QString;QOptional<QString;>;)V", 0, null),
+
+				p(null, "greeting.constructor.suffix", "java.lang.String", null, false, "org.acme.config.GreetingConstructorResource",
+						null, "GreetingConstructorResource(QString;QString;QOptional<QString;>;)V", 0, "!"),
+
+				p(null, "greeting.constructor.name", "java.util.Optional", null, false, "org.acme.config.GreetingConstructorResource",
+						null, "GreetingConstructorResource(QString;QString;QOptional<QString;>;)V", 0, null),
+
+				// setMessage(@ConfigProperty(name = "greeting.method.message") String message)
+				p(null, "greeting.method.message", "java.lang.String", null, false, "org.acme.config.GreetingMethodResource",
+						null, "setMessage(QString;)V", 0, null),
+
+				// setSuffix(@ConfigProperty(name = "greeting.method.suffix" , defaultValue="!") String suffix)
+				p(null, "greeting.method.suffix", "java.lang.String", null, false, "org.acme.config.GreetingMethodResource",
+						null, "setSuffix(QString;)V", 0, "!"),
+
+				// setName(@ConfigProperty(name = "greeting.method.name") Optional<String> name)
+				p(null, "greeting.method.name", "java.util.Optional", null, false, "org.acme.config.GreetingMethodResource",
+						null, "setName(QOptional<QString;>;)V", 0, null)
+				);
 
 		assertPropertiesDuplicate(infoFromClasspath);
 	}

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/MicroProfileConfigPropertyTest.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/MicroProfileConfigPropertyTest.java
@@ -35,7 +35,6 @@ public class MicroProfileConfigPropertyTest extends BasePropertiesManagerTest {
 	@Test
 	public void configQuickstartFromClasspath() throws Exception {
 
-		//
 		MicroProfileProjectInfo infoFromClasspath = getMicroProfileProjectInfoFromMavenProject(
 				MavenProjectName.config_quickstart, MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES);
 
@@ -44,7 +43,7 @@ public class MicroProfileConfigPropertyTest extends BasePropertiesManagerTest {
 		Assert.assertNotNull("Test existing of quarkus-core-deployment*.jar", f);
 
 		assertProperties(infoFromClasspath, 185 /* properties from JAR */ + //
-				3 /* properties from Java sources with ConfigProperty */ + //
+				9 /* properties from Java sources with ConfigProperty */ + //
 				2 /* properties from Java sources with ConfigRoot */,
 
 				// io.quarkus.deployment.ApplicationConfig
@@ -72,6 +71,31 @@ public class MicroProfileConfigPropertyTest extends BasePropertiesManagerTest {
 				p(null, "greeting.name", "java.util.Optional", null, false, "org.acme.config.GreetingResource", "name",
 						null, 0, null),
 
+				// GreetingConstructorResource(
+				// 		@ConfigProperty(name = "greeting.constructor.message") String message,
+				//		@ConfigProperty(name = "greeting.constructor.suffix" , defaultValue="!") String suffix,
+				//		@ConfigProperty(name = "greeting.constructor.name") Optional<String> name)
+				p(null, "greeting.constructor.message", "java.lang.String", null, false, "org.acme.config.GreetingConstructorResource",
+						null, "GreetingConstructorResource(QString;QString;QOptional<QString;>;)V", 0, null),
+
+				p(null, "greeting.constructor.suffix", "java.lang.String", null, false, "org.acme.config.GreetingConstructorResource",
+						null, "GreetingConstructorResource(QString;QString;QOptional<QString;>;)V", 0, "!"),
+
+				p(null, "greeting.constructor.name", "java.util.Optional", null, false, "org.acme.config.GreetingConstructorResource",
+						null, "GreetingConstructorResource(QString;QString;QOptional<QString;>;)V", 0, null),
+
+				// setMessage(@ConfigProperty(name = "greeting.method.message") String message)
+				p(null, "greeting.method.message", "java.lang.String", null, false, "org.acme.config.GreetingMethodResource",
+						null, "setMessage(QString;)V", 0, null),
+
+				// setSuffix(@ConfigProperty(name = "greeting.method.suffix" , defaultValue="!") String suffix)
+				p(null, "greeting.method.suffix", "java.lang.String", null, false, "org.acme.config.GreetingMethodResource",
+						null, "setSuffix(QString;)V", 0, "!"),
+
+				// setName(@ConfigProperty(name = "greeting.method.name") Optional<String> name)
+				p(null, "greeting.method.name", "java.util.Optional", null, false, "org.acme.config.GreetingMethodResource",
+						null, "setName(QOptional<QString;>;)V", 0, null),
+
 				// @ConfigRoot / CustomExtensionConfig / property1
 				p(null, "quarkus.custom-extension.property1", "java.lang.String", null, false,
 						"org.acme.config.CustomExtensionConfig", "property1", null, CONFIG_PHASE_BUILD_TIME, null),
@@ -89,7 +113,7 @@ public class MicroProfileConfigPropertyTest extends BasePropertiesManagerTest {
 		MicroProfileProjectInfo infoFromJavaSources = getMicroProfileProjectInfoFromMavenProject(
 				MavenProjectName.config_quickstart, MicroProfilePropertiesScope.ONLY_SOURCES);
 
-		assertProperties(infoFromJavaSources, 3 /* properties from Java sources with ConfigProperty */ + //
+		assertProperties(infoFromJavaSources, 9 /* properties from Java sources with ConfigProperty */ + //
 				2 /* properties from Java sources with ConfigRoot */,
 
 				// GreetingResource
@@ -107,6 +131,31 @@ public class MicroProfileConfigPropertyTest extends BasePropertiesManagerTest {
 				// Optional<String> name;
 				p(null, "greeting.name", "java.util.Optional", null, false, "org.acme.config.GreetingResource", "name",
 						null, 0, null),
+
+				// GreetingConstructorResource(
+				// 		@ConfigProperty(name = "greeting.constructor.message") String message,
+				//		@ConfigProperty(name = "greeting.constructor.suffix" , defaultValue="!") String suffix,
+				//		@ConfigProperty(name = "greeting.constructor.name") Optional<String> name)
+				p(null, "greeting.constructor.message", "java.lang.String", null, false, "org.acme.config.GreetingConstructorResource",
+						null, "GreetingConstructorResource(QString;QString;QOptional<QString;>;)V", 0, null),
+
+				p(null, "greeting.constructor.suffix", "java.lang.String", null, false, "org.acme.config.GreetingConstructorResource",
+						null, "GreetingConstructorResource(QString;QString;QOptional<QString;>;)V", 0, "!"),
+
+				p(null, "greeting.constructor.name", "java.util.Optional", null, false, "org.acme.config.GreetingConstructorResource",
+						null, "GreetingConstructorResource(QString;QString;QOptional<QString;>;)V", 0, null),
+
+				// setMessage(@ConfigProperty(name = "greeting.method.message") String message)
+				p(null, "greeting.method.message", "java.lang.String", null, false, "org.acme.config.GreetingMethodResource",
+						null, "setMessage(QString;)V", 0, null),
+				
+				// setSuffix(@ConfigProperty(name = "greeting.method.suffix" , defaultValue="!") String suffix)
+				p(null, "greeting.method.suffix", "java.lang.String", null, false, "org.acme.config.GreetingMethodResource",
+						null, "setSuffix(QString;)V", 0, "!"),
+
+				// setName(@ConfigProperty(name = "greeting.method.name") Optional<String> name)
+				p(null, "greeting.method.name", "java.util.Optional", null, false, "org.acme.config.GreetingMethodResource",
+						null, "setName(QOptional<QString;>;)V", 0, null),
 
 				// @ConfigRoot / CustomExtensionConfig / property1
 				p(null, "quarkus.custom-extension.property1", "java.lang.String", null, false,

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/PropertiesManagerLocationTest.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/PropertiesManagerLocationTest.java
@@ -12,13 +12,19 @@ package com.redhat.microprofile.jdt.core;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.Location;
 import org.junit.Assert;
 import org.junit.Test;
+
+import com.redhat.microprofile.jdt.core.utils.IJDTUtils;
 
 /**
  * Test with find MicroProfile definition.
@@ -68,9 +74,43 @@ public class PropertiesManagerLocationTest extends BasePropertiesManagerTest {
 		Location location = PropertiesManager.getInstance().findPropertyLocation(javaProject,
 				"org.acme.config.IGreetingConfiguration", null, "getName()QOptional<QString;>;",
 				JDT_UTILS, new NullProgressMonitor());
+		
 		Assert.assertNotNull("Definition from IGreetingConfiguration#getName() method", location);
 	}
+	
+	@Test
+	public void configPropertiesMethodTest() throws Exception {
+		// Enable classFileContentsSupport to generate jdt Location
+		enableClassFileContentsSupport();
 
+		IJavaProject javaProject = loadMavenProject(MavenProjectName.config_quickstart);
+
+		// Test with method with parameters
+		// greeting.constructor.message
+		Location location = PropertiesManager.getInstance().findPropertyLocation(javaProject,
+				"org.acme.config.GreetingMethodResource", null, "setMessage(QString;)V",
+				JDT_UTILS, new NullProgressMonitor());
+		
+		Assert.assertNotNull("Definition from GreetingMethodResource#setMessage() method", location);
+	}
+	
+	@Test
+	public void configPropertiesConstructorTest() throws Exception {
+		// Enable classFileContentsSupport to generate jdt Location
+		enableClassFileContentsSupport();
+
+		IJavaProject javaProject = loadMavenProject(MavenProjectName.config_quickstart);
+
+		// Test with constructor with parameters
+		// greeting.constructor.message
+		Location location = PropertiesManager.getInstance().findPropertyLocation(javaProject,
+				"org.acme.config.GreetingConstructorResource", null,
+				"GreetingConstructorResource(QString;QString;QOptional<QString;>;)V",
+				JDT_UTILS, new NullProgressMonitor());
+		
+		Assert.assertNotNull("Definition from GreetingConstructorResource constructor", location);
+	}
+	
 	private static void enableClassFileContentsSupport() {
 		Map<String, Object> extendedClientCapabilities = new HashMap<>();
 		extendedClientCapabilities.put("classFileContentsSupport", "true");


### PR DESCRIPTION
Fixes #135 

To test this PR, please use the `config-quickstart` test project. In that project, there will be ConfigProperty properties coming from constructor parameters and regular method (non-constructor) parameters.

Demo:
![demo](https://raw.githubusercontent.com/xorye/gifs/master/quarkus-ls/PR/%23135/demo.gif?token=AE3CR5JKTGRHOQE4YYH6RS26RN4FI)