### PR TITLE
Remove jax-rs snippets

### DIFF
--- a/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/resources/com/redhat/quarkus/snippets/quarkus-java.json
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/resources/com/redhat/quarkus/snippets/quarkus-java.json
@@ -1,43 +1,4 @@
 {
-	"Quarkus - new resource class": {
-		"prefix": "qrc",
-		"body": [
-			"package ${1:packagename};",
-			"",
-			"import javax.ws.rs.GET;",
-			"import javax.ws.rs.Path;",
-			"import javax.ws.rs.Produces;",
-			"import javax.ws.rs.core.MediaType;",
-			"",
-			"@Path(\"${2:/path}\")",
-			"public class ${TM_FILENAME_BASE} {",
-			"",
-			"\t@GET",
-			"\t@Produces(MediaType.TEXT_PLAIN)",
-			"\tpublic String ${3:methodname}() {",
-			"\t\treturn \"hello\";",
-			"\t}",
-			"}"
-		],
-		"description": "Quarkus REST resource class",
-		"context": {
-			"type": "javax.ws.rs.GET"
-		}
-	},
-	"Quarkus - new resource method": {
-		"prefix": "qrm",
-		"body": [
-			"@GET",
-			"@Produces(MediaType.TEXT_PLAIN)",
-			"public String ${1:methodname}() {",
-			"\treturn \"hello\";",
-			"}"
-		],
-		"description": "Quarkus REST resource method",
-		"context": {
-			"type": "javax.ws.rs.GET"
-		}
-	},
 	"Quarkus - new test resource class": {
 		"prefix": "qtrc",
 		"body": [

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/ls/JavaTextDocumentSnippetRegistryTest.java
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/src/test/java/com/redhat/quarkus/ls/JavaTextDocumentSnippetRegistryTest.java
@@ -38,21 +38,21 @@ public class JavaTextDocumentSnippetRegistryTest {
     JavaTextDocumentSnippetRegistry registry = new JavaTextDocumentSnippetRegistry();
     Assert.assertFalse("Tests has Quarkus Java snippets", registry.getSnippets().isEmpty());
 
-    Optional<Snippet> qrcSnippet = findByPrefix("qrc", registry);
-    Assert.assertTrue("Tests has Quarkus - new resource class (qrc) snippets", qrcSnippet.isPresent());
+    Optional<Snippet> qrtcSnippet = findByPrefix("qtrc", registry);
+    Assert.assertTrue("Tests has Quarkus - new test resource class (qtrc) snippets", qrtcSnippet.isPresent());
 
-    ISnippetContext<?> context = qrcSnippet.get().getContext();
-    Assert.assertNotNull("Quarkus - new resource class (qrc) snippet has context", context);
+    ISnippetContext<?> context = qrtcSnippet.get().getContext();
+    Assert.assertNotNull("Quarkus - new test resource class (qtrc) snippet has context", context);
 
-    Assert.assertTrue("Quarkus - new resource class (qrc) snippet context is Java context", context instanceof SnippetContextForJava);
+    Assert.assertTrue("Quarkus - new test resource class (qtrc) snippet context is Java context", context instanceof SnippetContextForJava);
 
     ProjectLabelInfoEntry projectInfo = new ProjectLabelInfoEntry("", new ArrayList<>());
     boolean match = ((SnippetContextForJava) context).isMatch(projectInfo);
-    Assert.assertFalse("Project has no javax.ws.rs.GET type", match);
+    Assert.assertFalse("Project has no io.quarkus.test.junit.QuarkusTest type", match);
 
-    ProjectLabelInfoEntry projectInfo2 = new ProjectLabelInfoEntry("", Arrays.asList("javax.ws.rs.GET"));
+    ProjectLabelInfoEntry projectInfo2 = new ProjectLabelInfoEntry("", Arrays.asList("io.quarkus.test.junit.QuarkusTest"));
     boolean match2 = ((SnippetContextForJava) context).isMatch(projectInfo2);
-    Assert.assertTrue("Project has javax.ws.rs.GET type", match2);
+    Assert.assertTrue("Project has io.quarkus.test.junit.QuarkusTest type", match2);
   }
 
   private static Optional<Snippet> findByPrefix(String prefix, SnippetRegistry registry) {


### PR DESCRIPTION
Removes the jax-rs snippets that were included in quarkus-ls. Since they were moved to lsp4mp (See: https://github.com/eclipse/lsp4mp/pull/32)

Note that the snippets were renamed from `qrc` -> `jaxrc` and `qrm` -> `jaxrm` to be runtime agnostic. So this should probably be mentioned in release notes/changelog for vscode-quarkus.

Signed-off-by: Ryan Zegray <ryan.zegray@ibm.com>