### PR TITLE
Run LSP4J callback methods in separate thread

### DIFF
--- a/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/MicroProfileTextDocumentService.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/main/java/com/redhat/microprofile/ls/MicroProfileTextDocumentService.java
@@ -65,6 +65,8 @@ public class MicroProfileTextDocumentService implements TextDocumentService {
 	private final JavaTextDocumentService javaTextDocumentService;
 	private SharedSettings sharedSettings;
 
+	private static final CompletableFuture COMPLETED = CompletableFuture.completedFuture(null);
+
 	public MicroProfileTextDocumentService(MicroProfileLanguageServer quarkusLanguageServer) {
 		textDocumentServicesMap = new HashMap<>();
 		this.sharedSettings = new SharedSettings();
@@ -96,108 +98,132 @@ public class MicroProfileTextDocumentService implements TextDocumentService {
 
 	@Override
 	public void didOpen(DidOpenTextDocumentParams params) {
-		TextDocumentService service = getTextDocumentService(params.getTextDocument());
-		if (service != null) {
-			service.didOpen(params);
-		}
+		CompletableFuture.runAsync(() -> {
+			TextDocumentService service = getTextDocumentService(params.getTextDocument());
+			if (service != null) {
+				service.didOpen(params);
+			}
+		});
 	}
 
 	@Override
 	public void didChange(DidChangeTextDocumentParams params) {
-		TextDocumentService service = getTextDocumentService(params.getTextDocument());
-		if (service != null) {
-			service.didChange(params);
-		}
+		CompletableFuture.runAsync(() -> {
+			TextDocumentService service = getTextDocumentService(params.getTextDocument());
+			if (service != null) {
+				service.didChange(params);
+			}
+		});
 	}
 
 	@Override
 	public void didClose(DidCloseTextDocumentParams params) {
-		TextDocumentService service = getTextDocumentService(params.getTextDocument());
-		if (service != null) {
-			service.didClose(params);
-		}
+		CompletableFuture.runAsync(() -> {
+			TextDocumentService service = getTextDocumentService(params.getTextDocument());
+			if (service != null) {
+				service.didClose(params);
+			}
+		});
 	}
 
 	@Override
 	public void didSave(DidSaveTextDocumentParams params) {
-		TextDocumentService service = getTextDocumentService(params.getTextDocument());
-		if (service != null) {
-			service.didSave(params);
-		}
+		CompletableFuture.runAsync(() -> {
+			TextDocumentService service = getTextDocumentService(params.getTextDocument());
+			if (service != null) {
+				service.didSave(params);
+			}
+		});
 	}
 
 	@Override
 	public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(CompletionParams position) {
-		TextDocumentService service = getTextDocumentService(position.getTextDocument());
-		if (service != null) {
-			return service.completion(position);
-		}
-		return CompletableFuture.completedFuture(null);
+		return COMPLETED.thenComposeAsync(it -> {
+			TextDocumentService service = getTextDocumentService(position.getTextDocument());
+			if (service != null) {
+				return service.completion(position);
+			}
+			return CompletableFuture.completedFuture(null);
+		});
 	}
 
 	@Override
 	public CompletableFuture<Hover> hover(HoverParams params) {
-		TextDocumentService service = getTextDocumentService(params.getTextDocument());
-		if (service != null) {
-			return service.hover(params);
-		}
-		return CompletableFuture.completedFuture(null);
+		return COMPLETED.thenComposeAsync(it -> {
+			TextDocumentService service = getTextDocumentService(params.getTextDocument());
+			if (service != null) {
+				return service.hover(params);
+			}
+			return CompletableFuture.completedFuture(null);
+		});
 	}
 
 	@Override
 	public CompletableFuture<List<Either<SymbolInformation, DocumentSymbol>>> documentSymbol(
 			DocumentSymbolParams params) {
-		TextDocumentService service = getTextDocumentService(params.getTextDocument());
-		if (service != null) {
-			return service.documentSymbol(params);
-		}
-		return CompletableFuture.completedFuture(null);
+		return COMPLETED.thenComposeAsync(it -> {
+			TextDocumentService service = getTextDocumentService(params.getTextDocument());
+			if (service != null) {
+				return service.documentSymbol(params);
+			}
+			return CompletableFuture.completedFuture(null);
+		});
 	}
 
 	@Override
 	public CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>> definition(
 			DefinitionParams params) {
-		TextDocumentService service = getTextDocumentService(params.getTextDocument());
-		if (service != null) {
-			return service.definition(params);
-		}
-		return CompletableFuture.completedFuture(null);
+		return COMPLETED.thenComposeAsync(it -> {
+			TextDocumentService service = getTextDocumentService(params.getTextDocument());
+			if (service != null) {
+				return service.definition(params);
+			}
+			return CompletableFuture.completedFuture(null);
+		});
 	}
 
 	@Override
 	public CompletableFuture<List<? extends TextEdit>> formatting(DocumentFormattingParams params) {
-		TextDocumentService service = getTextDocumentService(params.getTextDocument());
-		if (service != null) {
-			return service.formatting(params);
-		}
-		return CompletableFuture.completedFuture(null);
+		return COMPLETED.thenComposeAsync(it -> {
+			TextDocumentService service = getTextDocumentService(params.getTextDocument());
+			if (service != null) {
+				return service.formatting(params);
+			}
+			return CompletableFuture.completedFuture(null);
+		});
 	}
 
 	@Override
 	public CompletableFuture<List<? extends TextEdit>> rangeFormatting(DocumentRangeFormattingParams params) {
-		TextDocumentService service = getTextDocumentService(params.getTextDocument());
-		if (service != null) {
-			return service.rangeFormatting(params);
-		}
-		return CompletableFuture.completedFuture(null);
+		return COMPLETED.thenComposeAsync(it -> {
+			TextDocumentService service = getTextDocumentService(params.getTextDocument());
+			if (service != null) {
+				return service.rangeFormatting(params);
+			}
+			return CompletableFuture.completedFuture(null);
+		});
 	}
 
 	@Override
 	public CompletableFuture<List<Either<Command, CodeAction>>> codeAction(CodeActionParams params) {
-		TextDocumentService service = getTextDocumentService(params.getTextDocument());
-		if (service != null) {
-			return service.codeAction(params);
-		}
-		return CompletableFuture.completedFuture(null);
+		return COMPLETED.thenComposeAsync(it -> {
+			TextDocumentService service = getTextDocumentService(params.getTextDocument());
+			if (service != null) {
+				return service.codeAction(params);
+			}
+			return CompletableFuture.completedFuture(null);
+		});
 	}
 
 	@Override
 	public CompletableFuture<List<? extends CodeLens>> codeLens(CodeLensParams params) {
-		TextDocumentService service = getTextDocumentService(params.getTextDocument());
-		if (service != null) {
-			return service.codeLens(params);
-		}
-		return CompletableFuture.completedFuture(null);
+		return COMPLETED.thenComposeAsync(it -> {
+			TextDocumentService service = getTextDocumentService(params.getTextDocument());
+			if (service != null) {
+				return service.codeLens(params);
+			}
+			return CompletableFuture.completedFuture(null);
+		});
 	}
 
 	public void propertiesChanged(MicroProfilePropertiesChangeEvent event) {

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/ls/MicroProfileLSTest.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/java/com/redhat/microprofile/ls/MicroProfileLSTest.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.microprofile.ls;
+
+import com.redhat.microprofile.commons.MicroProfileJavaProjectLabelsParams;
+import com.redhat.microprofile.commons.MicroProfileProjectInfo;
+import com.redhat.microprofile.commons.MicroProfileProjectInfoParams;
+import com.redhat.microprofile.commons.ProjectLabelInfoEntry;
+import com.redhat.microprofile.ls.api.MicroProfileLanguageClientAPI;
+import com.redhat.microprofile.ls.api.MicroProfileLanguageServerAPI;
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.jsonrpc.Launcher;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+
+public class MicroProfileLSTest {
+    private static class MyLanguageClient implements MicroProfileLanguageClientAPI {
+
+        private final CountDownLatch latch;
+
+        private MyLanguageClient(CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public CompletableFuture<MicroProfileProjectInfo> getProjectInfo(MicroProfileProjectInfoParams params) {
+            return null;
+        }
+
+        @Override
+        public void telemetryEvent(Object object) {
+            System.out.println("telemetryEvent called");
+        }
+
+        @Override
+        public void publishDiagnostics(PublishDiagnosticsParams diagnostics) {
+        }
+
+        @Override
+        public void showMessage(MessageParams messageParams) {
+            System.out.println("showMessage called");
+        }
+
+        @Override
+        public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams) {
+            return null;
+        }
+
+        @Override
+        public void logMessage(MessageParams message) {
+            System.out.println("MessageParams called");
+        }
+
+        @Override
+        public CompletableFuture<ProjectLabelInfoEntry> getJavaProjectlabels(MicroProfileJavaProjectLabelsParams javaParams) {
+            latch.countDown();
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private static Process p;
+
+    @BeforeClass
+    public static void init() throws IOException {
+        String javaHome = System.getProperty("java.home");
+        String classPath = System.getProperty("java.class.path");
+        ProcessBuilder builder = new ProcessBuilder();
+        p = builder.command(javaHome + File.separatorChar + "bin" + File.separatorChar + "java", "-classpath", classPath, MicroProfileServerLauncher.class.getName()).start();
+    }
+
+    @AfterClass
+    public static void shutdown() {
+        p.destroy();
+    }
+
+    private Launcher<MicroProfileLanguageServerAPI> getLauncher(CountDownLatch latch) {
+        MyLanguageClient client = new MyLanguageClient(latch);
+        Launcher<MicroProfileLanguageServerAPI> launcher = Launcher.createLauncher(client, MicroProfileLanguageServerAPI.class, p.getInputStream(), p.getOutputStream(), Executors.newCachedThreadPool(), it-> it);
+        launcher.startListening();
+        return launcher;
+    }
+
+    @Test
+    public void burstDidOpen() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(10);
+        Launcher<MicroProfileLanguageServerAPI> launcher = getLauncher(latch);
+        CompletableFuture.runAsync(() -> {
+            for (int i=1; i < 11;i++) {
+                try {
+                    URL url = MicroProfileLSTest.class.getResource("Class" + i + ".java");
+                    byte[] content = Files.readAllBytes(Paths.get(url.toURI()));
+                    TextDocumentItem item = new TextDocumentItem(url.toURI().toString(), "java", 0, new String(content, 0, content.length, StandardCharsets.UTF_8));
+                    launcher.getRemoteProxy().getTextDocumentService().didOpen(new DidOpenTextDocumentParams(item));
+                } catch (IOException e) {
+                } catch (URISyntaxException e) {
+                }
+            }
+        });
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+    }
+}

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class1.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class1.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.microprofile.ls;
+
+public class Class1 {
+}

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class10.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class10.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.microprofile.ls;
+
+public class Class10 {
+}

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class2.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class2.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.microprofile.ls;
+
+public class Class2 {
+}

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class3.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class3.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.microprofile.ls;
+
+public class Class3 {
+}

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class4.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class4.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.microprofile.ls;
+
+public class Class4 {
+}

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class5.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class5.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.microprofile.ls;
+
+public class Class5 {
+}

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class6.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class6.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.microprofile.ls;
+
+public class Class6 {
+}

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class7.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class7.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.microprofile.ls;
+
+public class Class7 {
+}

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class8.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class8.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.microprofile.ls;
+
+public class Class8 {
+}

--- a/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class9.java
+++ b/microprofile.ls/com.redhat.microprofile.ls/src/test/resources/com/redhat/microprofile/ls/Class9.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.microprofile.ls;
+
+public class Class9 {
+}


### PR DESCRIPTION
This is a POC to fix #338 

It is composed on purpose of 2 commits:
- the first one is a unit test that demonstrate the issue and should fail if you cherry-pick only this commit
- the second one is an example on how to update the LSP4J callback methods to make sure they run on a separate thread.

This PR is drafted because I think there are other part of the LS that needs to be updated as well

Fixes #338 