### PR TITLE
Add snippets for microprofile fault tolerance

### DIFF
--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/snippets/MicroProfileJavaSnippetRegistryLoader.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/snippets/MicroProfileJavaSnippetRegistryLoader.java
@@ -30,6 +30,8 @@ public class MicroProfileJavaSnippetRegistryLoader implements ISnippetRegistryLo
 				SnippetContextForJava.TYPE_ADAPTER);
 		registry.registerSnippets(MicroProfileJavaSnippetRegistryLoader.class.getResourceAsStream("mp-openapi.json"),
 				SnippetContextForJava.TYPE_ADAPTER);
+		registry.registerSnippets(MicroProfileJavaSnippetRegistryLoader.class.getResourceAsStream("mp-faulttolerance.json"),
+				SnippetContextForJava.TYPE_ADAPTER);
 	}
 
 	@Override

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/resources/com/redhat/microprofile/snippets/mp-faulttolerance.json
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/resources/com/redhat/microprofile/snippets/mp-faulttolerance.json
@@ -1,0 +1,93 @@
+{
+  "@Timeout": {
+    "prefix": [
+      "@Timeout"
+    ],
+    "body": [
+      "@Timeout($1)"
+    ],
+    "description": "The annotation to define a method execution timeout.",
+    "context": {
+      "type": "org.eclipse.microprofile.faulttolerance.Timeout"
+    }
+  },
+  "@Retry": {
+    "prefix": [
+      "@Retry"
+    ],
+    "body": [
+      "@Retry(",
+      "\tretryOn = $1,",
+      "\tmaxRetries = $2,",
+      "\tmaxDuration = $3,",
+      "\tabortOn = $4",
+      ")"
+    ],
+    "description": "The retry annotation to define the number of retries",
+    "context": {
+      "type": "org.eclipse.microprofile.faulttolerance.Retry"
+    }
+  },
+  "@Fallback with method": {
+    "prefix": [
+      "@Fallback"
+    ],
+    "body": [
+      "@Fallback(",
+      "\tfallbackMethod = \"$1\",",
+      "\tapplyOn = $2,",
+      "\tskipOn = $3",
+      ")"
+    ],
+    "description": "The fallback annotation using a fallback method",
+    "context": {
+      "type": "org.eclipse.microprofile.faulttolerance.Fallback"
+    }
+  },
+  "@Fallback with class": {
+    "prefix": [
+      "@Fallback"
+    ],
+    "body": [
+      "@Fallback(",
+      "\tvalue = $1,",
+      "\tapplyOn = $2,",
+      "\tskipOn = $3",
+      ")"
+    ],
+    "description": "The fallback annotation using a fallback class",
+    "context": {
+      "type": "org.eclipse.microprofile.faulttolerance.Fallback"
+    }
+  },
+  "@CircuitBreaker": {
+    "prefix": [
+      "@CircuitBreaker"
+    ],
+    "body": [
+      "@CircuitBreaker(",
+      "\trequestVolumeThreshold=$1,",
+      "\tfailureRatio=$2,",
+      "\tsuccessThreshold=$3,",
+      "\tfailOn = $4,",
+      "\tskipOn = $5",
+      ")"
+    ],
+    "description": "Defines a circuit breaker policy to an individual method or a class.",
+    "context": {
+      "type": "org.eclipse.microprofile.faulttolerance.CircuitBreaker"
+    }
+  },
+  "@Bulkhead": {
+    "prefix": [
+      "@Bulkhead"
+    ],
+    "body": [
+      "@Bulkhead(value=$1)"
+    ],
+    "description": "Define bulkhead policy to limit the number of the concurrent calls to an instance.",
+    "context": {
+      "type": "org.eclipse.microprofile.faulttolerance.Bulkhead"
+    }
+  }
+}

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/ls/JavaTextDocumentSnippetRegistryTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/ls/JavaTextDocumentSnippetRegistryTest.java
@@ -32,11 +32,15 @@ import com.redhat.microprofile.snippets.SnippetContextForJava;
  */
 public class JavaTextDocumentSnippetRegistryTest {
 
-	@Test
-	public void javaSnippets() {
-		JavaTextDocumentSnippetRegistry registry = new JavaTextDocumentSnippetRegistry();
-		Assert.assertFalse("Tests has MicroProfile Java snippets", registry.getSnippets().isEmpty());
+	private static JavaTextDocumentSnippetRegistry registry = new JavaTextDocumentSnippetRegistry();
 
+	@Test
+	public void haveJavaSnippets() {
+		Assert.assertFalse("Tests has MicroProfile Java snippets", registry.getSnippets().isEmpty());
+	}
+
+	@Test
+	public void mpMetricsSnippets() {
 		Optional<Snippet> metricSnippet = findByPrefix("@Metric", registry);
 		Assert.assertTrue("Tests has @Metric Java snippets", metricSnippet.isPresent());
 
@@ -52,6 +56,44 @@ public class JavaTextDocumentSnippetRegistryTest {
 				Arrays.asList("org.eclipse.microprofile.metrics.annotation.Metric"));
 		boolean match2 = ((SnippetContextForJava) context).isMatch(projectInfo2);
 		Assert.assertTrue("Project has org.eclipse.microprofile.metrics.annotation.Metric type", match2);
+	}
+
+	@Test
+	public void mpOpenAPISnippets() {
+		Optional<Snippet> apiResponseSnippet = findByPrefix("@APIResponse", registry);
+		Assert.assertTrue("Tests has @APIResponse Java snippets", apiResponseSnippet.isPresent());
+
+		ISnippetContext<?> context = apiResponseSnippet.get().getContext();
+		Assert.assertNotNull("@APIResponse snippet has context", context);
+		Assert.assertTrue("@APIResponse snippet context is Java context", context instanceof SnippetContextForJava);
+
+		ProjectLabelInfoEntry projectInfo = new ProjectLabelInfoEntry("", new ArrayList<>());
+		boolean match = ((SnippetContextForJava) context).isMatch(projectInfo);
+		Assert.assertFalse("Project has no org.eclipse.microprofile.openapi.annotations.responses.APIResponse type", match);
+
+		ProjectLabelInfoEntry projectInfo2 = new ProjectLabelInfoEntry("",
+				Arrays.asList("org.eclipse.microprofile.openapi.annotations.responses.APIResponse"));
+		boolean match2 = ((SnippetContextForJava) context).isMatch(projectInfo2);
+		Assert.assertTrue("Project has org.eclipse.microprofile.openapi.annotations.responses.APIResponse type", match2);
+	}
+
+	@Test
+	public void mpFaultToleranceSnippets() {
+		Optional<Snippet> fallbackSnippet = findByPrefix("@Fallback", registry);
+		Assert.assertTrue("Tests has @Fallback Java snippets", fallbackSnippet.isPresent());
+
+		ISnippetContext<?> context = fallbackSnippet.get().getContext();
+		Assert.assertNotNull("@Fallback snippet has context", context);
+		Assert.assertTrue("@Fallback snippet context is Java context", context instanceof SnippetContextForJava);
+
+		ProjectLabelInfoEntry projectInfo = new ProjectLabelInfoEntry("", new ArrayList<>());
+		boolean match = ((SnippetContextForJava) context).isMatch(projectInfo);
+		Assert.assertFalse("Project has no org.eclipse.microprofile.faulttolerance.Fallback type", match);
+
+		ProjectLabelInfoEntry projectInfo2 = new ProjectLabelInfoEntry("",
+				Arrays.asList("org.eclipse.microprofile.faulttolerance.Fallback"));
+		boolean match2 = ((SnippetContextForJava) context).isMatch(projectInfo2);
+		Assert.assertTrue("Project has org.eclipse.microprofile.faulttolerance.Fallback type", match2);
 	}
 
 	private static Optional<Snippet> findByPrefix(String prefix, SnippetRegistry registry) {


### PR DESCRIPTION
Closes #307 

Add snippets for MicroProfile fault tolerance annotations 

![image](https://user-images.githubusercontent.com/16768710/79477601-5e4d2900-7fd8-11ea-9e1e-4c24c6442024.png)

Tested using a quarkus project generated from https://start.microprofile.io/ with fault tolerance enabled, that I updated to use MicroProfile 3.3 