### PR TITLE
Display properties with profiles in @ConfigProperty name hover

### DIFF
--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/commons/MicroProfileJavaHoverParams.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/commons/MicroProfileJavaHoverParams.java
@@ -24,16 +24,18 @@ public class MicroProfileJavaHoverParams {
 	private String uri;
 	private Position position;
 	private DocumentFormat documentFormat;
+	private boolean surroundEqualsWithSpaces;
 
 	public MicroProfileJavaHoverParams() {
 
 	}
 
-	public MicroProfileJavaHoverParams(String uri, Position position, DocumentFormat documentFormat) {
+	public MicroProfileJavaHoverParams(String uri, Position position, DocumentFormat documentFormat, boolean surroundEqualsWithSpaces) {
 		this();
 		setUri(uri);
 		setPosition(position);
 		setDocumentFormat(documentFormat);
+		setSurroundEqualsWithSpaces(surroundEqualsWithSpaces);
 	}
 
 	/**
@@ -78,5 +80,13 @@ public class MicroProfileJavaHoverParams {
 
 	public void setDocumentFormat(DocumentFormat documentFormat) {
 		this.documentFormat = documentFormat;
+	}
+
+	public boolean getSurroundEqualsWithSpaces() {
+		return surroundEqualsWithSpaces;
+	}
+
+	public void setSurroundEqualsWithSpaces(boolean surroundEqualsWithSpaces) {
+		this.surroundEqualsWithSpaces = surroundEqualsWithSpaces;
 	}
 }

--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/PropertiesManagerForJava.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/PropertiesManagerForJava.java
@@ -202,8 +202,10 @@ public class PropertiesManagerForJava {
 		IJavaElement hoverElement = getHoveredElement(typeRoot, hoveredOffset);
 		
 		DocumentFormat documentFormat = params.getDocumentFormat();
+		boolean surroundEqualsWithSpaces = params.getSurroundEqualsWithSpaces();
 		List<Hover> hovers = new ArrayList<>();
-		collectHover(uri, typeRoot, hoverElement, utils, hoverPosition, documentFormat, hovers, monitor);
+		collectHover(uri, typeRoot, hoverElement, utils, hoverPosition, documentFormat,
+				surroundEqualsWithSpaces, hovers, monitor);
 		if (hovers.isEmpty()) {
 			return null;
 		}
@@ -262,10 +264,11 @@ public class PropertiesManagerForJava {
 	}
 
 	private void collectHover(String uri, ITypeRoot typeRoot, IJavaElement hoverElement, IJDTUtils utils,
-			Position hoverPosition, DocumentFormat documentFormat, List<Hover> hovers, IProgressMonitor monitor) {
+			Position hoverPosition, DocumentFormat documentFormat, boolean surroundEqualsWithSpaces,
+			List<Hover> hovers, IProgressMonitor monitor) {
 		// Collect all adapted hover participant
 		JavaHoverContext context = new JavaHoverContext(uri, typeRoot, utils, hoverElement, hoverPosition,
-				documentFormat);
+				documentFormat, surroundEqualsWithSpaces);
 		List<JavaHoverDefinition> definitions = JavaFeaturesRegistry.getInstance().getJavaHoverDefinitions().stream()
 				.filter(definition -> definition.isAdaptedForHover(context, monitor)).collect(Collectors.toList());
 		if (definitions.isEmpty()) {

--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/java/hover/JavaHoverContext.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/java/hover/JavaHoverContext.java
@@ -32,13 +32,16 @@ public class JavaHoverContext extends AbtractJavaContext {
 	private final IJavaElement hoverElement;
 
 	private final DocumentFormat documentFormat;
+	
+	private final boolean surroundEqualsWithSpaces;
 
 	public JavaHoverContext(String uri, ITypeRoot typeRoot, IJDTUtils utils, IJavaElement hoverElement,
-			Position hoverPosition, DocumentFormat documentFormat) {
+			Position hoverPosition, DocumentFormat documentFormat, boolean surroundEqualsWithSpaces) {
 		super(uri, typeRoot, utils);
 		this.hoverElement = hoverElement;
 		this.hoverPosition = hoverPosition;
 		this.documentFormat = documentFormat;
+		this.surroundEqualsWithSpaces = surroundEqualsWithSpaces;
 	}
 
 	public DocumentFormat getDocumentFormat() {
@@ -51,6 +54,10 @@ public class JavaHoverContext extends AbtractJavaContext {
 
 	public Position getHoverPosition() {
 		return hoverPosition;
+	}
+	
+	public boolean isSurroundEqualsWithSpaces() {
+		return surroundEqualsWithSpaces;
 	}
 
 }

--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/project/JDTMicroProfileProject.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/project/JDTMicroProfileProject.java
@@ -10,7 +10,9 @@
 package com.redhat.microprofile.jdt.core.project;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.jdt.core.IJavaProject;
 
@@ -47,6 +49,14 @@ public class JDTMicroProfileProject {
 			}
 		}
 		return defaultValue;
+	}
+	
+	public Set<String> getPropertyKeys() {
+		Set<String> results = new HashSet<String>();
+		for (IConfigSource configSource : configSources) {
+			results.addAll(configSource.getPropertyKeys());
+		}
+		return results;
 	}
 
 	public Integer getPropertyAsInteger(String key, Integer defaultValue) {

--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/ls/MicroProfileDelegateCommandHandlerForJava.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/ls/MicroProfileDelegateCommandHandlerForJava.java
@@ -260,6 +260,7 @@ public class MicroProfileDelegateCommandHandlerForJava implements IDelegateComma
 		if (documentFormatIndex != null) {
 			documentFormat = DocumentFormat.forValue(documentFormatIndex.intValue());
 		}
-		return new MicroProfileJavaHoverParams(javaFileUri, hoverPosition, documentFormat);
+		boolean surroundEqualsWithSpaces = ((Boolean) obj.get("surroundEqualsWithSpaces")).booleanValue();
+		return new MicroProfileJavaHoverParams(javaFileUri, hoverPosition, documentFormat, surroundEqualsWithSpaces);
 	}
 }

--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/project/AbstractConfigSource.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/project/AbstractConfigSource.java
@@ -16,7 +16,9 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -144,6 +146,15 @@ public abstract class AbstractConfigSource<T> implements IConfigSource {
 		}
 		return null;
 	}
+	
+	@Override
+	public final Set<String> getPropertyKeys() {
+		T config = getConfig();
+		if (config == null) {
+			return Collections.<String>emptySet();
+		}
+		return getPropertyKeys(config);
+	}
 
 	private void reset() {
 		config = null;
@@ -166,5 +177,13 @@ public abstract class AbstractConfigSource<T> implements IConfigSource {
 	 * @return the property from the given <code>key</code> and null otherwise.
 	 */
 	protected abstract String getProperty(String key, T config);
+	
+	/**
+	 * Returns all property keys defined in the config.
+	 * 
+	 * @param config
+	 * @return all property keys defined in the config.
+	 */
+	protected abstract Set<String> getPropertyKeys(T config);
 
 }

--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/project/IConfigSource.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/project/IConfigSource.java
@@ -9,6 +9,8 @@
 *******************************************************************************/
 package com.redhat.microprofile.jdt.internal.core.project;
 
+import java.util.Set;
+
 /**
  * Configuration file API
  * 
@@ -34,4 +36,11 @@ public interface IConfigSource {
 	 *         otherwise.
 	 */
 	Integer getPropertyAsInt(String key);
+	
+	/**
+	 * Returns all property keys defined in the config.
+	 * 
+	 * @return all property keys defined in the config.
+	 */
+	Set<String> getPropertyKeys();
 }

--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/project/PropertiesConfigSource.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/project/PropertiesConfigSource.java
@@ -12,6 +12,7 @@ package com.redhat.microprofile.jdt.internal.core.project;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
+import java.util.Set;
 
 import org.eclipse.jdt.core.IJavaProject;
 
@@ -37,6 +38,11 @@ public class PropertiesConfigSource extends AbstractConfigSource<Properties> {
 		Properties properties = new Properties();
 		properties.load(input);
 		return properties;
+	}
+
+	@Override
+	protected Set<String> getPropertyKeys(Properties properties) {
+		return properties.stringPropertyNames();
 	}
 
 }

--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/project/YamlConfigSource.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/project/YamlConfigSource.java
@@ -12,6 +12,7 @@ package com.redhat.microprofile.jdt.internal.core.project;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.jdt.core.IJavaProject;
 import org.yaml.snakeyaml.Yaml;
@@ -19,7 +20,7 @@ import org.yaml.snakeyaml.Yaml;
 /**
  * Yaml config source implementation
  * 
- * @author dakwon
+ * @author David Kwon
  *
  */
 public class YamlConfigSource extends AbstractConfigSource<Map<String, Object>> {
@@ -65,6 +66,11 @@ public class YamlConfigSource extends AbstractConfigSource<Map<String, Object>> 
 		}
 		
 		return String.valueOf(value);
+	}
+
+	@Override
+	protected Set<String> getPropertyKeys(Map<String, Object> config) {
+		return config.keySet();
 	}
 
 }

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/JavaHoverTest.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/src/main/java/com/redhat/microprofile/jdt/core/JavaHoverTest.java
@@ -195,6 +195,7 @@ public class JavaHoverTest extends BasePropertiesManagerTest {
 		params.setDocumentFormat(DocumentFormat.Markdown);
 		params.setPosition(hoverPosition);
 		params.setUri(javaFileUri);
+		params.setSurroundEqualsWithSpaces(true);
 
 		return PropertiesManagerForJava.getInstance().hover(params, JDT_UTILS, new NullProgressMonitor());
 	}

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/commons/MicroProfileJavaHoverParams.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/commons/MicroProfileJavaHoverParams.java
@@ -24,16 +24,18 @@ public class MicroProfileJavaHoverParams {
 	private String uri;
 	private Position position;
 	private DocumentFormat documentFormat;
+	private boolean surroundEqualsWithSpaces;
 
 	public MicroProfileJavaHoverParams() {
 
 	}
 
-	public MicroProfileJavaHoverParams(String uri, Position position, DocumentFormat documentFormat) {
+	public MicroProfileJavaHoverParams(String uri, Position position, DocumentFormat documentFormat, boolean surroundEqualsWithSpaces) {
 		this();
 		setUri(uri);
 		setPosition(position);
 		setDocumentFormat(documentFormat);
+		setSurroundEqualsWithSpaces(surroundEqualsWithSpaces);
 	}
 
 	/**
@@ -78,5 +80,13 @@ public class MicroProfileJavaHoverParams {
 
 	public void setDocumentFormat(DocumentFormat documentFormat) {
 		this.documentFormat = documentFormat;
+	}
+
+	public boolean getSurroundEqualsWithSpaces() {
+		return surroundEqualsWithSpaces;
+	}
+
+	public void setSurroundEqualsWithSpaces(boolean surroundEqualsWithSpaces) {
+		this.surroundEqualsWithSpaces = surroundEqualsWithSpaces;
 	}
 }

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/JavaTextDocumentService.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/JavaTextDocumentService.java
@@ -173,9 +173,10 @@ public class JavaTextDocumentService extends AbstractTextDocumentService {
 	@Override
 	public CompletableFuture<Hover> hover(HoverParams params) {
 		boolean markdownSupported = sharedSettings.getHoverSettings().isContentFormatSupported(MarkupKind.MARKDOWN);
+		boolean surroundEqualsWithSpaces = sharedSettings.getFormattingSettings().isSurroundEqualsWithSpaces();
 		DocumentFormat documentFormat = markdownSupported ? DocumentFormat.Markdown : DocumentFormat.PlainText;
 		MicroProfileJavaHoverParams javaParams = new MicroProfileJavaHoverParams(params.getTextDocument().getUri(),
-				params.getPosition(), documentFormat);
+				params.getPosition(), documentFormat, surroundEqualsWithSpaces);
 		return microprofileLanguageServer.getLanguageClient().getJavaHover(javaParams);
 	}
 


### PR DESCRIPTION
My proposed fix for #277 

This PR displays the property key's value for all profiles, regardless of whether or not the `quarkus.profile` system property or the `QUARKUS_PROFILE` environment variable has been set.

![image](https://user-images.githubusercontent.com/20326645/78183071-4b155780-7435-11ea-804a-f2ef5c3c71ff.png)

Please feel free to try it out with the config-quickstart and/or config-hover test projects.

No tests have been written yet, and code might be a bit messy for now. I will address that soon.

Signed-off-by: David Kwon <dakwon@redhat.com>