### PR TITLE
Remove Quarkus name in MicroProfile LS and jdt.ls extension

### DIFF
--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/commons/MicroProfilePropertiesChangeEvent.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/commons/MicroProfilePropertiesChangeEvent.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * The quarkus project properties change event.
+ * The MicroProfile project properties change event.
  * 
  * @author Angelo ZERR
  *
@@ -27,18 +27,18 @@ public class MicroProfilePropertiesChangeEvent {
 	private Set<String> projectURIs;
 
 	/**
-	 * Returns the search scope to collect the Quarkus properties.
+	 * Returns the search scope to collect the MicroProfile properties.
 	 * 
-	 * @return the search scope to collect the Quarkus properties.
+	 * @return the search scope to collect the MicroProfile properties.
 	 */
 	public List<MicroProfilePropertiesScope> getType() {
 		return type;
 	}
 
 	/**
-	 * Set the search scope to collect the Quarkus properties.
+	 * Set the search scope to collect the MicroProfile properties.
 	 * 
-	 * @param type the search scope to collect the Quarkus properties.
+	 * @param type the search scope to collect the MicroProfile properties.
 	 */
 	public void setType(List<MicroProfilePropertiesScope> type) {
 		this.type = type;

--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/commons/MicroProfilePropertiesScope.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/commons/MicroProfilePropertiesScope.java
@@ -16,7 +16,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Quarkus properties scope. Quarkus properties can be changed when:
+ * MicroProfile properties scope. MicroProfile properties can be changed when:
  * 
  * <ul>
  * <li>{@link #dependencies}: a dependency changed (ex : add, remove a new JAR

--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/AbstractPropertiesProvider.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/AbstractPropertiesProvider.java
@@ -107,7 +107,7 @@ public abstract class AbstractPropertiesProvider implements IPropertiesProvider 
 	 * @param extensionName the extension name and null otherwise.
 	 * @param binary        true if the property comes from a JAR and false
 	 *                      otherwise.
-	 * @param phase         the Quarkus config phase.
+	 * @param phase         the MicroProfile config phase.
 	 * @return the item metadata.
 	 */
 	protected ItemMetadata addItemMetadata(IPropertiesCollector collector, String name, String type, String description,

--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/MicroProfileCorePlugin.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/MicroProfileCorePlugin.java
@@ -16,7 +16,7 @@ import com.redhat.microprofile.jdt.internal.core.MicroProfilePropertiesListenerM
 import com.redhat.microprofile.jdt.internal.core.PropertiesProviderRegistry;
 
 /**
- * The activator class controls the Quarkus JDT LS Extension plug-in life cycle
+ * The activator class controls the MicroProfile JDT LS Extension plug-in life cycle
  */
 public class MicroProfileCorePlugin implements BundleActivator {
 
@@ -48,20 +48,20 @@ public class MicroProfileCorePlugin implements BundleActivator {
 	}
 
 	/**
-	 * Add the given quarkus properties changed listener.
+	 * Add the given MicroProfile properties changed listener.
 	 * 
 	 * @param listener the listener to add
 	 */
-	public void addQuarkusPropertiesChangedListener(IMicroProfilePropertiesChangedListener listener) {
+	public void addMicroProfilePropertiesChangedListener(IMicroProfilePropertiesChangedListener listener) {
 		MicroProfilePropertiesListenerManager.getInstance().addMicroProfilePropertiesChangedListener(listener);
 	}
 
 	/**
-	 * Remove the given quarkus properties changed listener.
+	 * Remove the given MicroProfile properties changed listener.
 	 * 
 	 * @param listener the listener to remove
 	 */
-	public void removeQuarkusPropertiesChangedListener(IMicroProfilePropertiesChangedListener listener) {
+	public void removeMicroProfilePropertiesChangedListener(IMicroProfilePropertiesChangedListener listener) {
 		MicroProfilePropertiesListenerManager.getInstance().removeMicroProfilePropertiesChangedListener(listener);
 	}
 }

--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/utils/IJDTUtils.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/utils/IJDTUtils.java
@@ -28,7 +28,7 @@ import com.redhat.microprofile.commons.DocumentFormat;
 /**
  * JDT LS utils provides some helpful utilities. To avoid having a strong
  * dependencies to JDT-LS, we use this API. This API gives the capability to
- * consume Quarkus manager without having JDT LS.
+ * consume MicroProfile manager without having JDT LS.
  * 
  * @author Angelo ZERR
  *

--- a/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/ls/MicroProfileDelegateCommandHandler.java
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/ls/MicroProfileDelegateCommandHandler.java
@@ -60,7 +60,7 @@ public class MicroProfileDelegateCommandHandler extends AbstractMicroProfileDele
 	}
 
 	/**
-	 * Returns the Quarkus project information
+	 * Returns the MicroProfile project information
 	 * 
 	 * @param arguments
 	 * @param commandId

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/commons/MicroProfilePropertiesChangeEvent.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/commons/MicroProfilePropertiesChangeEvent.java
@@ -27,18 +27,18 @@ public class MicroProfilePropertiesChangeEvent {
 	private Set<String> projectURIs;
 
 	/**
-	 * Returns the search scope to collect the Quarkus properties.
+	 * Returns the search scope to collect the MicroProfile properties.
 	 * 
-	 * @return the search scope to collect the Quarkus properties.
+	 * @return the search scope to collect the MicroProfile properties.
 	 */
 	public List<MicroProfilePropertiesScope> getType() {
 		return type;
 	}
 
 	/**
-	 * Set the search scope to collect the Quarkus properties.
+	 * Set the search scope to collect the MicroProfile properties.
 	 * 
-	 * @param type the search scope to collect the Quarkus properties.
+	 * @param type the search scope to collect the MicroProfile properties.
 	 */
 	public void setType(List<MicroProfilePropertiesScope> type) {
 		this.type = type;

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/commons/MicroProfilePropertiesScope.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/commons/MicroProfilePropertiesScope.java
@@ -16,7 +16,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Quarkus properties scope. Quarkus properties can be changed when:
+ * MicroProfile properties scope. MicroProfile properties can be changed when:
  * 
  * <ul>
  * <li>{@link #dependencies}: a dependency changed (ex : add, remove a new JAR

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/AbstractTextDocumentService.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/AbstractTextDocumentService.java
@@ -35,7 +35,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.TextDocumentService;
 
 /**
- * Abstract class for text document service. As Quarkus LS manages
+ * Abstract class for text document service. As MicroProfile LS manages
  * application.properties and java file, we need to implement completion, hover
  * with empty result.
  * 

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/ApplicationPropertiesTextDocumentService.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/ApplicationPropertiesTextDocumentService.java
@@ -81,9 +81,9 @@ public class ApplicationPropertiesTextDocumentService extends AbstractTextDocume
 
 	private DocumentFormat documentFormat;
 
-	public ApplicationPropertiesTextDocumentService(MicroProfileLanguageServer quarkusLanguageServer,
+	public ApplicationPropertiesTextDocumentService(MicroProfileLanguageServer microProfileLanguageServer,
 			SharedSettings sharedSettings) {
-		this.microprofileLanguageServer = quarkusLanguageServer;
+		this.microprofileLanguageServer = microProfileLanguageServer;
 		this.documents = new ModelTextDocuments<PropertiesModel>((document, cancelChecker) -> {
 			return PropertiesModel.parse(document);
 		});
@@ -149,7 +149,7 @@ public class ApplicationPropertiesTextDocumentService extends AbstractTextDocume
 
 	@Override
 	public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(CompletionParams params) {
-		// Get Quarkus project information which stores all available Quarkus
+		// Get MicroProfile project information which stores all available MicroProfile
 		// properties
 		MicroProfileProjectInfoParams projectInfoParams = createProjectInfoParams(params.getTextDocument());
 		return getProjectInfoCache().getProjectInfo(projectInfoParams).thenComposeAsync(projectInfo -> {
@@ -158,7 +158,7 @@ public class ApplicationPropertiesTextDocumentService extends AbstractTextDocume
 			}
 			// then get the Properties model document
 			return getPropertiesModel(params.getTextDocument(), (cancelChecker, document) -> {
-				// then return completion by using the Quarkus project information and the
+				// then return completion by using the MicroProfile project information and the
 				// Properties model document
 				CompletionList list = getMicroProfileLanguageService().doComplete(document, params.getPosition(),
 						projectInfo, sharedSettings.getCompletionSettings(), sharedSettings.getFormattingSettings(),
@@ -170,7 +170,7 @@ public class ApplicationPropertiesTextDocumentService extends AbstractTextDocume
 
 	@Override
 	public CompletableFuture<Hover> hover(HoverParams params) {
-		// Get Quarkus project information which stores all available Quarkus
+		// Get MicroProfile project information which stores all available MicroProfile
 		// properties
 		MicroProfileProjectInfoParams projectInfoParams = createProjectInfoParams(params.getTextDocument());
 		return getProjectInfoCache().getProjectInfo(projectInfoParams).thenComposeAsync(projectInfo -> {
@@ -179,7 +179,7 @@ public class ApplicationPropertiesTextDocumentService extends AbstractTextDocume
 			}
 			// then get the Properties model document
 			return getPropertiesModel(params.getTextDocument(), (cancelChecker, document) -> {
-				// then return hover by using the Quarkus project information and the
+				// then return hover by using the MicroProfile project information and the
 				// Properties model document
 				return getMicroProfileLanguageService().doHover(document, params.getPosition(), projectInfo,
 						sharedSettings.getHoverSettings());
@@ -274,12 +274,12 @@ public class ApplicationPropertiesTextDocumentService extends AbstractTextDocume
 	}
 
 	private MicroProfileLanguageService getMicroProfileLanguageService() {
-		return microprofileLanguageServer.getQuarkusLanguageService();
+		return microprofileLanguageServer.getMicroProfileLanguageService();
 	}
 
 	private void triggerValidationFor(ModelTextDocument<PropertiesModel> document) {
-		// Get Quarkus project information which stores all available Quarkus
-		// properties
+		// Get MicroProfile project information which stores all available
+		// MicroProfile properties
 		MicroProfileProjectInfoParams projectInfoParams = createProjectInfoParams(document.getUri());
 		getProjectInfoCache().getProjectInfo(projectInfoParams).thenComposeAsync(projectInfo -> {
 			if (projectInfo.getProperties().isEmpty()) {
@@ -287,7 +287,7 @@ public class ApplicationPropertiesTextDocumentService extends AbstractTextDocume
 			}
 			// then get the Properties model document
 			return getPropertiesModel(document, (cancelChecker, model) -> {
-				// then return do validation by using the Quarkus project information and the
+				// then return do validation by using the MicroProfile project information and the
 				// Properties model document
 				List<Diagnostic> diagnostics = getMicroProfileLanguageService().doDiagnostics(model, projectInfo,
 						getSharedSettings().getValidationSettings(), cancelChecker);
@@ -380,9 +380,9 @@ public class ApplicationPropertiesTextDocumentService extends AbstractTextDocume
 	}
 
 	/**
-	 * Updates Quarkus formatting settings configured from the client.
+	 * Updates MicroProfile formatting settings configured from the client.
 	 * 
-	 * @param newFormatting the new Quarkus formatting settings
+	 * @param newFormatting the new MicroProfile formatting settings
 	 */
 	public void updateFormattingSettings(MicroProfileFormattingSettings newFormatting) {
 		MicroProfileFormattingSettings formatting = sharedSettings.getFormattingSettings();

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/MicroProfileLanguageServer.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/MicroProfileLanguageServer.java
@@ -46,7 +46,7 @@ import com.redhat.microprofile.settings.capabilities.MicroProfileCapabilityManag
 import com.redhat.microprofile.settings.capabilities.ServerCapabilitiesInitializer;
 
 /**
- * Quarkus language server.
+ * MicroProfile language server.
  *
  */
 public class MicroProfileLanguageServer implements LanguageServer, ProcessLanguageServer, MicroProfileLanguageServerAPI,
@@ -54,7 +54,7 @@ public class MicroProfileLanguageServer implements LanguageServer, ProcessLangua
 
 	private static final Logger LOGGER = Logger.getLogger(MicroProfileLanguageServer.class.getName());
 
-	private final MicroProfileLanguageService quarkusLanguageService;
+	private final MicroProfileLanguageService microProfileLanguageService;
 	private final MicroProfileTextDocumentService textDocumentService;
 	private final WorkspaceService workspaceService;
 
@@ -63,14 +63,14 @@ public class MicroProfileLanguageServer implements LanguageServer, ProcessLangua
 	private MicroProfileCapabilityManager capabilityManager;
 
 	public MicroProfileLanguageServer() {
-		quarkusLanguageService = new MicroProfileLanguageService();
+		microProfileLanguageService = new MicroProfileLanguageService();
 		textDocumentService = new MicroProfileTextDocumentService(this);
 		workspaceService = new MicroProfileWorkspaceService(this);
 	}
 
 	@Override
 	public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
-		LOGGER.info("Initializing Quarkus server " + getVersion() + " with " + System.getProperty("java.home"));
+		LOGGER.info("Initializing MicroProfile server " + getVersion() + " with " + System.getProperty("java.home"));
 
 		this.parentProcessId = params.getProcessId();
 
@@ -102,32 +102,32 @@ public class MicroProfileLanguageServer implements LanguageServer, ProcessLangua
 	}
 
 	/**
-	 * Update Quarkus settings configured from the client.
+	 * Update MicroProfile settings configured from the client.
 	 * 
-	 * @param initializationOptionsSettings the Quarkus settings
+	 * @param initializationOptionsSettings the MicroProfile settings
 	 */
 	public synchronized void updateSettings(Object initializationOptionsSettings) {
 		if (initializationOptionsSettings == null) {
 			return;
 		}
 		// Update client settings
-		initializationOptionsSettings = AllMicroProfileSettings.getQuarkusToolsSettings(initializationOptionsSettings);
-		MicroProfileGeneralClientSettings quarkusClientSettings = MicroProfileGeneralClientSettings
-				.getGeneralQuarkusSettings(initializationOptionsSettings);
-		if (quarkusClientSettings != null) {
-			MicroProfileSymbolSettings newSymbols = quarkusClientSettings.getSymbols();
+		initializationOptionsSettings = AllMicroProfileSettings.getMicroProfileToolsSettings(initializationOptionsSettings);
+		MicroProfileGeneralClientSettings clientSettings = MicroProfileGeneralClientSettings
+				.getGeneralMicroProfileSettings(initializationOptionsSettings);
+		if (clientSettings != null) {
+			MicroProfileSymbolSettings newSymbols = clientSettings.getSymbols();
 			if (newSymbols != null) {
 				textDocumentService.updateSymbolSettings(newSymbols);
 			}
-			MicroProfileValidationSettings newValidation = quarkusClientSettings.getValidation();
+			MicroProfileValidationSettings newValidation = clientSettings.getValidation();
 			if (newValidation != null) {
 				textDocumentService.updateValidationSettings(newValidation);
 			}
-			MicroProfileFormattingSettings newFormatting = quarkusClientSettings.getFormatting();
+			MicroProfileFormattingSettings newFormatting = clientSettings.getFormatting();
 			if (newFormatting != null) {
 				textDocumentService.updateFormattingSettings(newFormatting);
 			}
-			MicroProfileCodeLensSettings newCodeLens = quarkusClientSettings.getCodeLens();
+			MicroProfileCodeLensSettings newCodeLens = clientSettings.getCodeLens();
 			if (newCodeLens != null) {
 				textDocumentService.updateCodeLensSettings(newCodeLens);
 			}
@@ -175,8 +175,8 @@ public class MicroProfileLanguageServer implements LanguageServer, ProcessLangua
 		return parentProcessId != null ? parentProcessId : 0;
 	}
 
-	public MicroProfileLanguageService getQuarkusLanguageService() {
-		return quarkusLanguageService;
+	public MicroProfileLanguageService getMicroProfileLanguageService() {
+		return microProfileLanguageService;
 	}
 
 	@Override

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/MicroProfileProjectInfoCache.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/MicroProfileProjectInfoCache.java
@@ -103,7 +103,7 @@ class MicroProfileProjectInfoCache {
 		}
 
 		/**
-		 * Clear the cache only for Quarkus properties coming from java sources.
+		 * Clear the cache only for MicroProfile properties coming from java sources.
 		 */
 		public void clearPropertiesFromSource() {
 			setReloadFromSource(true);
@@ -115,7 +115,7 @@ class MicroProfileProjectInfoCache {
 		}
 
 		/**
-		 * Add the new quarkus properties in the cache coming java sources.
+		 * Add the new MicroProfile properties in the cache coming java sources.
 		 * 
 		 * @param propertiesFromJavaSource properties to add in the cache.
 		 */
@@ -219,7 +219,7 @@ class MicroProfileProjectInfoCache {
 
 		MicroProfileProjectInfoWrapper wrapper = getProjectInfoWrapper(projectInfo);
 		if (wrapper.isReloadFromSource()) {
-			// There are some java sources changed, get the Quarkus properties from java
+			// There are some java sources changed, get the MicroProfile properties from java
 			// sources.
 			params.setScopes(MicroProfilePropertiesScope.ONLY_SOURCES);
 			return provider.getProjectInfo(params). //

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/MicroProfileServerLauncher.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/MicroProfileServerLauncher.java
@@ -25,7 +25,7 @@ import com.redhat.microprofile.ls.api.MicroProfileLanguageClientAPI;
 import com.redhat.microprofile.ls.commons.ParentProcessWatcher;
 
 /**
- * Quarkus server launcher
+ * MicroProfile server launcher
  *
  */
 public class MicroProfileServerLauncher {
@@ -64,7 +64,7 @@ public class MicroProfileServerLauncher {
 		return new Builder<LanguageClient>().setLocalService(server).setRemoteInterface(MicroProfileLanguageClientAPI.class) // Set
 																														// client
 																														// as
-																														// Quarkus
+																														// MicroProfile
 																														// language
 																														// client
 				.setInput(in).setOutput(out).setExecutorService(executorService).wrapMessages(wrapper).create();

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/MicroProfileWorkspaceService.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/MicroProfileWorkspaceService.java
@@ -14,7 +14,7 @@ import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.services.WorkspaceService;
 
 /**
- * Quarkus workspace service.
+ * MicroProfile workspace service.
  *
  */
 public class MicroProfileWorkspaceService implements WorkspaceService {

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileCodeActions.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileCodeActions.java
@@ -47,7 +47,7 @@ import com.redhat.microprofile.utils.PositionUtils;
 import com.redhat.microprofile.utils.StringUtils;
 
 /**
- * The Quarkus code actions
+ * The MicroProfile code actions
  * 
  * @author Angelo ZERR
  *
@@ -60,13 +60,13 @@ class MicroProfileCodeActions {
 
 	/**
 	 * Returns code actions for the given diagnostics of the application.properties
-	 * <code>document</code> by using the given Quarkus properties metadata
+	 * <code>document</code> by using the given MicroProfile properties metadata
 	 * <code>projectInfo</code>.
 	 * 
 	 * @param context             the code action context
 	 * @param range               the range
 	 * @param document            the properties model.
-	 * @param projectInfo         the Quarkus properties
+	 * @param projectInfo         the MicroProfile project info
 	 * @param formattingSettings  the formatting settings.
 	 * @param commandCapabilities the command capabilities
 	 * @return the result of the code actions.
@@ -93,7 +93,7 @@ class MicroProfileCodeActions {
 
 	/**
 	 * Creation code action for 'unknown' property by searching similar name from
-	 * the known Quarkus properties.
+	 * the known MicroProfile properties.
 	 * 
 	 * <p>
 	 * LIMITATION: mapped property are not supported.
@@ -101,7 +101,7 @@ class MicroProfileCodeActions {
 	 * 
 	 * @param diagnostic          the diagnostic
 	 * @param document            the properties model.
-	 * @param projectInfo         the Quarkus properties
+	 * @param projectInfo         the MicroProfile project info
 	 * @param commandCapabilities the command capabilities
 	 * @param codeActions         code actions list to fill.
 	 */
@@ -132,7 +132,7 @@ class MicroProfileCodeActions {
 				doCodeActionForIgnoreUnknownValidation(propertyName, diagnostic, document, projectInfo, codeActions);
 			}
 		} catch (BadLocationException e) {
-			LOGGER.log(Level.SEVERE, "In QuarkusCodeActions, position error", e);
+			LOGGER.log(Level.SEVERE, "In MicroProfileCodeActions, position error", e);
 		}
 	}
 
@@ -147,7 +147,7 @@ class MicroProfileCodeActions {
 	 *
 	 * @param diagnostic         the diagnostic
 	 * @param document           the properties model
-	 * @param projectInfo        the Quarkus properties
+	 * @param projectInfo        the MicroProfile properties
 	 * @param valuesRulesManager the ValueRulesManager
 	 * @param codeActions        the code actions list to fill
 	 */
@@ -210,7 +210,7 @@ class MicroProfileCodeActions {
 			}
 
 		} catch (BadLocationException e) {
-			LOGGER.log(Level.SEVERE, "In QuarkusCodeActions, position error", e);
+			LOGGER.log(Level.SEVERE, "In MicroProfileCodeActions, position error", e);
 		}
 	}
 
@@ -221,7 +221,7 @@ class MicroProfileCodeActions {
 	 * @param propertyName the property name to add to array for code action
 	 * @param diagnostic   the corresponding unknown property diagnostic
 	 * @param document     the properties model
-	 * @param projectInfo  the Quarkus properties
+	 * @param projectInfo  the MicroProfile properties
 	 * @param codeActions  the list of code actions
 	 */
 	private void doCodeActionForIgnoreUnknownValidation(String propertyName, Diagnostic diagnostic,
@@ -309,7 +309,7 @@ class MicroProfileCodeActions {
 					stringToInsert.toString(), textDocument, requiredDiagnostics);
 			codeActions.add(insertAction);
 		} catch (BadLocationException e) {
-			LOGGER.log(Level.SEVERE, "In QuarkusCodeActions, position error", e);
+			LOGGER.log(Level.SEVERE, "In MicroProfileCodeActions, position error", e);
 		}
 
 	}

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileDefinition.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileDefinition.java
@@ -53,8 +53,8 @@ public class MicroProfileDefinition {
 	 * 
 	 * @param document              the properties model.
 	 * @param position              the position where definition was triggered
-	 * @param projectInfo           the Quarkus properties
-	 * @param provider              the Quarkus property definition provider.
+	 * @param projectInfo           the MicroProfile project info
+	 * @param provider              the MicroProfile property definition provider.
 	 * @param definitionLinkSupport true if {@link LocationLink} must be returned
 	 *                              and false otherwise.
 	 * @return as promise the Java field definition location of the property at the

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileFormatter.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileFormatter.java
@@ -36,7 +36,7 @@ import com.redhat.microprofile.utils.PositionUtils;
  * <li>Remove extra newlines in between properties</li>
  * <li>Remove whitespaces before and after properties</li>
  * <li>Add/remove spacing surrounding the equals sign, depending on
- * <code>QuarkusFormattingSettings</code></li>
+ * <code>MicroProfileFormattingSettings</code></li>
  * </ul>
  * 
  */
@@ -73,7 +73,7 @@ class MicroProfileFormatter {
 	 * 
 	 * @param document           the properties model document
 	 * @param range              the range specifying the lines to format
-	 * @param formattingSettings the client's <code>QuarkusFormattingSettings</code>
+	 * @param formattingSettings the client's <code>MicroProfileFormattingSettings</code>
 	 * @return Returns a <code>List<TextEdit></code> that formats the the
 	 *         application.properties file represented by <code>document</code>,
 	 *         within the lines covered by the specified <code>range</code>.

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileHover.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileHover.java
@@ -47,7 +47,7 @@ class MicroProfileHover {
 	 * 
 	 * @param document           the properties model document
 	 * @param position           the hover position
-	 * @param projectInfo        the Quarkus project information
+	 * @param projectInfo        the MicroProfile project information
 	 * @param valuesRulesManager manager for values rules
 	 * @param hoverSettings      the hover settings
 	 * @return Hover object for the currently hovered token
@@ -61,7 +61,7 @@ class MicroProfileHover {
 			node = document.findNodeAt(position);
 			offset = document.offsetAt(position);
 		} catch (BadLocationException e) {
-			LOGGER.log(Level.SEVERE, "In QuarkusHover, position error", e);
+			LOGGER.log(Level.SEVERE, "MicroProfileHover, position error", e);
 			return null;
 		}
 		if (node == null) {
@@ -121,19 +121,19 @@ class MicroProfileHover {
 	 * 
 	 * @param key           the property key
 	 * @param offset        the hover offset
-	 * @param projectInfo   the Quarkus project information
+	 * @param projectInfo   the MicroProfile project information
 	 * @param hoverSettings the hover settings
 	 * @return the documentation hover for property key represented by token
 	 */
 	private static Hover getPropertyKeyHover(PropertyKey key, MicroProfileProjectInfo projectInfo,
 			MicroProfileHoverSettings hoverSettings) {
 		boolean markdownSupported = hoverSettings.isContentFormatSupported(MarkupKind.MARKDOWN);
-		// retrieve Quarkus property from the project information
+		// retrieve MicroProfile property from the project information
 		String propertyName = key.getPropertyName();
 
 		ItemMetadata item = MicroProfilePropertiesUtils.getProperty(propertyName, projectInfo);
 		if (item != null) {
-			// Quarkus property, found, display her documentation as hover
+			// MicroProfile property, found, display her documentation as hover
 			MarkupContent markupContent = DocumentationUtils.getDocumentation(item, key.getProfile(),
 					markdownSupported);
 			Hover hover = new Hover();
@@ -149,7 +149,7 @@ class MicroProfileHover {
 	 * key <code>node</code>
 	 * 
 	 * @param node          the property key node
-	 * @param projectInfo   the Quarkus project information
+	 * @param projectInfo   the MicroProfile project information
 	 * @param hoverSettings the hover settings
 	 * @return the documentation hover for property key represented by token
 	 */
@@ -157,7 +157,7 @@ class MicroProfileHover {
 			ValuesRulesManager valuesRulesManager, MicroProfileHoverSettings hoverSettings) {
 		PropertyValue value = ((PropertyValue) node);
 		boolean markdownSupported = hoverSettings.isContentFormatSupported(MarkupKind.MARKDOWN);
-		// retrieve Quarkus property from the project information
+		// retrieve MicroProfile property from the project information
 		String propertyValue = value.getValue();
 		if (propertyValue == null || propertyValue.isEmpty()) {
 			return null;
@@ -166,7 +166,7 @@ class MicroProfileHover {
 		ItemMetadata item = MicroProfilePropertiesUtils.getProperty(propertyName, projectInfo);
 		ValueHint enumItem = getValueHint(propertyValue, item, projectInfo, valuesRulesManager, value.getOwnerModel());
 		if (enumItem != null) {
-			// Quarkus property enumeration item, found, display her documentation as hover
+			// MicroProfile property enumeration item, found, display its documentation as hover
 			MarkupContent markupContent = DocumentationUtils.getDocumentation(enumItem, markdownSupported);
 			Hover hover = new Hover();
 			hover.setContents(markupContent);

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileLanguageService.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileLanguageService.java
@@ -38,7 +38,7 @@ import com.redhat.microprofile.settings.MicroProfileHoverSettings;
 import com.redhat.microprofile.settings.MicroProfileValidationSettings;
 
 /**
- * The Quarkus language service.
+ * The MicroProfile language service.
  * 
  * @author Angelo ZERR
  *
@@ -74,7 +74,7 @@ public class MicroProfileLanguageService {
 	 * 
 	 * @param document           the properties model document
 	 * @param position           the position where completion was triggered
-	 * @param projectInfo        the Quarkus project information
+	 * @param projectInfo        the MicroProfile project information
 	 * @param completionSettings the completion settings
 	 * @param cancelChecker      the cancel checker
 	 * @return completion list for the given position
@@ -91,7 +91,7 @@ public class MicroProfileLanguageService {
 	 * 
 	 * @param document      the properties model document
 	 * @param position      the hover position
-	 * @param projectInfo   the Quarkus project information
+	 * @param projectInfo   the MicroProfile project information
 	 * @param hoverSettings the hover settings
 	 * @return Hover object for the currently hovered token
 	 */
@@ -129,8 +129,8 @@ public class MicroProfileLanguageService {
 	 * 
 	 * @param document              the properties model.
 	 * @param position              the position where definition was triggered
-	 * @param projectInfo           the Quarkus properties
-	 * @param provider              the Quarkus property definition provider.
+	 * @param projectInfo           the MicroProfile project info
+	 * @param provider              the MicroProfile property definition provider.
 	 * @param definitionLinkSupport true if {@link LocationLink} must be returned
 	 *                              and false otherwise.
 	 * @return as promise the Java field definition location of the property at the
@@ -173,10 +173,10 @@ public class MicroProfileLanguageService {
 
 	/**
 	 * Validate the given application.properties <code>document</code> by using the
-	 * given Quarkus properties metadata <code>projectInfo</code>.
+	 * given MicroProfile properties metadata <code>projectInfo</code>.
 	 * 
 	 * @param document           the properties model.
-	 * @param projectInfo        the Quarkus properties
+	 * @param projectInfo        the MicroProfile project info.
 	 * @param validationSettings the validation settings.
 	 * @param cancelChecker      the cancel checker.
 	 * @return the result of the validation.
@@ -189,13 +189,13 @@ public class MicroProfileLanguageService {
 
 	/**
 	 * Returns code actions for the given diagnostics of the application.properties
-	 * <code>document</code> by using the given Quarkus properties metadata
+	 * <code>document</code> by using the given MicroProfile properties metadata
 	 * <code>projectInfo</code>.
 	 * 
 	 * @param context             the code action context
 	 * @param range               the range
 	 * @param document            the properties model.
-	 * @param projectInfo         the Quarkus properties
+	 * @param projectInfo         the MicroProfile project info
 	 * @param formattingSettings  the formatting settings.
 	 * @param commandCapabilities the command capabilities
 	 * @return the result of the code actions.

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileSymbolsProvider.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileSymbolsProvider.java
@@ -27,7 +27,7 @@ import com.redhat.microprofile.model.Node.NodeType;
 import com.redhat.microprofile.utils.PositionUtils;
 
 /**
- * The Quarkus symbols provider
+ * The MicroProfile symbols provider
  * 
  * @author Angelo ZERR
  *

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileValidator.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileValidator.java
@@ -37,14 +37,14 @@ import com.redhat.microprofile.utils.PositionUtils;
 import com.redhat.microprofile.utils.StringUtils;
 
 /**
- * Quarkus validator to validate properties declared in application.properties.
+ * MicroProfile validator to validate properties declared in application.properties.
  * 
  * @author Angelo ZERR
  *
  */
 class MicroProfileValidator {
 
-	private static final String QUARKUS_DIAGNOSTIC_SOURCE = "quarkus";
+	private static final String MICROPROFILE_DIAGNOSTIC_SOURCE = "microprofile";
 
 	private final MicroProfileProjectInfo projectInfo;
 	private final ValuesRulesManager valuesRulesManager;
@@ -360,7 +360,7 @@ class MicroProfileValidator {
 
 	private void addDiagnostic(String message, Node node, DiagnosticSeverity severity, String code) {
 		Range range = PositionUtils.createRange(node);
-		diagnostics.add(new Diagnostic(range, message, severity, QUARKUS_DIAGNOSTIC_SOURCE, code));
+		diagnostics.add(new Diagnostic(range, message, severity, MICROPROFILE_DIAGNOSTIC_SOURCE, code));
 	}
 
 	public MicroProfileValidationSettings getValidationSettings() {

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/AllMicroProfileSettings.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/AllMicroProfileSettings.java
@@ -49,7 +49,7 @@ public class AllMicroProfileSettings {
 		this.quarkus = quarkus;
 	}
 
-	public static Object getQuarkusToolsSettings(Object initializationOptionsSettings) {
+	public static Object getMicroProfileToolsSettings(Object initializationOptionsSettings) {
 		AllMicroProfileSettings rootSettings = JSONUtility.toModel(initializationOptionsSettings, AllMicroProfileSettings.class);
 		if (rootSettings == null) {
 			return null;

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/MicroProfileCodeLensSettings.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/MicroProfileCodeLensSettings.java
@@ -10,7 +10,7 @@
 package com.redhat.microprofile.settings;
 
 /**
- * Quarkus code lens settings.
+ * MicroProfile code lens settings.
  * 
  * @author Angelo ZERR
  *

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/MicroProfileFormattingSettings.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/MicroProfileFormattingSettings.java
@@ -10,7 +10,7 @@
 package com.redhat.microprofile.settings;
 
 /**
- * Quarkus formatting settings
+ * MicroProfile formatting settings
  */
 public class MicroProfileFormattingSettings {
 

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/MicroProfileGeneralClientSettings.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/MicroProfileGeneralClientSettings.java
@@ -114,7 +114,7 @@ public class MicroProfileGeneralClientSettings {
 	 * @param initializationOptionsSettings the initialization options
 	 * @return the general settings from the given initialization options
 	 */
-	public static MicroProfileGeneralClientSettings getGeneralQuarkusSettings(Object initializationOptionsSettings) {
+	public static MicroProfileGeneralClientSettings getGeneralMicroProfileSettings(Object initializationOptionsSettings) {
 		return JSONUtility.toModel(initializationOptionsSettings, MicroProfileGeneralClientSettings.class);
 	}
 }

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/MicroProfileSymbolSettings.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/MicroProfileSymbolSettings.java
@@ -11,7 +11,7 @@
 package com.redhat.microprofile.settings;
 
 /**
- * Quarkus symbol settings.
+ * MicroProfile symbol settings.
  * 
  * @author Angelo ZERR
  *

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/MicroProfileValidationSettings.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/MicroProfileValidationSettings.java
@@ -10,7 +10,7 @@
 package com.redhat.microprofile.settings;
 
 /**
- * Quarkus validation settings.
+ * MicroProfile validation settings.
  * 
  * @author Angelo ZERR
  *
@@ -97,9 +97,9 @@ public class MicroProfileValidationSettings {
 	}
 
 	/**
-	 * Returns the settings for unknown Quarkus properties validation.
+	 * Returns the settings for unknown MicroProfile properties validation.
 	 * 
-	 * @return the settings for unknown Quarkus properties validation.
+	 * @return the settings for unknown MicroProfile properties validation.
 	 */
 	public MicroProfileValidationTypeSettings getUnknown() {
 		updateDefault();
@@ -107,9 +107,9 @@ public class MicroProfileValidationSettings {
 	}
 
 	/**
-	 * Set the settings for unknown Quarkus properties validation.
+	 * Set the settings for unknown MicroProfile properties validation.
 	 * 
-	 * @param unknown the settings for unknown Quarkus properties validation.
+	 * @param unknown the settings for unknown MicroProfile properties validation.
 	 */
 	public void setUnknown(MicroProfileValidationTypeSettings unknown) {
 		this.unknown = unknown;
@@ -117,9 +117,9 @@ public class MicroProfileValidationSettings {
 	}
 
 	/**
-	 * Returns the settings for duplicate Quarkus properties validation.
+	 * Returns the settings for duplicate MicroProfile properties validation.
 	 * 
-	 * @return the settings for duplicate Quarkus properties validation.
+	 * @return the settings for duplicate MicroProfile properties validation.
 	 */
 	public MicroProfileValidationTypeSettings getDuplicate() {
 		updateDefault();
@@ -127,9 +127,9 @@ public class MicroProfileValidationSettings {
 	}
 
 	/**
-	 * Set the settings for duplicate Quarkus properties validation.
+	 * Set the settings for duplicate MicroProfile properties validation.
 	 * 
-	 * @param duplicate the settings for duplicate Quarkus properties validation.
+	 * @param duplicate the settings for duplicate MicroProfile properties validation.
 	 */
 	public void setDuplicate(MicroProfileValidationTypeSettings duplicate) {
 		this.duplicate = duplicate;
@@ -147,9 +147,9 @@ public class MicroProfileValidationSettings {
 	}
 
 	/**
-	 * Returns the settings for value of Quarkus properties validation.
+	 * Returns the settings for value of MicroProfile properties validation.
 	 * 
-	 * @return the settings for value of Quarkus properties validation.
+	 * @return the settings for value of MicroProfile properties validation.
 	 */
 	public MicroProfileValidationTypeSettings getValue() {
 		updateDefault();
@@ -157,9 +157,9 @@ public class MicroProfileValidationSettings {
 	}
 
 	/**
-	 * Set the settings for value of Quarkus properties validation.
+	 * Set the settings for value of MicroProfile properties validation.
 	 * 
-	 * @param value the settings for value of Quarkus properties validation.
+	 * @param value the settings for value of MicroProfile properties validation.
 	 */
 	public void setValue(MicroProfileValidationTypeSettings value) {
 		this.value = value;

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/MicroProfileValidationTypeSettings.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/MicroProfileValidationTypeSettings.java
@@ -18,7 +18,7 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 import com.redhat.microprofile.utils.AntPathMatcher;
 
 /**
- * Quarkus validation type settings.
+ * MicroProfile validation type settings.
  * 
  * @author Angelo ZERR
  *

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/SharedSettings.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/SharedSettings.java
@@ -10,7 +10,7 @@
 package com.redhat.microprofile.settings;
 
 /**
- * Quarkus shared settings.
+ * Shared settings.
  * 
  * @author Angelo ZERR
  *

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/utils/DocumentationUtils.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/utils/DocumentationUtils.java
@@ -30,13 +30,13 @@ public class DocumentationUtils {
 	}
 
 	/**
-	 * Returns the documentation of the given Quarkus property.
+	 * Returns the documentation of the given MicroProfile property.
 	 * 
-	 * @param item     the Quarkus property.
+	 * @param item     the MicroProfile property.
 	 * @param profile  the profile
 	 * @param markdown true if documentation must be formatted as markdown and false
 	 *                 otherwise.
-	 * @return the documentation of the given Quarkus property.
+	 * @return the documentation of the given MicroProfile property.
 	 */
 	public static MarkupContent getDocumentation(ItemMetadata item, String profile, boolean markdown) {
 
@@ -115,7 +115,7 @@ public class DocumentationUtils {
 	 * @param item     the enumeration item
 	 * @param markdown true if documentation must be formatted as markdown and false
 	 *                 otherwise.
-	 * @return the documentation of the given Quarkus property.
+	 * @return the documentation of the given enumeration item.
 	 */
 	public static MarkupContent getDocumentation(ValueHint item, boolean markdown) {
 

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/utils/MicroProfilePropertiesUtils.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/utils/MicroProfilePropertiesUtils.java
@@ -23,7 +23,7 @@ import com.redhat.microprofile.model.values.ValuesRulesManager;
 import com.redhat.microprofile.services.QuarkusModel;
 
 /**
- * Quarkus project information utilities.
+ * MicroProfile project information utilities.
  * 
  * @author Angelo ZERR
  *
@@ -83,7 +83,7 @@ public class MicroProfilePropertiesUtils {
 	/**
 	 * Returns the enums values according the property type.
 	 * 
-	 * @param property           the Quarkus property
+	 * @param property           the property
 	 * @param projectInfo
 	 * @param valuesRulesManager
 	 * @param model
@@ -105,12 +105,12 @@ public class MicroProfilePropertiesUtils {
 	}
 
 	/**
-	 * Returns the Quarkus property from the given property name and null otherwise.
+	 * Returns the MicroProfile property from the given property name and null otherwise.
 	 * 
 	 * @param propertyName the property name
-	 * @param info         the quarkus project information which hosts the Quarkus
+	 * @param info         the MicroProfile project information which hosts the MicroProfile
 	 *                     properties.
-	 * @return the Quarkus property from the given property name and null otherwise.
+	 * @return the MicroProfile property from the given property name and null otherwise.
 	 */
 	public static ItemMetadata getProperty(String propertyName, MicroProfileProjectInfo info) {
 		Collection<ItemMetadata> properties = info.getProperties();

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/commons/PropertyInfo.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/commons/PropertyInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 Red Hat Inc. and others.
+* Copyright (c) 2019-2020 Red Hat Inc. and others.
 * All rights reserved. This program and the accompanying materials
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v20.html
@@ -15,7 +15,7 @@ import com.redhat.microprofile.commons.metadata.ItemMetadata;
  * Property information which contains:
  * 
  * <ul>
- * <li>a Quarkus property</li>
+ * <li>a MicroProfile property</li>
  * <li>a profile</li>
  * <ul>
  * 
@@ -34,9 +34,9 @@ public class PropertyInfo {
 	}
 
 	/**
-	 * Returns the Quarkus property and null otherwise.
+	 * Returns the MicroProfile property and null otherwise.
 	 * 
-	 * @return the Quarkus property and null otherwise.
+	 * @return the MicroProfile property and null otherwise.
 	 */
 	public ItemMetadata getProperty() {
 		return property;

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/ls/MicroProfileLanguageServerScopeChangedTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/ls/MicroProfileLanguageServerScopeChangedTest.java
@@ -89,7 +89,7 @@ public class MicroProfileLanguageServerScopeChangedTest {
 	public void classpathChanged() throws InterruptedException, ExecutionException {
 		MicroProfileLanguageServer server = createServer();
 		MockMicroProfileLanguageClient client = (MockMicroProfileLanguageClient) server.getLanguageClient();
-		// Initialize quarkus properties
+		// Initialize properties
 		client.changedClasspath(PROJECT1, property1FromJar, property2FromJar, property1FromSources);
 
 		didOpen(PROJECT1_APPLICATION_PROPERTIES, server);
@@ -128,7 +128,7 @@ public class MicroProfileLanguageServerScopeChangedTest {
 	public void javaSourcesChangedInThreadContext() throws InterruptedException, ExecutionException {
 		MicroProfileLanguageServer server = createServer();
 		MockMicroProfileLanguageClient client = (MockMicroProfileLanguageClient) server.getLanguageClient();
-		// Initialize quarkus properties
+		// Initialize properties
 		client.changedClasspath(PROJECT1, property1FromJar, property2FromJar, property1FromSources);
 
 		didOpen(PROJECT1_APPLICATION_PROPERTIES, server);
@@ -143,8 +143,8 @@ public class MicroProfileLanguageServerScopeChangedTest {
 		assertCompletions(list, 2, c("quarkus.application.name", "quarkus.application.name=", r(0, 0, 0)), //
 				c("greeting.message", "greeting.message=", r(0, 0, 0)));
 
-		// create a lot of thread which change java sources (update Quarkus properties)
-		// and execute completion (to recompute Quarkus properties)
+		// create a lot of thread which change java sources (update properties)
+		// and execute completion (to recompute properties)
 		List<Thread> threads = new ArrayList<>();
 		List<Integer> count = new ArrayList<>();
 		for (int i = 0; i < 1000; i++) {

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/ls/MockMicroProfileLanguageClient.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/ls/MockMicroProfileLanguageClient.java
@@ -167,7 +167,7 @@ public class MockMicroProfileLanguageClient implements MicroProfileLanguageClien
 			}
 
 		}
-		// Throw Quarkus event
+		// Throw properties change event
 		MicroProfilePropertiesChangeEvent event = new MicroProfilePropertiesChangeEvent();
 		event.setType(MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES);
 		event.setProjectURIs(new HashSet<String>(Arrays.asList(projectURI)));
@@ -199,7 +199,7 @@ public class MockMicroProfileLanguageClient implements MicroProfileLanguageClien
 				hintsFromSources.add((ItemHint) item);
 			}
 		}
-		// Throw Quarkus event
+		// Throw properties change event
 		MicroProfilePropertiesChangeEvent event = new MicroProfilePropertiesChangeEvent();
 		event.setType(MicroProfilePropertiesScope.ONLY_SOURCES);
 		event.setProjectURIs(new HashSet<String>(Arrays.asList(projectURI)));

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/ls/MockMicroProfilePropertyDefinitionProvider.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/ls/MockMicroProfilePropertyDefinitionProvider.java
@@ -22,7 +22,7 @@ import com.redhat.microprofile.ls.api.MicroProfilePropertyDefinitionProvider;
 import com.redhat.microprofile.services.MicroProfileAssert;
 
 /**
- * Mock for Quarkus property definition provider.
+ * Mock for MicroProfile property definition provider.
  * 
  * @author Angelo ZERR
  *

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesHoverTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesHoverTest.java
@@ -31,7 +31,7 @@ public class ApplicationPropertiesHoverTest {
 	};
 
 	@Test
-	public void testQuarkusKeyHoverMarkdown() throws BadLocationException {
+	public void testKeyHoverMarkdown() throws BadLocationException {
 		String value = "quarkus.applica|tion.name = name";
 		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator() + //
 				"The name of the application.\nIf not set, defaults to the name of the project (except for tests where it is not set at all)."
@@ -43,7 +43,7 @@ public class ApplicationPropertiesHoverTest {
 	};
 
 	@Test
-	public void testQuarkusKeyHoverPlaintext() throws BadLocationException {
+	public void testKeyHoverPlaintext() throws BadLocationException {
 		String value = "quarkus.applica|tion.name = name";
 		String hoverLabel = "quarkus.application.name" + System.lineSeparator() + System.lineSeparator() + //
 				"The name of the application.\nIf not set, defaults to the name of the project (except for tests where it is not set at all)."
@@ -55,7 +55,7 @@ public class ApplicationPropertiesHoverTest {
 	};
 
 	@Test
-	public void testQuarkusKeyHoverNoSpaces() throws BadLocationException {
+	public void testKeyHoverNoSpaces() throws BadLocationException {
 		String value = "quarkus.applica|tion.name=name";
 		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator() + //
 				"The name of the application.\nIf not set, defaults to the name of the project (except for tests where it is not set at all)."
@@ -67,14 +67,14 @@ public class ApplicationPropertiesHoverTest {
 	};
 
 	@Test
-	public void testNoQuarkusKeyHoverOnEqualsSign() throws BadLocationException {
+	public void testNoKeyHoverOnEqualsSign() throws BadLocationException {
 		assertHoverMarkdown("quarkus.application.name |= name", null, 0);
 		assertHoverMarkdown("quarkus.application.name|=name", null, 0);
 		assertHoverMarkdown("quarkus.log.syslog.async.overflow|=DISCARD", null, 0);
 	};
 
 	@Test
-	public void testNoQuarkusValueHoverOnEqualsSign() throws BadLocationException {
+	public void testNoValueHoverOnEqualsSign() throws BadLocationException {
 		assertHoverMarkdown("quarkus.log.syslog.async.overflow |= DISCARD", null, 0);
 		assertHoverMarkdown("quarkus.log.syslog.async.overflow|=DISCARD", null, 0);
 	};
@@ -134,7 +134,7 @@ public class ApplicationPropertiesHoverTest {
 	};
 
 	@Test
-	public void testQuarkusKeyWithProfileHoverMarkdown() throws BadLocationException {
+	public void testKeyWithProfileHoverMarkdown() throws BadLocationException {
 		String value = "%dev.quarkus.applica|tion.name = name";
 		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator() + //
 				"The name of the application.\nIf not set, defaults to the name of the project (except for tests where it is not set at all)."
@@ -147,7 +147,7 @@ public class ApplicationPropertiesHoverTest {
 	};
 
 	@Test
-	public void testQuarkusKeyMap() throws BadLocationException {
+	public void testKeyMap() throws BadLocationException {
 		String value = "quar|kus.log.category.\"com.lordofthejars\".level=DEBUG";
 		String hoverLabel = "**quarkus.log.category.\\{\\*\\}.level**" + System.lineSeparator() + System.lineSeparator()
 				+ //

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/MicroProfileAssert.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/MicroProfileAssert.java
@@ -67,7 +67,7 @@ import com.redhat.microprofile.utils.DocumentationUtils;
 import com.redhat.microprofile.utils.PositionUtils;
 
 /**
- * Quarkus assert
+ * MicroProfile assert
  * 
  * @author Angelo ZERR
  *
@@ -78,7 +78,7 @@ public class MicroProfileAssert {
 
 	private static MicroProfilePropertyDefinitionProvider DEFAULT_DEFINITION_PROVIDER;
 
-	private static final String QUARKUS_DIAGNOSTIC_SOURCE = "quarkus";
+	private static final String MICROPROFILE_DIAGNOSTIC_SOURCE = "microprofile";
 
 	public static MicroProfileProjectInfo getDefaultMicroProfileProjectInfo() {
 		if (DEFAULT_PROJECT == null) {
@@ -467,7 +467,7 @@ public class MicroProfileAssert {
 	public static Diagnostic d(int startLine, int startCharacter, int endLine, int endCharacter, String message,
 			DiagnosticSeverity severity, ValidationType code) {
 		return new Diagnostic(r(startLine, startCharacter, endLine, endCharacter), message, severity,
-				QUARKUS_DIAGNOSTIC_SOURCE, code.name());
+				MICROPROFILE_DIAGNOSTIC_SOURCE, code.name());
 	}
 
 	// ------------------- CodeAction assert
@@ -503,16 +503,16 @@ public class MicroProfileAssert {
 		CodeActionContext context = new CodeActionContext();
 		context.setDiagnostics(diagnostics);
 
-		MicroProfileCommandCapabilities quarkusCommandCapabilities = new MicroProfileCommandCapabilities();
+		MicroProfileCommandCapabilities mpCommandCapabilities = new MicroProfileCommandCapabilities();
 
 		List<String> valueSet = Arrays.asList(CommandKind.COMMAND_CONFIGURATION_UPDATE);
 		CommandKindCapabilities commandKindCapabilities = new CommandKindCapabilities(valueSet);
 		CommandCapabilities commandCapabilities = new CommandCapabilities(commandKindCapabilities);
 
-		quarkusCommandCapabilities.setCapabilities(commandCapabilities);
+		mpCommandCapabilities.setCapabilities(commandCapabilities);
 
 		List<CodeAction> actual = languageService.doCodeActions(context, range, model, projectInfo, formattingSettings,
-				quarkusCommandCapabilities);
+				mpCommandCapabilities);
 		assertCodeActions(actual, expected);
 	}
 

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/settings/SettingsTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/settings/SettingsTest.java
@@ -17,9 +17,6 @@ import org.junit.Test;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import com.redhat.microprofile.settings.AllMicroProfileSettings;
-import com.redhat.microprofile.settings.InitializationOptionsSettings;
-import com.redhat.microprofile.settings.MicroProfileGeneralClientSettings;
 
 /**
  * Tests for settings.
@@ -58,15 +55,15 @@ public class SettingsTest {
 	public void initializationOptionsSettings() {
 
 		// Emulate InitializeParams#getInitializationOptions() object created as
-		// JSONObject when QuarkusLanguageServer#initialize(InitializeParams params) is
+		// JSONObject when MicroProfileLanguageServer#initialize(InitializeParams params) is
 		// called
 		InitializeParams params = createInitializeParams(json);
 		Object initializationOptionsSettings = InitializationOptionsSettings.getSettings(params);
 
 		// Test client commons settings
-		initializationOptionsSettings = AllMicroProfileSettings.getQuarkusToolsSettings(initializationOptionsSettings);
+		initializationOptionsSettings = AllMicroProfileSettings.getMicroProfileToolsSettings(initializationOptionsSettings);
 		MicroProfileGeneralClientSettings settings = MicroProfileGeneralClientSettings
-				.getGeneralQuarkusSettings(initializationOptionsSettings);
+				.getGeneralMicroProfileSettings(initializationOptionsSettings);
 		assertNotNull(settings);
 
 		// Symbols


### PR DESCRIPTION
Fixes #262 

In this PR I renamed most instances of "Quarkus" to "MicroProfile" from files under:
`quarkus-ls/microprofile.ls/com.redhat.microprofile.ls/` and
`quarkus-ls/microprofile.jdt/com.redhat.microprofile.jdt.core/`.

In these instances, I did not rename Quarkus to MicroProfile:
* Everything in `quarkus-ls/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/quarkus/snippets/` was left alone
* [AllMicroProfileSettings.java](https://github.com/redhat-developer/quarkus-ls/blob/master/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/AllMicroProfileSettings.java) was left alone because it defined the `quarkus` setting key. If this were to change, vscode-quarkus must be changed too.
* [MicroProfileCodeActions.java#L234](https://github.com/redhat-developer/quarkus-ls/blob/ce8ff788618cfb9f69a17c290170e84841e5198f/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileCodeActions.java#L234) was left alone to prevent the `quarkus.*` pattern from being suggested in the unknown property code action
* [MicroProfileCompletions.java#L234](https://github.com/redhat-developer/quarkus-ls/blob/ce8ff788618cfb9f69a17c290170e84841e5198f/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileCompletions.java#L234) which is a comment referring to Quarkus profiles
* [MicroProfileCodeActions.java#L255](https://github.com/redhat-developer/quarkus-ls/blob/ce8ff788618cfb9f69a17c290170e84841e5198f/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/MicroProfileCodeActions.java#L255) refers to a Quarkus specific setting
* [QuarkusModel.java](https://github.com/xorye/quarkus-ls/blob/262rename/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/services/QuarkusModel.java) was left alone because it contained data specific to Quarkus
* [IPropertiesCollector.java#L39](https://github.com/redhat-developer/quarkus-ls/blob/ce8ff788618cfb9f69a17c290170e84841e5198f/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/IPropertiesCollector.java#L39) I think phase is specific to Quarkus
* [FakeJavaProject.java#L47](https://github.com/redhat-developer/quarkus-ls/blob/ce8ff788618cfb9f69a17c290170e84841e5198f/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/internal/core/FakeJavaProject.java#L47) I kept "Quarkus" here because the comments mention "deployment jar"
* [PropertiesManager.java](https://github.com/xorye/quarkus-ls/blob/262rename/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/PropertiesManager.java) Mostly kept "Quarkus" in this file, because this file also mentions "deployment jar"s.