### PR TITLE
Rename quarkus settings/commands

### DIFF
--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/commons/client/CommandKind.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/commons/client/CommandKind.java
@@ -23,21 +23,21 @@ public class CommandKind {
 	/**
 	 * Client command to open references
 	 */
-	public static final String COMMAND_REFERENCES = "quarkus.command.references";
+	public static final String COMMAND_REFERENCES = "microprofile.command.references";
 
 	/**
 	 * Client command to open implementations
 	 */
-	public static final String COMMAND_IMPLEMENTATIONS = "quarkus.command.implementations";
+	public static final String COMMAND_IMPLEMENTATIONS = "microprofile.command.implementations";
 
 	/**
 	 * Client command to open URI
 	 */
-	public static final String COMMAND_OPEN_URI = "quarkus.command.open.uri";
+	public static final String COMMAND_OPEN_URI = "microprofile.command.open.uri";
 
 	/**
 	 * Client command to update client configuration settings
 	 */
-	public static final String COMMAND_CONFIGURATION_UPDATE = "quarkus.command.configuration.update";
+	public static final String COMMAND_CONFIGURATION_UPDATE = "microprofile.command.configuration.update";
 
 }

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/AllMicroProfileSettings.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/AllMicroProfileSettings.java
@@ -15,9 +15,9 @@ import com.google.gson.annotations.JsonAdapter;
 import com.redhat.microprofile.utils.JSONUtility;
 
 /**
- * Represents all settings under the 'quarkus' key
+ * Represents all settings under the 'microprofile' key
  * 
- * { 'quarkus': {...} }
+ * { 'microprofile': {...} }
  */
 public class AllMicroProfileSettings {
 
@@ -33,20 +33,20 @@ public class AllMicroProfileSettings {
 	}
 
 	@JsonAdapter(JsonElementTypeAdapter.Factory.class)
-	private Object quarkus;
+	private Object microprofile;
 
 	/**
-	 * @return the quarkus
+	 * @return the microprofile
 	 */
-	public Object getQuarkus() {
-		return quarkus;
+	public Object getMicroProfile() {
+		return microprofile;
 	}
 
 	/**
-	 * @param quarkus the quarkus to set
+	 * @param microprofile the microprofile to set
 	 */
-	public void setQuarkus(Object quarkus) {
-		this.quarkus = quarkus;
+	public void setQuarkus(Object microprofile) {
+		this.microprofile = microprofile;
 	}
 
 	public static Object getMicroProfileToolsSettings(Object initializationOptionsSettings) {
@@ -54,7 +54,7 @@ public class AllMicroProfileSettings {
 		if (rootSettings == null) {
 			return null;
 		}
-		ToolsSettings quarkusSettings = JSONUtility.toModel(rootSettings.getQuarkus(), ToolsSettings.class);
-		return quarkusSettings != null ? quarkusSettings.getTools() : null;
+		ToolsSettings microprofileSettings = JSONUtility.toModel(rootSettings.getMicroProfile(), ToolsSettings.class);
+		return microprofileSettings != null ? microprofileSettings.getTools() : null;
 	}
 }

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/settings/SettingsTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/settings/SettingsTest.java
@@ -25,14 +25,10 @@ public class SettingsTest {
 
 	private final String json = "{\r\n" + 
 			"    \"settings\": {\r\n" + 
-			"        \"quarkus\": {\r\n" + 
+			"        \"microprofile\": {\r\n" + 
 			"            \"tools\": {\r\n" + 
 			"                \"trace\": {\r\n" + 
 			"                    \"server\": \"verbose\"\r\n" + 
-			"                },\r\n" + 
-			"                \"starter\": {\r\n" + 
-			"                    \"api\": \"http://code.quarkus.io/api\",\r\n" + 
-			"                    \"defaults\": {}\r\n" + 
 			"                },\r\n" + 
 			"                \"symbols\": {\r\n" + 
 			"                    \"showAsTree\": true\r\n" + 


### PR DESCRIPTION
Fixes #325 

Marking this PR are as a draft for now since these settings will need to be either be renamed in vscode-quarkus or removed once there is a published vscode-microprofile that starts the LS.
