### PR TITLE
Fixed datasource snippet

### DIFF
--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/resources/com/redhat/quarkus/snippets/quarkus-properties.json
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/resources/com/redhat/quarkus/snippets/quarkus-properties.json
@@ -26,5 +26,15 @@
 		"context": {
 			"dependency": "quarkus-jaeger"
 		}
+	},
+	"Add Hibernate ORM datasource properties": {
+		"prefix": "qhormd",
+		"body": [
+			"quarkus.hibernate-orm.database.generation=${5|none,drop-and-create,create,drop,update|}"
+		],
+		"description": "Configure Quarkus Hibernate ORM datasource",
+		"context": {
+			"dependency": "quarkus-hibernate-orm"
+		}
 	}
 }

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/resources/com/redhat/quarkus/snippets/quarkus-properties.json
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/resources/com/redhat/quarkus/snippets/quarkus-properties.json
@@ -1,4 +1,20 @@
 {
+	"Add datasource properties for Hibernate ORM": {
+		"prefix": "qds",
+		"body": [
+			"quarkus.datasource.db-kind=${1|mariadb,mysql,h2,postgresql,derby,mssql|}",
+			"quarkus.datasource.username=${2:developer}",
+			"quarkus.datasource.password=${3:developer}",
+			"quarkus.datasource.jdbc.url=${4|jdbc:mariadb://localhost:3306/mydb,jdbc:mysql://localhost:3306/test,jdbc:h2:mem:mydb,jdbc:postgresql://localhost:5432/mydb,jdbc:derby://localhost:1527/mydb,jdbc:sqlserver://localhost:1433;databaseName=mydb|}",
+			"quarkus.datasource.jdbc.min-size=${5:5}",
+			"quarkus.datasource.jdbc.max-size=${6:15}",
+			"quarkus.hibernate-orm.database.generation=${7|none,drop-and-create,create,drop,update|}"
+		],
+		"description": "Configure Quarkus datasource",
+		"context": {
+			"dependency": "quarkus-hibernate-orm"
+		}
+	},
 	"Add datasource properties": {
 		"prefix": "qds",
 		"body": [

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/resources/com/redhat/quarkus/snippets/quarkus-properties.json
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/resources/com/redhat/quarkus/snippets/quarkus-properties.json
@@ -2,11 +2,13 @@
 	"Add datasource properties": {
 		"prefix": "qds",
 		"body": [
-			"quarkus.datasource.url=${1|jdbc:mariadb://localhost:3306/mydb,jdbc:mysql://localhost:3306/test,jdbc:h2:mem:mydb,jdbc:postgresql://localhost:5432/mydb,jdbc:derby://localhost:1527/mydb,jdbc:sqlserver://localhost:1433;databaseName=mydb|}",
-			"quarkus.datasource.db-kind=${2|mariadb,mysql,h2,postgresql,derby,mssql|}",
-			"quarkus.datasource.username=${3:developer}",
-			"quarkus.datasource.password=${4:developer}",
-			"quarkus.hibernate-orm.database.generation=${5|none,drop-and-create,create,drop,update|}"
+			"quarkus.datasource.db-kind=${1|mariadb,mysql,h2,postgresql,derby,mssql|}",
+			"quarkus.datasource.username=${2:developer}",
+			"quarkus.datasource.password=${3:developer}",
+			"quarkus.datasource.jdbc.url=${4|jdbc:mariadb://localhost:3306/mydb,jdbc:mysql://localhost:3306/test,jdbc:h2:mem:mydb,jdbc:postgresql://localhost:5432/mydb,jdbc:derby://localhost:1527/mydb,jdbc:sqlserver://localhost:1433;databaseName=mydb|}",
+			"quarkus.datasource.jdbc.min-size=${5:5}",
+			"quarkus.datasource.jdbc.max-size=${6:15}",
+			"quarkus.hibernate-orm.database.generation=${7|none,drop-and-create,create,drop,update|}"
 		],
 		"description": "Configure Quarkus datasource",
 		"context": {

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/resources/com/redhat/quarkus/snippets/quarkus-properties.json
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/resources/com/redhat/quarkus/snippets/quarkus-properties.json
@@ -1,20 +1,4 @@
 {
-	"Add datasource properties for Hibernate ORM": {
-		"prefix": "qds",
-		"body": [
-			"quarkus.datasource.db-kind=${1|mariadb,mysql,h2,postgresql,derby,mssql|}",
-			"quarkus.datasource.username=${2:developer}",
-			"quarkus.datasource.password=${3:developer}",
-			"quarkus.datasource.jdbc.url=${4|jdbc:mariadb://localhost:3306/mydb,jdbc:mysql://localhost:3306/test,jdbc:h2:mem:mydb,jdbc:postgresql://localhost:5432/mydb,jdbc:derby://localhost:1527/mydb,jdbc:sqlserver://localhost:1433;databaseName=mydb|}",
-			"quarkus.datasource.jdbc.min-size=${5:5}",
-			"quarkus.datasource.jdbc.max-size=${6:15}",
-			"quarkus.hibernate-orm.database.generation=${7|none,drop-and-create,create,drop,update|}"
-		],
-		"description": "Configure Quarkus datasource",
-		"context": {
-			"dependency": "quarkus-hibernate-orm"
-		}
-	},
 	"Add datasource properties": {
 		"prefix": "qds",
 		"body": [

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/resources/com/redhat/quarkus/snippets/quarkus-properties.json
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/resources/com/redhat/quarkus/snippets/quarkus-properties.json
@@ -7,8 +7,7 @@
 			"quarkus.datasource.password=${3:developer}",
 			"quarkus.datasource.jdbc.url=${4|jdbc:mariadb://localhost:3306/mydb,jdbc:mysql://localhost:3306/test,jdbc:h2:mem:mydb,jdbc:postgresql://localhost:5432/mydb,jdbc:derby://localhost:1527/mydb,jdbc:sqlserver://localhost:1433;databaseName=mydb|}",
 			"quarkus.datasource.jdbc.min-size=${5:5}",
-			"quarkus.datasource.jdbc.max-size=${6:15}",
-			"quarkus.hibernate-orm.database.generation=${7|none,drop-and-create,create,drop,update|}"
+			"quarkus.datasource.jdbc.max-size=${6:15}"
 		],
 		"description": "Configure Quarkus datasource",
 		"context": {

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/resources/com/redhat/quarkus/snippets/quarkus-properties.json
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/resources/com/redhat/quarkus/snippets/quarkus-properties.json
@@ -26,15 +26,5 @@
 		"context": {
 			"dependency": "quarkus-jaeger"
 		}
-	},
-	"Add Hibernate ORM datasource properties": {
-		"prefix": "qhormd",
-		"body": [
-			"quarkus.hibernate-orm.database.generation=${5|none,drop-and-create,create,drop,update|}"
-		],
-		"description": "Configure Quarkus Hibernate ORM datasource",
-		"context": {
-			"dependency": "quarkus-hibernate-orm"
-		}
 	}
 }

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesCompletionTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesCompletionTest.java
@@ -327,14 +327,4 @@ public class ApplicationPropertiesCompletionTest {
 		assertCompletionWithDependencies(value, 0, new String[]{});
 	}
 
-	@Test
-	public void snippetCompletionHibernateORM() throws BadLocationException {
-		String value = "qhormd|";
-		assertCompletionWithDependencies(value, null, new String[] {"quarkus-hibernate-orm"},
-				c("qhormd",
-				"quarkus.hibernate-orm.database.generation=${5|none,drop-and-create,create,drop,update|}",
-				r(0, 0, 6)));
-		assertCompletionWithDependencies(value, 0, new String[]{});
-	}
-
 }

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesCompletionTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesCompletionTest.java
@@ -12,6 +12,7 @@ package com.redhat.microprofile.services;
 import static com.redhat.microprofile.services.MicroProfileAssert.c;
 import static com.redhat.microprofile.services.MicroProfileAssert.r;
 import static com.redhat.microprofile.services.MicroProfileAssert.testCompletionFor;
+import static com.redhat.microprofile.services.MicroProfileAssert.assertCompletionWithDependencies;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -296,6 +297,44 @@ public class ApplicationPropertiesCompletionTest {
 		testCompletionFor(value, false, true, c("quarkus.http.cors", "quarkus.http.cors = false", r(0, 0, 0)));
 		testCompletionFor(value, true, true,
 				c("quarkus.http.cors", "quarkus.http.cors = ${1|false,true|}", r(0, 0, 0)));
+	}
+	
+	@Test
+	public void snippetCompletionDatasource() throws BadLocationException {
+		String value = "qds|";
+		assertCompletionWithDependencies(value, null, new String[] {"quarkus-agroal"},
+				c("qds",
+				"quarkus.datasource.db-kind=${1|mariadb,mysql,h2,postgresql,derby,mssql|}" + System.lineSeparator() +
+				"quarkus.datasource.username=${2:developer}" + System.lineSeparator() +
+				"quarkus.datasource.password=${3:developer}" + System.lineSeparator() +
+				"quarkus.datasource.jdbc.url=${4|jdbc:mariadb://localhost:3306/mydb,jdbc:mysql://localhost:3306/test,jdbc:h2:mem:mydb,jdbc:postgresql://localhost:5432/mydb,jdbc:derby://localhost:1527/mydb,jdbc:sqlserver://localhost:1433;databaseName=mydb|}" + System.lineSeparator() +
+				"quarkus.datasource.jdbc.min-size=${5:5}" + System.lineSeparator() +
+				"quarkus.datasource.jdbc.max-size=${6:15}",
+				r(0, 0, 3)));
+		assertCompletionWithDependencies(value, 0, new String[]{});
+	}
+
+	@Test
+	public void snippetCompletionJaeger() throws BadLocationException {
+		String value = "qj|";
+		assertCompletionWithDependencies(value, null, new String[] {"quarkus-jaeger"},
+				c("qj",
+				"quarkus.jaeger.service-name=${1:myservice}" + System.lineSeparator() +
+				"quarkus.jaeger.sampler-type=${2:const}" + System.lineSeparator() +
+				"quarkus.jaeger.sampler-param=${3:1}" + System.lineSeparator() +
+				"quarkus.jaeger.endpoint=${4:http://localhost:14268/api/traces}",
+				r(0, 0, 2)));
+		assertCompletionWithDependencies(value, 0, new String[]{});
+	}
+
+	@Test
+	public void snippetCompletionHibernateORM() throws BadLocationException {
+		String value = "qhormd|";
+		assertCompletionWithDependencies(value, null, new String[] {"quarkus-hibernate-orm"},
+				c("qhormd",
+				"quarkus.hibernate-orm.database.generation=${5|none,drop-and-create,create,drop,update|}",
+				r(0, 0, 6)));
+		assertCompletionWithDependencies(value, 0, new String[]{});
 	}
 
 }


### PR DESCRIPTION
Added the suggested fields to the datasource snippet. Moved the Hibernate ORM portion of the snippet to a separate snippet that only shows up if Hibernate ORM is used by the Quarkus project. Fixes #316.