### PR TITLE
Hover support for @ConfigProperty name bounded to method parameters

### DIFF
--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/config/java/MicroProfileConfigHoverParticipant.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/config/java/MicroProfileConfigHoverParticipant.java
@@ -19,8 +19,8 @@ import static com.redhat.microprofile.jdt.core.utils.AnnotationUtils.getAnnotati
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IAnnotatable;
 import org.eclipse.jdt.core.IAnnotation;
-import org.eclipse.jdt.core.IField;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.ISourceRange;
@@ -62,7 +62,7 @@ public class MicroProfileConfigHoverParticipant implements IJavaHoverParticipant
 	@Override
 	public Hover collectHover(JavaHoverContext context, IProgressMonitor monitor) throws CoreException {
 		IJavaElement hoverElement = context.getHoverElement();
-		if (hoverElement.getElementType() != IJavaElement.FIELD) {
+		if (hoverElement.getElementType() != IJavaElement.FIELD && hoverElement.getElementType() != IJavaElement.LOCAL_VARIABLE) {
 			return null;
 		}
 
@@ -70,7 +70,7 @@ public class MicroProfileConfigHoverParticipant implements IJavaHoverParticipant
 		IJDTUtils utils = context.getUtils();
 
 		Position hoverPosition = context.getHoverPosition();
-		IField hoverField = (IField) hoverElement;
+		IAnnotatable hoverField = (IAnnotatable) hoverElement;
 
 		IAnnotation annotation = getAnnotation(hoverField, CONFIG_PROPERTY_ANNOTATION);
 

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/projects/maven/config-quickstart/src/main/resources/application.properties
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/projects/maven/config-quickstart/src/main/resources/application.properties
@@ -1,3 +1,1 @@
 # Your configuration properties
-greeting.message = hello
-greeting.name = quarkus

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/JavaHoverTest.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/JavaHoverTest.java
@@ -13,20 +13,16 @@ import java.io.IOException;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.redhat.microprofile.commons.DocumentFormat;
@@ -42,22 +38,7 @@ import com.redhat.microprofile.jdt.internal.config.java.MicroProfileConfigHoverP
 public class JavaHoverTest extends BasePropertiesManagerTest {
 
 	private static IJavaProject javaProject;
-	private static String javaFileUri;
 
-	@BeforeClass
-	public static void setup() throws Exception {
-		JavaLanguageServerPlugin.getProjectsManager().setAutoBuilding(true);
-
-		javaProject = loadMavenProject(MavenProjectName.config_hover);
-		IProject project = javaProject.getProject();
-		project.build(IncrementalProjectBuilder.FULL_BUILD, new NullProgressMonitor());
-
-		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/GreetingResource.java"));
-		javaFileUri = javaFile.getLocation().toFile().toURI().toString();
-
-	}
-
-	@Before
 	@After
 	public void cleanup() throws JavaModelException, IOException {
 		deleteFile(JDTMicroProfileProject.APPLICATION_YAML_FILE, javaProject);
@@ -66,58 +47,70 @@ public class JavaHoverTest extends BasePropertiesManagerTest {
 
 	@Test
 	public void configPropertyNameHover() throws Exception {
+		
+		javaProject = loadMavenProject(MavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/GreetingResource.java"));
+		String javaFileUri = javaFile.getLocation().toFile().toURI().toString();
+		
 		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE,
 				"greeting.message = hello\r\n" + "greeting.name = quarkus\r\n" + "greeting.number = 100", javaProject);
 		// Position(14, 40) is the character after the | symbol:
 		// @ConfigProperty(name = "greeting.mes|sage")
-		Hover info = getActualHover(new Position(14, 40));
+		Hover info = getActualHover(new Position(14, 40), javaFileUri);
 		assertHover("greeting.message", "hello", 14, 28, 44, info);
 
 		// Test left edge
 		// Position(14, 28) is the character after the | symbol:
 		// @ConfigProperty(name = "|greeting.message")
-		info = getActualHover(new Position(14, 28));
+		info = getActualHover(new Position(14, 28), javaFileUri);
 		assertHover("greeting.message", "hello", 14, 28, 44, info);
 
 		// Test right edge
 		// Position(14, 43) is the character after the | symbol:
 		// @ConfigProperty(name = "greeting.messag|e")
-		info = getActualHover(new Position(14, 43));
+		info = getActualHover(new Position(14, 43), javaFileUri);
 		assertHover("greeting.message", "hello", 14, 28, 44, info);
 
 		// Test no hover
 		// Position(14, 27) is the character after the | symbol:
 		// @ConfigProperty(name = |"greeting.message")
-		info = getActualHover(new Position(14, 27));
+		info = getActualHover(new Position(14, 27), javaFileUri);
 		Assert.assertNull(info);
 
 		// Test no hover 2
 		// Position(14, 44) is the character after the | symbol:
 		// @ConfigProperty(name = "greeting.message|")
-		info = getActualHover(new Position(14, 44));
+		info = getActualHover(new Position(14, 44), javaFileUri);
 		Assert.assertNull(info);
 
 		// Hover default value
 		// Position(17, 33) is the character after the | symbol:
 		// @ConfigProperty(name = "greet|ing.suffix", defaultValue="!")
-		info = getActualHover(new Position(17, 33));
+		info = getActualHover(new Position(17, 33), javaFileUri);
 		assertHover("greeting.suffix", "!", 17, 28, 43, info);
 
 		// Hover override default value
 		// Position(26, 33) is the character after the | symbol:
 		// @ConfigProperty(name = "greet|ing.number", defaultValue="0")
-		info = getActualHover(new Position(26, 33));
+		info = getActualHover(new Position(26, 33), javaFileUri);
 		assertHover("greeting.number", "100", 26, 28, 43, info);
 
 		// Hover when no value
 		// Position(23, 33) is the character after the | symbol:
 		// @ConfigProperty(name = "greet|ing.missing")
-		info = getActualHover(new Position(23, 33));
+		info = getActualHover(new Position(23, 33), javaFileUri);
 		assertHover("greeting.missing", null, 23, 28, 44, info);
 	}
 
 	@Test
 	public void configPropertyNameYaml() throws Exception {
+		
+		javaProject = loadMavenProject(MavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/GreetingResource.java"));
+		String javaFileUri = javaFile.getLocation().toFile().toURI().toString();
+		
 		saveFile(JDTMicroProfileProject.APPLICATION_YAML_FILE,
 				"greeting:\n" + "  message: message from yaml\n" + "  number: 2001", javaProject);
 
@@ -126,23 +119,78 @@ public class JavaHoverTest extends BasePropertiesManagerTest {
 
 		// Position(14, 40) is the character after the | symbol:
 		// @ConfigProperty(name = "greeting.mes|sage")
-		Hover info = getActualHover(new Position(14, 40));
+		Hover info = getActualHover(new Position(14, 40), javaFileUri);
 		assertHover("greeting.message", "message from yaml", 14, 28, 44, info);
 
 		// Position(26, 33) is the character after the | symbol:
 		// @ConfigProperty(name = "greet|ing.number", defaultValue="0")
-		info = getActualHover(new Position(26, 33));
+		info = getActualHover(new Position(26, 33), javaFileUri);
 		assertHover("greeting.number", "2001", 26, 28, 43, info);
 
 		saveFile(JDTMicroProfileProject.APPLICATION_YAML_FILE, "greeting:\n" + "  message: message from yaml",
 				javaProject);
 
 		// fallback to application.properties
-		info = getActualHover(new Position(26, 33));
+		info = getActualHover(new Position(26, 33), javaFileUri);
 		assertHover("greeting.number", "100", 26, 28, 43, info);
 	}
+	
+	@Test
+	public void configPropertyNameMethod() throws Exception {
+		
+		javaProject = loadMavenProject(MavenProjectName.config_quickstart);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/GreetingMethodResource.java"));
+		String javaFileUri = javaFile.getLocation().toFile().toURI().toString();
 
-	private Hover getActualHover(Position hoverPosition) throws JavaModelException {
+		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE,
+				"greeting.method.message = hello", javaProject);
+
+		// Position(22, 61) is the character after the | symbol:
+		// @ConfigProperty(name = "greeting.m|ethod.message")
+		Hover info = getActualHover(new Position(22, 61), javaFileUri);
+		assertHover("greeting.method.message", "hello", 22, 51, 74, info);
+
+		// Position(27, 60) is the character after the | symbol:
+		// @ConfigProperty(name = "greeting.m|ethod.suffix" , defaultValue="!")
+		info = getActualHover(new Position(27, 60), javaFileUri);
+		assertHover("greeting.method.suffix", "!", 27, 50, 72, info);
+
+		// Position(32, 58) is the character after the | symbol:
+		// @ConfigProperty(name = "greeting.method.name")
+		info = getActualHover(new Position(32, 58), javaFileUri);
+		assertHover("greeting.method.name", null, 32, 48, 68, info);
+	}
+	
+	@Test
+	public void configPropertyNameConstructor() throws Exception {
+		
+		javaProject = loadMavenProject(MavenProjectName.config_quickstart);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/GreetingConstructorResource.java"));
+		String javaFileUri = javaFile.getLocation().toFile().toURI().toString();
+
+		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE,
+				"greeting.constructor.message = hello", javaProject);
+
+		// Position(23, 48) is the character after the | symbol:
+		// @ConfigProperty(name = "greeting.con|structor.message")
+		Hover info = getActualHover(new Position(23, 48), javaFileUri);
+		assertHover("greeting.constructor.message", "hello", 23, 36, 64, info);
+
+		// Position(24, 48) is the character after the | symbol:
+		// @ConfigProperty(name = "greeting.con|structor.suffix" , defaultValue="!")
+		info = getActualHover(new Position(24, 48), javaFileUri);
+		assertHover("greeting.constructor.suffix", "!", 24, 36, 63, info);
+
+		// Position(25, 48) is the character after the | symbol:
+		// @ConfigProperty(name = "greeting.con|structor.name")
+		info = getActualHover(new Position(25, 48), javaFileUri);
+		assertHover("greeting.constructor.name", null, 25, 36, 61, info);
+	}
+
+
+	private Hover getActualHover(Position hoverPosition,String javaFileUri) throws JavaModelException {
 		MicroProfileJavaHoverParams params = new MicroProfileJavaHoverParams();
 		params.setDocumentFormat(DocumentFormat.Markdown);
 		params.setPosition(hoverPosition);


### PR DESCRIPTION
This PR implements hover support for `@ConfigProperty` name, that are bounded to methods.

To test this PR, please open the config-quickstart test project and hover over the `@ConfigProperty` names in the `GreetingConstructorResource` and `GreetingMethodResource` classes:

![demo](https://raw.githubusercontent.com/xorye/gifs/master/quarkus-ls/PR/%23286/hover-config-property.gif?token=AE3CR5I5HQILS6E2SAUZO4C6RXWNK)



Signed-off-by: David Kwon <dakwon@redhat.com>