### PR TITLE
vscode-quarkus should not be a Java formatter

### DIFF
--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/capabilities/IMicroProfileRegistrationConfiguration.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/capabilities/IMicroProfileRegistrationConfiguration.java
@@ -1,0 +1,29 @@
+/**
+ *  Copyright (c) 2019-2020 Red Hat, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *  Red Hat Inc. - initial API and implementation
+ */
+package com.redhat.microprofile.settings.capabilities;
+
+import org.eclipse.lsp4j.Registration;
+
+/**
+ * LSP Registration configuration API.
+ *
+ */
+public interface IMicroProfileRegistrationConfiguration {
+
+	/**
+	 * Configure the given LSP registration.
+	 * 
+	 * @param registration the registration to configure.
+	 */
+	public void configure(Registration registration);
+}

--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/capabilities/ServerCapabilitiesConstants.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/settings/capabilities/ServerCapabilitiesConstants.java
@@ -44,8 +44,9 @@ public class ServerCapabilitiesConstants {
 	public static final String CODE_ACTION_ID = UUID.randomUUID().toString();
 	public static final String CODE_LENS_ID = UUID.randomUUID().toString();
 
-	public static final CompletionOptions DEFAULT_COMPLETION_OPTIONS = new CompletionOptions(false, Arrays.asList(".",
-			"%", "=" /* triggered characters for properties file */ , "@" /* triggered characters for java snippets annotation */));
+	public static final CompletionOptions DEFAULT_COMPLETION_OPTIONS = new CompletionOptions(false,
+			Arrays.asList(".", "%", "=" /* triggered characters for properties file */ ,
+					"@" /* triggered characters for java snippets annotation */));
 
 	public static final CodeLensOptions DEFAULT_CODELENS_OPTIONS = new CodeLensOptions();
 }

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/capabilities/QuarkusRegistrationConfiguration.java
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/settings/capabilities/QuarkusRegistrationConfiguration.java
@@ -1,0 +1,46 @@
+/**
+ *  Copyright (c) 2019-2020 Red Hat, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *  Red Hat Inc. - initial API and implementation
+ */
+package com.redhat.quarkus.settings.capabilities;
+
+import static com.redhat.microprofile.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_FORMATTING;
+import static com.redhat.microprofile.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_RANGE_FORMATTING;
+
+import org.eclipse.lsp4j.DocumentFilter;
+import org.eclipse.lsp4j.Registration;
+import org.eclipse.lsp4j.TextDocumentRegistrationOptions;
+
+import com.redhat.microprofile.settings.capabilities.IMicroProfileRegistrationConfiguration;
+
+/**
+ * Specific Quarkus LSP Registration configuration
+ *
+ */
+public class QuarkusRegistrationConfiguration implements IMicroProfileRegistrationConfiguration {
+
+	@Override
+	public void configure(Registration registration) {
+		switch (registration.getMethod()) {
+		case TEXT_DOCUMENT_FORMATTING:
+		case TEXT_DOCUMENT_RANGE_FORMATTING:
+			// add "quarkus-properties" as language document filter for formatting
+			((TextDocumentRegistrationOptions) registration.getRegisterOptions()).getDocumentSelector()
+					.add(new DocumentFilter("quarkus-properties", null, null));
+			break;
+		default:
+			break;
+
+		}
+
+	}
+
+}

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/resources/META-INF/services/com.redhat.microprofile.settings.capabilities.IMicroProfileRegistrationConfiguration
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/resources/META-INF/services/com.redhat.microprofile.settings.capabilities.IMicroProfileRegistrationConfiguration
@@ -1,0 +1,1 @@
+com.redhat.quarkus.settings.capabilities.QuarkusRegistrationConfiguration


### PR DESCRIPTION
vscode-quarkus should not be a Java formatter

Fixes https://github.com/redhat-developer/vscode-quarkus/issues/166

Signed-off-by: azerr <azerr@redhat.com>