### PR TITLE
Fix build failure and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ This project contains:
 
  * [MicroProfile JDT LS Extensions](https://github.com/redhat-developer/quarkus-ls/tree/master/microprofile.jdt)
  * [MicroProfile Language Server](https://github.com/redhat-developer/quarkus-ls/tree/master/microprofile.ls)
+
+ You can build all projects at once by running the `buildAll.sh` script (`buildAll.bat` on Windows).

--- a/buildAll.bat
+++ b/buildAll.bat
@@ -1,0 +1,4 @@
+cd microprofile.jdt && .\mvnw.cmd clean verify ^
+&& cd ..\microprofile.ls\com.redhat.microprofile.ls && .\mvnw.cmd clean install ^
+&& cd ..\..\quarkus.ls.ext\com.redhat.quarkus.ls && .\mvnw.cmd clean verify ^
+&& cd ..\..

--- a/buildAll.sh
+++ b/buildAll.sh
@@ -1,0 +1,4 @@
+cd microprofile.jdt && ./mvnw clean verify \
+&& cd ../microprofile.ls/com.redhat.microprofile.ls && ./mvnw clean install \
+&& cd ../../quarkus.ls.ext/com.redhat.quarkus.ls && ./mvnw clean verify \
+&& cd ../..

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/projects/gradle/empty-gradle-project/gradle/wrapper/gradle-wrapper.properties
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/projects/gradle/empty-gradle-project/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/microprofile.jdt/com.redhat.microprofile.jdt.test/projects/gradle/quarkus-gradle-project/gradle/wrapper/gradle-wrapper.properties
+++ b/microprofile.jdt/com.redhat.microprofile.jdt.test/projects/gradle/quarkus-gradle-project/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/microprofile.ls/com.redhat.microprofile.ls/pom.xml
+++ b/microprofile.ls/com.redhat.microprofile.ls/pom.xml
@@ -1,4 +1,4 @@
-	<project xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/microprofile.ls/com.redhat.microprofile.ls/pom.xml
+++ b/microprofile.ls/com.redhat.microprofile.ls/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
+	<project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
@@ -73,6 +73,18 @@
 						<id>parse-version</id>
 						<goals>
 							<goal>parse-version</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.2.0</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/snippets/SnippetContextForProperties.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/snippets/SnippetContextForProperties.java
@@ -60,8 +60,8 @@ public class SnippetContextForProperties implements ISnippetContext<Set<String>>
 	}
 
 	@Override
-	public boolean isMatch(Set<String> dependencys) {
-		return dependencys.contains(dependency);
+	public boolean isMatch(Set<String> dependencies) {
+		return dependencies != null && dependencies.contains(dependency);
 	}
 
 	private static class SnippetContextForPropertiesAdapter extends TypeAdapter<SnippetContextForProperties> {

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/commons/JavaVersion.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/commons/JavaVersion.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.microprofile.commons;
+
+/**
+ * Java version utility class
+ * 
+ * @author Fred Bricon
+ *
+ */
+public class JavaVersion {
+	/**
+	 * Current Java specification version running in this JVM
+	 */
+	public static final int CURRENT;
+
+	private JavaVersion() {
+		//no public instantiation
+	}
+	
+	static {
+		// Java > 1.8 have better API than this. See java.lang.Runtime.version()
+		String version = System.getProperty("java.specification.version");
+		if (version.startsWith("1.")) {
+			version = version.substring(2);
+		}
+		CURRENT = Integer.parseInt(version);
+	}
+	
+}

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesCompletionTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesCompletionTest.java
@@ -298,33 +298,5 @@ public class ApplicationPropertiesCompletionTest {
 		testCompletionFor(value, true, true,
 				c("quarkus.http.cors", "quarkus.http.cors = ${1|false,true|}", r(0, 0, 0)));
 	}
-	
-	@Test
-	public void snippetCompletionDatasource() throws BadLocationException {
-		String value = "qds|";
-		assertCompletionWithDependencies(value, null, new String[] {"quarkus-agroal"},
-				c("qds",
-				"quarkus.datasource.db-kind=${1|mariadb,mysql,h2,postgresql,derby,mssql|}" + System.lineSeparator() +
-				"quarkus.datasource.username=${2:developer}" + System.lineSeparator() +
-				"quarkus.datasource.password=${3:developer}" + System.lineSeparator() +
-				"quarkus.datasource.jdbc.url=${4|jdbc:mariadb://localhost:3306/mydb,jdbc:mysql://localhost:3306/test,jdbc:h2:mem:mydb,jdbc:postgresql://localhost:5432/mydb,jdbc:derby://localhost:1527/mydb,jdbc:sqlserver://localhost:1433;databaseName=mydb|}" + System.lineSeparator() +
-				"quarkus.datasource.jdbc.min-size=${5:5}" + System.lineSeparator() +
-				"quarkus.datasource.jdbc.max-size=${6:15}",
-				r(0, 0, 3)));
-		assertCompletionWithDependencies(value, 0, new String[]{});
-	}
-
-	@Test
-	public void snippetCompletionJaeger() throws BadLocationException {
-		String value = "qj|";
-		assertCompletionWithDependencies(value, null, new String[] {"quarkus-jaeger"},
-				c("qj",
-				"quarkus.jaeger.service-name=${1:myservice}" + System.lineSeparator() +
-				"quarkus.jaeger.sampler-type=${2:const}" + System.lineSeparator() +
-				"quarkus.jaeger.sampler-param=${3:1}" + System.lineSeparator() +
-				"quarkus.jaeger.endpoint=${4:http://localhost:14268/api/traces}",
-				r(0, 0, 2)));
-		assertCompletionWithDependencies(value, 0, new String[]{});
-	}
 
 }

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesDiagnosticsTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/ApplicationPropertiesDiagnosticsTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.Test;
 
+import com.redhat.microprofile.commons.JavaVersion;
 import com.redhat.microprofile.commons.MicroProfileProjectInfo;
 import com.redhat.microprofile.commons.metadata.ConverterKind;
 import com.redhat.microprofile.commons.metadata.ItemHint;
@@ -697,6 +698,7 @@ public class ApplicationPropertiesDiagnosticsTest {
 		
 		String ls = System.lineSeparator();
 		value = "mp.opentracing.server.skip-pattern=(";
+
 		testDiagnosticsFor(value, projectInfo, settings, //
 				d(0, 35, 36, "Unclosed group near index 1" + ls + "(" + ls + "",
 						DiagnosticSeverity.Error, ValidationType.value));
@@ -712,9 +714,16 @@ public class ApplicationPropertiesDiagnosticsTest {
 						DiagnosticSeverity.Error, ValidationType.value));
 
 		value = "mp.opentracing.server.skip-pattern={";
+		
+		StringBuilder message = new StringBuilder("Illegal repetition");
+		if (JavaVersion.CURRENT > 12) {
+			message.append(" near index 1");
+		}
+		message.append(ls).append("{").append(ls);
+		
 		testDiagnosticsFor(value, projectInfo, settings, //
-				d(0, 35, 36, "Illegal repetition" + ls + "{" + ls,
-						DiagnosticSeverity.Error, ValidationType.value));
+				d(0, 35, 36, message.toString(),
+						DiagnosticSeverity.Error, ValidationType.value));			
 	}
 
 	@Test

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/MicroProfileAssert.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/MicroProfileAssert.java
@@ -474,8 +474,7 @@ public class MicroProfileAssert {
 	}
 
 	public static void assertDiagnostics(List<Diagnostic> actual, List<Diagnostic> expected) {
-		List<Diagnostic> received = actual;
-		Assert.assertEquals("Unexpected diagnostics:\n" + actual, expected, received);
+		Assert.assertEquals("Unexpected diagnostics:\n", expected, actual);
 	}
 
 	public static Diagnostic d(int line, int startCharacter, int endCharacter, String message,

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/MicroProfileAssert.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/services/MicroProfileAssert.java
@@ -12,6 +12,7 @@ package com.redhat.microprofile.services;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -269,7 +270,7 @@ public class MicroProfileAssert {
 		assertCompletions(actual, expectedCount, expectedItems);
 	}
 	
-	public static void assertCompletionWithDependencies(String value, Integer expectedCount, String[] dependencies, CompletionItem... expectedItems) {
+	public static void assertCompletionWithDependencies(String value, Integer expectedCount, Collection<String> dependencies, CompletionItem... expectedItems) {
 		int offset = value.indexOf('|');
 		value = value.substring(0, offset) + value.substring(offset + 1);
 		TextDocumentSnippetRegistry registry = new TextDocumentSnippetRegistry(LanguageId.properties.name());
@@ -277,7 +278,7 @@ public class MicroProfileAssert {
 		List<CompletionItem> items = registry.getCompletionItems(document, offset, true, context -> {
 			if (context instanceof SnippetContextForProperties) {
 				SnippetContextForProperties contextProperties = (SnippetContextForProperties) context;
-				return contextProperties.isMatch(new HashSet<>(Arrays.asList(dependencies)));
+				return contextProperties.isMatch(new HashSet<>(dependencies));
 			}
 			return false;
 		});

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/pom.xml
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/pom.xml
@@ -154,6 +154,13 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.redhat.microprofile</groupId>
+			<artifactId>com.redhat.microprofile.ls</artifactId>
+			<classifier>tests</classifier>
+			<version>${microprofile.ls.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/ls/ApplicationPropertiesCompletionTest.java
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/ls/ApplicationPropertiesCompletionTest.java
@@ -12,6 +12,8 @@ package com.redhat.quarkus.ls;
 import static com.redhat.microprofile.services.MicroProfileAssert.assertCompletionWithDependencies;
 import static com.redhat.microprofile.services.MicroProfileAssert.c;
 import static com.redhat.microprofile.services.MicroProfileAssert.r;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
 
 import org.junit.Test;
 
@@ -29,7 +31,7 @@ public class ApplicationPropertiesCompletionTest {
 	@Test
 	public void snippetCompletionDatasource() throws BadLocationException {
 		String value = "qds|";
-		assertCompletionWithDependencies(value, null, new String[] {"quarkus-agroal"},
+		assertCompletionWithDependencies(value, null, singleton("quarkus-agroal"),
 				c("qds",
 				"quarkus.datasource.db-kind=${1|mariadb,mysql,h2,postgresql,derby,mssql|}" + System.lineSeparator() +
 				"quarkus.datasource.username=${2:developer}" + System.lineSeparator() +
@@ -38,20 +40,20 @@ public class ApplicationPropertiesCompletionTest {
 				"quarkus.datasource.jdbc.min-size=${5:5}" + System.lineSeparator() +
 				"quarkus.datasource.jdbc.max-size=${6:15}",
 				r(0, 0, 3)));
-		assertCompletionWithDependencies(value, 0, new String[]{});
+		assertCompletionWithDependencies(value, 0, emptySet());
 	}
 
 	@Test
 	public void snippetCompletionJaeger() throws BadLocationException {
 		String value = "qj|";
-		assertCompletionWithDependencies(value, null, new String[] {"quarkus-jaeger"},
+		assertCompletionWithDependencies(value, null, singleton("quarkus-jaeger"),
 				c("qj",
 				"quarkus.jaeger.service-name=${1:myservice}" + System.lineSeparator() +
 				"quarkus.jaeger.sampler-type=${2:const}" + System.lineSeparator() +
 				"quarkus.jaeger.sampler-param=${3:1}" + System.lineSeparator() +
 				"quarkus.jaeger.endpoint=${4:http://localhost:14268/api/traces}",
 				r(0, 0, 2)));
-		assertCompletionWithDependencies(value, 0, new String[]{});
+		assertCompletionWithDependencies(value, 0, emptySet());
 	}
 
 }

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/ls/ApplicationPropertiesCompletionTest.java
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/ls/ApplicationPropertiesCompletionTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+0* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.ls;
+
+import static com.redhat.microprofile.services.MicroProfileAssert.assertCompletionWithDependencies;
+import static com.redhat.microprofile.services.MicroProfileAssert.c;
+import static com.redhat.microprofile.services.MicroProfileAssert.r;
+
+import org.junit.Test;
+
+import com.redhat.microprofile.ls.commons.BadLocationException;
+
+/**
+ * Test with completion in 'application.properties' file.
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class ApplicationPropertiesCompletionTest {
+
+	
+	@Test
+	public void snippetCompletionDatasource() throws BadLocationException {
+		String value = "qds|";
+		assertCompletionWithDependencies(value, null, new String[] {"quarkus-agroal"},
+				c("qds",
+				"quarkus.datasource.db-kind=${1|mariadb,mysql,h2,postgresql,derby,mssql|}" + System.lineSeparator() +
+				"quarkus.datasource.username=${2:developer}" + System.lineSeparator() +
+				"quarkus.datasource.password=${3:developer}" + System.lineSeparator() +
+				"quarkus.datasource.jdbc.url=${4|jdbc:mariadb://localhost:3306/mydb,jdbc:mysql://localhost:3306/test,jdbc:h2:mem:mydb,jdbc:postgresql://localhost:5432/mydb,jdbc:derby://localhost:1527/mydb,jdbc:sqlserver://localhost:1433;databaseName=mydb|}" + System.lineSeparator() +
+				"quarkus.datasource.jdbc.min-size=${5:5}" + System.lineSeparator() +
+				"quarkus.datasource.jdbc.max-size=${6:15}",
+				r(0, 0, 3)));
+		assertCompletionWithDependencies(value, 0, new String[]{});
+	}
+
+	@Test
+	public void snippetCompletionJaeger() throws BadLocationException {
+		String value = "qj|";
+		assertCompletionWithDependencies(value, null, new String[] {"quarkus-jaeger"},
+				c("qj",
+				"quarkus.jaeger.service-name=${1:myservice}" + System.lineSeparator() +
+				"quarkus.jaeger.sampler-type=${2:const}" + System.lineSeparator() +
+				"quarkus.jaeger.sampler-param=${3:1}" + System.lineSeparator() +
+				"quarkus.jaeger.endpoint=${4:http://localhost:14268/api/traces}",
+				r(0, 0, 2)));
+		assertCompletionWithDependencies(value, 0, new String[]{});
+	}
+
+}


### PR DESCRIPTION
- moved quarkus snippet tests to quarkus.ls
- generated microprofile.ls test jar so test classes can be reused in
quarkus tests
- fixed failing tests when running on Java > 12
- added buildAll scripts for convenience

Signed-off-by: Fred Bricon <fbricon@gmail.com>
