### PR TITLE
Add support for java.math.BigDecimal and java.math.BigInteger types

### DIFF
--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/commons/metadata/ItemMetadata.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/commons/metadata/ItemMetadata.java
@@ -165,6 +165,16 @@ public class ItemMetadata extends ItemBase {
 				"java.util.Optional<java.lang.Short>".equals(getType());
 	}
 
+	public boolean isBigDecimalType() {
+		return "java.math.BigDecimal".equals(getType()) || //
+				"java.util.Optional<java.math.BigDecimal>".equals(getType());
+	}
+
+	public boolean isBigIntegerType() {
+		return "java.math.BigInteger".equals(getType()) || //
+				"java.util.Optional<java.math.BigInteger>".equals(getType());
+	}
+
 	public boolean isRegexType() {
 		return "java.util.regex.Pattern".equals(getType()) || //
 				"java.util.Optional<java.util.regex.Pattern>".equals(getType());

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/commons/metadata/ItemMetadata.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/commons/metadata/ItemMetadata.java
@@ -4,6 +4,8 @@
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v20.html
 *
+* SPDX-License-Identifier: EPL-2.0
+*
 * Contributors:
 *     Red Hat Inc. - initial API and implementation
 *******************************************************************************/
@@ -161,6 +163,16 @@ public class ItemMetadata extends ItemBase {
 		return "short".equals(getType()) || //
 				"java.lang.Short".equals(getType()) || //
 				"java.util.Optional<java.lang.Short>".equals(getType());
+	}
+
+	public boolean isBigDecimalType() {
+		return "java.math.BigDecimal".equals(getType()) || //
+				"java.util.Optional<java.math.BigDecimal>".equals(getType());
+	}
+
+	public boolean isBigIntegerType() {
+		return "java.math.BigInteger".equals(getType()) || //
+				"java.util.Optional<java.math.BigInteger>".equals(getType());
 	}
 
 	public boolean isRegexType() {

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileValidator.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileValidator.java
@@ -9,6 +9,8 @@
 *******************************************************************************/
 package com.redhat.microprofile.services;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -32,6 +34,7 @@ import com.redhat.microprofile.model.values.ValuesRulesManager;
 import com.redhat.microprofile.settings.MicroProfileValidationSettings;
 import com.redhat.microprofile.utils.MicroProfilePropertiesUtils;
 import com.redhat.microprofile.utils.PositionUtils;
+import com.redhat.microprofile.utils.StringUtils;
 
 /**
  * Quarkus validator to validate properties declared in application.properties.
@@ -207,7 +210,9 @@ class MicroProfileValidator {
 				|| (metadata.isBooleanType() && !isBooleanString(value))
 				|| (metadata.isDoubleType() && !isDoubleString(value))
 				|| (metadata.isLongType() && !isLongString(value))
-				|| (metadata.isShortType() && !isShortString(value))) {
+				|| (metadata.isShortType() && !isShortString(value))
+				|| (metadata.isBigDecimalType() && !isBigDecimalString(value))
+				|| (metadata.isBigIntegerType() && !isBigIntegerString(value))) {
 			return "Type mismatch: " + metadata.getType() + " expected";
 		}
 		return null;
@@ -218,6 +223,9 @@ class MicroProfileValidator {
 	}
 
 	private static boolean isIntegerString(String str) {
+		if (!StringUtils.hasText(str)) {
+			return false;
+		}
 		try {
 			Integer.parseInt(str);
 			return true;
@@ -227,6 +235,9 @@ class MicroProfileValidator {
 	}
 
 	private static boolean isFloatString(String str) {
+		if (!StringUtils.hasText(str)) {
+			return false;
+		}
 		try {
 			Float.parseFloat(str);
 			return true;
@@ -236,6 +247,9 @@ class MicroProfileValidator {
 	}
 
 	private static boolean isLongString(String str) {
+		if (!StringUtils.hasText(str)) {
+			return false;
+		}
 		try {
 			Long.parseLong(str);
 			return true;
@@ -245,6 +259,9 @@ class MicroProfileValidator {
 	}
 
 	private static boolean isDoubleString(String str) {
+		if (!StringUtils.hasText(str)) {
+			return false;
+		}
 		try {
 			Double.parseDouble(str);
 			return true;
@@ -254,8 +271,35 @@ class MicroProfileValidator {
 	}
 
 	private static boolean isShortString(String str) {
+		if (!StringUtils.hasText(str)) {
+			return false;
+		}
 		try {
 			Short.parseShort(str);
+			return true;
+		} catch (NumberFormatException e) {
+			return false;
+		}
+	}
+
+	private static boolean isBigDecimalString(String str) {
+		if (!StringUtils.hasText(str)) {
+			return false;
+		}
+		try {
+			new BigDecimal(str);
+			return true;
+		} catch (NumberFormatException e) {
+			return false;
+		}
+	}
+
+	private static boolean isBigIntegerString(String str) {
+		if (!StringUtils.hasText(str)) {
+			return false;
+		}
+		try {
+			new BigInteger(str);
 			return true;
 		} catch (NumberFormatException e) {
 			return false;

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/utils/JSONSchemaUtils.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/utils/JSONSchemaUtils.java
@@ -323,10 +323,10 @@ public class JSONSchemaUtils {
 		if (item.isBooleanType()) {
 			return JSONSchemaType.booleanType;
 		}
-		if (item.isIntegerType()) {
+		if (item.isIntegerType() || item.isBigIntegerType()) {
 			return JSONSchemaType.integer;
 		}
-		if (item.isLongType() || item.isShortType() || item.isDoubleType() || item.isFloatType()) {
+		if (item.isLongType() || item.isShortType() || item.isDoubleType() || item.isFloatType() || item.isBigDecimalType()) {
 			return JSONSchemaType.number;
 		}
 		// In case of enum and no type has been found, we use string

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesDiagnosticsTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesDiagnosticsTest.java
@@ -15,6 +15,7 @@ import static com.redhat.microprofile.services.MicroProfileAssert.testDiagnostic
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.Test;
@@ -404,6 +405,100 @@ public class ApplicationPropertiesDiagnosticsTest {
 		value = "quarkus.thread-pool.growth-resistance=hello";
 		testDiagnosticsFor(value, getDefaultMicroProfileProjectInfo(), settings,
 				d(0, 38, 43, "Type mismatch: float expected", DiagnosticSeverity.Error, ValidationType.value));
+	}
+
+	@Test
+	public void validateBigDecimalError() throws BadLocationException {
+		MicroProfileProjectInfo projectInfo = new MicroProfileProjectInfo();
+		List<ItemMetadata> properties = new ArrayList<ItemMetadata>();
+		ItemMetadata p1 = new ItemMetadata();
+		p1.setName("quarkus.BigDecimal");
+		p1.setType("java.math.BigDecimal");
+		properties.add(p1);
+		ItemMetadata p2 = new ItemMetadata();
+		p2.setName("quarkus.Optional.BigDecimal");
+		p2.setType("java.util.Optional<java.math.BigDecimal>");
+		properties.add(p2);
+		projectInfo.setProperties(properties);
+
+		MicroProfileValidationSettings settings = new MicroProfileValidationSettings();
+		
+		String value = "quarkus.BigDecimal=12\n" + //
+				"quarkus.Optional.BigDecimal=12";
+		testDiagnosticsFor(value, projectInfo, settings);
+
+		value = "quarkus.BigDecimal=-19\n" + //
+				"quarkus.Optional.BigDecimal=-19";
+		testDiagnosticsFor(value, projectInfo, settings);
+
+		value = "quarkus.BigDecimal=3.14159\n" + //
+				"quarkus.Optional.BigDecimal=3.14159";
+		testDiagnosticsFor(value, projectInfo, settings);
+
+		value = "quarkus.BigDecimal=314.159e-2\n" + //
+				"quarkus.Optional.BigDecimal=314.159e-2";
+		testDiagnosticsFor(value, projectInfo, settings);
+
+		value = "quarkus.BigDecimal=hello world\n" + //
+				"quarkus.Optional.BigDecimal=hello world";
+		testDiagnosticsFor(value, projectInfo, settings,
+				d(0, 19, 30, "Type mismatch: java.math.BigDecimal expected", DiagnosticSeverity.Error, ValidationType.value),
+				d(1, 28, 39, "Type mismatch: java.util.Optional<java.math.BigDecimal> expected", DiagnosticSeverity.Error, ValidationType.value));
+		
+		value = "quarkus.BigDecimal=true\n" + //
+				"quarkus.Optional.BigDecimal=true";
+		testDiagnosticsFor(value, projectInfo, settings,
+				d(0, 19, 23, "Type mismatch: java.math.BigDecimal expected", DiagnosticSeverity.Error, ValidationType.value),
+				d(1, 28, 32, "Type mismatch: java.util.Optional<java.math.BigDecimal> expected", DiagnosticSeverity.Error, ValidationType.value));
+	}
+
+	@Test
+	public void validateBigIntegerError() throws BadLocationException {
+		MicroProfileProjectInfo projectInfo = new MicroProfileProjectInfo();
+		List<ItemMetadata> properties = new ArrayList<ItemMetadata>();
+		ItemMetadata p1 = new ItemMetadata();
+		p1.setName("quarkus.BigInteger");
+		p1.setType("java.math.BigInteger");
+		properties.add(p1);
+		ItemMetadata p2 = new ItemMetadata();
+		p2.setName("quarkus.Optional.BigInteger");
+		p2.setType("java.util.Optional<java.math.BigInteger>");
+		properties.add(p2);
+		projectInfo.setProperties(properties);
+
+		MicroProfileValidationSettings settings = new MicroProfileValidationSettings();
+		
+		String value = "quarkus.BigInteger=12\n" + //
+				"quarkus.Optional.BigInteger=12";
+		testDiagnosticsFor(value, projectInfo, settings);
+
+		value = "quarkus.BigInteger=-19\n" + //
+				"quarkus.Optional.BigInteger=-19";
+		testDiagnosticsFor(value, projectInfo, settings);
+
+		value = "quarkus.BigInteger=hello world\n" + //
+				"quarkus.Optional.BigInteger=hello world";
+		testDiagnosticsFor(value, projectInfo, settings,
+				d(0, 19, 30, "Type mismatch: java.math.BigInteger expected", DiagnosticSeverity.Error, ValidationType.value),
+				d(1, 28, 39, "Type mismatch: java.util.Optional<java.math.BigInteger> expected", DiagnosticSeverity.Error, ValidationType.value));
+		
+		value = "quarkus.BigInteger=true\n" + //
+				"quarkus.Optional.BigInteger=true";
+		testDiagnosticsFor(value, projectInfo, settings,
+				d(0, 19, 23, "Type mismatch: java.math.BigInteger expected", DiagnosticSeverity.Error, ValidationType.value),
+				d(1, 28, 32, "Type mismatch: java.util.Optional<java.math.BigInteger> expected", DiagnosticSeverity.Error, ValidationType.value));
+
+		value = "quarkus.BigInteger=3.14159\n" + //
+				"quarkus.Optional.BigInteger=3.14159";
+		testDiagnosticsFor(value, projectInfo, settings,
+				d(0, 19, 26, "Type mismatch: java.math.BigInteger expected", DiagnosticSeverity.Error, ValidationType.value),
+				d(1, 28, 35, "Type mismatch: java.util.Optional<java.math.BigInteger> expected", DiagnosticSeverity.Error, ValidationType.value));
+
+		value = "quarkus.BigInteger=314.159e-2\n" + //
+				"quarkus.Optional.BigInteger=314.159e-2";
+		testDiagnosticsFor(value, projectInfo, settings,
+				d(0, 19, 29, "Type mismatch: java.math.BigInteger expected", DiagnosticSeverity.Error, ValidationType.value),
+				d(1, 28, 38, "Type mismatch: java.util.Optional<java.math.BigInteger> expected", DiagnosticSeverity.Error, ValidationType.value));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #261

To test this PR, please open the `microprofile-open-tracing` project and experiment with the `quarkus.jaeger.sampler-param` property in `application.properties`. This property expects the `java.math.BigDecimal` type.

`java.math.BigDecimal` can be represented in different ways, as explained here: https://docs.oracle.com/javase/7/docs/api/java/math/BigDecimal.html#BigDecimal(java.lang.String)

![image](https://user-images.githubusercontent.com/20326645/78607932-feaf8a80-782d-11ea-9db2-c22b2cf062f1.png)

![image](https://user-images.githubusercontent.com/20326645/78607954-066f2f00-782e-11ea-9013-fea6c7cd0f1e.png)

![image](https://user-images.githubusercontent.com/20326645/78607961-096a1f80-782e-11ea-8048-3fac08aa08f7.png)

![image](https://user-images.githubusercontent.com/20326645/78607969-0cfda680-782e-11ea-98f3-1f6de9ec33b8.png)

This also works for `application.yaml` files.

As for the `java.math.BigInteger` type, I'm not aware of any property with this type, but I added support for it anyways. For the meantime, this can be tested by adding:
```
    @ConfigProperty(name = "greeting.BigInteger")
    BigInteger bigInteger;

```
in a resource class.


Signed-off-by: David Kwon <dakwon@redhat.com>