### PR TITLE
Allow exclude unknown property pattern * to match forward slashes

### DIFF
--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/utils/AntPathMatcher.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/utils/AntPathMatcher.java
@@ -216,7 +216,7 @@ public class AntPathMatcher implements PathMatcher {
 	 * as far as the given base path goes is sufficient)
 	 * @return {@code true} if the supplied {@code path} matched, {@code false} if it didn't
 	 */
-	protected boolean doMatch(String pattern,  String path, boolean fullMatch,
+	protected boolean doMatch(String pattern, String path, boolean fullMatch,
 			 Map<String, String> uriTemplateVariables) {
 
 		if (path == null || path.startsWith(this.pathSeparator) != pattern.startsWith(this.pathSeparator)) {
@@ -228,7 +228,17 @@ public class AntPathMatcher implements PathMatcher {
 			return false;
 		}
 
-		String[] pathDirs = tokenizePath(path);
+		String[] pathDirs = null;
+		if (pattern.indexOf("/") > -1) {
+			// if pattern includes '/', this means that the
+			// path string should be tokenized with this.pathSeparator = "/"
+			pathDirs = tokenizePath(path);
+		} else {
+			// else, assume that '/' in the path string is not being
+			// treated differently than any other character.
+			// As a result, the path string is considered one single entity.
+			pathDirs = new String[] {path};
+		}
 		int pattIdxStart = 0;
 		int pattIdxEnd = pattDirs.length - 1;
 		int pathIdxStart = 0;
@@ -266,8 +276,11 @@ public class AntPathMatcher implements PathMatcher {
 			return true;
 		}
 		else if (pattIdxStart > pattIdxEnd) {
-			// String not exhausted, but pattern is. Failure.
-			return false;
+			// Path not exhausted, but pattern is.
+
+			// If the pattern's last character is a wildcard (*),
+			// match the whole remaining path.
+			return pattern.charAt(pattern.length() - 1) == '*';
 		}
 		else if (!fullMatch && "**".equals(pattDirs[pattIdxStart])) {
 			// Path start definitely matches due to "**" part in pattern.

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesDiagnosticsTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesDiagnosticsTest.java
@@ -138,7 +138,8 @@ public class ApplicationPropertiesDiagnosticsTest {
 	@Test
 	public void validateUnknownPropertiesExcludedWithPattern() throws BadLocationException {
 		String value = "com.mycompany.remoteServices.MyServiceClient/mp-rest/url=url\n" + //
-				"com.mycompany.remoteServices.MyServiceClient/mp-rest/uri=uri";
+				"com.mycompany.remoteServices.MyServiceClient/mp-rest/uri=uri\n" + //
+				"com.mycompany.foo=bar";
 
 		MicroProfileValidationSettings settings = new MicroProfileValidationSettings();
 		MicroProfileValidationTypeSettings unknown = new MicroProfileValidationTypeSettings();
@@ -148,14 +149,86 @@ public class ApplicationPropertiesDiagnosticsTest {
 		// */mp-rest/url pattern --> only
 		// com.mycompany.remoteServices.MyServiceClient/mp-rest/url is ignored
 		unknown.setExcluded(new String[] { "*/mp-rest/url" });
-		testDiagnosticsFor(value, 1, getDefaultMicroProfileProjectInfo(), settings,
+		testDiagnosticsFor(value, 2, getDefaultMicroProfileProjectInfo(), settings,
 				d(1, 0, 56, "Unknown property 'com.mycompany.remoteServices.MyServiceClient/mp-rest/uri'",
+						DiagnosticSeverity.Error, ValidationType.unknown),
+				d(2, 0, 17, "Unknown property 'com.mycompany.foo'",
 						DiagnosticSeverity.Error, ValidationType.unknown));
 
-		// */mp-rest/* pattern --> all errors are ignored
+		// */mp-rest/* pattern --> all errors containing path 'mp-rest' are ignored
 		unknown.setExcluded(new String[] { "*/mp-rest/*" });
+		testDiagnosticsFor(value, 1, getDefaultMicroProfileProjectInfo(), settings,
+				d(2, 0, 17, "Unknown property 'com.mycompany.foo'",
+						DiagnosticSeverity.Error, ValidationType.unknown));
+
+		value = "com.mycompany.remoteServices.MyServiceClient/mp-rest/url/foo=url\n" + //
+				"com.mycompany.remoteServices.MyServiceClient/mp-rest/uri/bar=uri\n" + //
+				"com.mycompany.remoteServices.MyOtherClient/mp-rest/url/foo=url\n" + //
+				"com.mycompany.remoteServices.MyOtherClient/mp-rest/uri/bar=uri\n" + //
+				"com.mycompany.foo=bar";
+
+		// com.mycompany.* pattern --> all errors are ignored
+		unknown.setExcluded(new String[] { "com.mycompany.*" });
 		testDiagnosticsFor(value, 0, getDefaultMicroProfileProjectInfo(), settings);
 
+		// com.mycompany.remoteServices.MyServiceClient/**/ --> all 'MyServiceClient' errors are ignored
+		unknown.setExcluded(new String[] { "com.mycompany.remoteServices.MyServiceClient/**/" });
+		testDiagnosticsFor(value, 3, getDefaultMicroProfileProjectInfo(), settings,
+				d(2, 0, 58, "Unknown property 'com.mycompany.remoteServices.MyOtherClient/mp-rest/url/foo'",
+						DiagnosticSeverity.Error, ValidationType.unknown),
+				d(3, 0, 58, "Unknown property 'com.mycompany.remoteServices.MyOtherClient/mp-rest/uri/bar'",
+						DiagnosticSeverity.Error, ValidationType.unknown),
+				d(4, 0, 17, "Unknown property 'com.mycompany.foo'",
+						DiagnosticSeverity.Error, ValidationType.unknown));
+		
+		// com.mycompany.remoteServices.MyServiceClient/**/foo --> all errors
+		// for 'MyServiceClient' properties ending with path 'foo' are ignored
+		unknown.setExcluded(new String[] { "com.mycompany.remoteServices.MyServiceClient/**/foo" });
+		testDiagnosticsFor(value, 4, getDefaultMicroProfileProjectInfo(), settings,
+				d(1, 0, 60, "Unknown property 'com.mycompany.remoteServices.MyServiceClient/mp-rest/uri/bar'",
+						DiagnosticSeverity.Error, ValidationType.unknown),
+				d(2, 0, 58, "Unknown property 'com.mycompany.remoteServices.MyOtherClient/mp-rest/url/foo'",
+						DiagnosticSeverity.Error, ValidationType.unknown),
+				d(3, 0, 58, "Unknown property 'com.mycompany.remoteServices.MyOtherClient/mp-rest/uri/bar'",
+						DiagnosticSeverity.Error, ValidationType.unknown),
+				d(4, 0, 17, "Unknown property 'com.mycompany.foo'",
+						DiagnosticSeverity.Error, ValidationType.unknown));
+
+		// com.mycompany.*/**/foo --> all errors for properties
+		// ending with path 'foo' are ignored
+		unknown.setExcluded(new String[] { "com.mycompany.*/**/foo" });
+		testDiagnosticsFor(value, 3, getDefaultMicroProfileProjectInfo(), settings,
+				d(1, 0, 60, "Unknown property 'com.mycompany.remoteServices.MyServiceClient/mp-rest/uri/bar'",
+						DiagnosticSeverity.Error, ValidationType.unknown),
+				d(3, 0, 58, "Unknown property 'com.mycompany.remoteServices.MyOtherClient/mp-rest/uri/bar'",
+						DiagnosticSeverity.Error, ValidationType.unknown),
+				d(4, 0, 17, "Unknown property 'com.mycompany.foo'",
+						DiagnosticSeverity.Error, ValidationType.unknown));
+
+		// com*MyService*/**/foo --> all errors for 'MyService' properties
+		// ending with path 'foo' are ignored
+		unknown.setExcluded(new String[] { "com*MyService*/**/foo" });
+		testDiagnosticsFor(value, 4, getDefaultMicroProfileProjectInfo(), settings,
+				d(1, 0, 60, "Unknown property 'com.mycompany.remoteServices.MyServiceClient/mp-rest/uri/bar'",
+						DiagnosticSeverity.Error, ValidationType.unknown),
+				d(2, 0, 58, "Unknown property 'com.mycompany.remoteServices.MyOtherClient/mp-rest/url/foo'",
+						DiagnosticSeverity.Error, ValidationType.unknown),
+				d(3, 0, 58, "Unknown property 'com.mycompany.remoteServices.MyOtherClient/mp-rest/uri/bar'",
+						DiagnosticSeverity.Error, ValidationType.unknown),
+				d(4, 0, 17, "Unknown property 'com.mycompany.foo'",
+						DiagnosticSeverity.Error, ValidationType.unknown));
+
+		// *foo --> all errors ending with 'foo' are ignored
+		unknown.setExcluded(new String[] { "*foo" });
+		testDiagnosticsFor(value, 2, getDefaultMicroProfileProjectInfo(), settings,
+				d(1, 0, 60, "Unknown property 'com.mycompany.remoteServices.MyServiceClient/mp-rest/uri/bar'",
+						DiagnosticSeverity.Error, ValidationType.unknown),
+				d(3, 0, 58, "Unknown property 'com.mycompany.remoteServices.MyOtherClient/mp-rest/uri/bar'",
+						DiagnosticSeverity.Error, ValidationType.unknown));
+
+		// * pattern --> all errors are ignored
+		unknown.setExcluded(new String[] { "*" });
+		testDiagnosticsFor(value, 0, getDefaultMicroProfileProjectInfo(), settings);
 	};
 
 	@Test


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-quarkus/issues/237 by allowing a pattern terminating with `*` to match everything, including forward slashes

Signed-off-by: David Kwon <dakwon@redhat.com>