### PR TITLE
Automatically infer package names when inserting class snippets

### DIFF
--- a/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/resources/com/redhat/quarkus/snippets/quarkus-java.json
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/resources/com/redhat/quarkus/snippets/quarkus-java.json
@@ -2,9 +2,7 @@
 	"Quarkus - new test resource class": {
 		"prefix": "qtrc",
 		"body": [
-			"package ${1:packagename};",
-			"",
-			"import io.quarkus.test.junit.QuarkusTest;",
+			"${packagename}import io.quarkus.test.junit.QuarkusTest;",
 			"import org.junit.jupiter.api.Test;",
 			"",
 			"import static io.restassured.RestAssured.given;",
@@ -32,9 +30,7 @@
 	"Quarkus - new native test resource class": {
 		"prefix": "qntrc",
 		"body": [
-			"package ${1:packagename};",
-			"",
-			"import io.quarkus.test.junit.SubstrateTest;",
+			"${packagename}import io.quarkus.test.junit.SubstrateTest;",
 			"",
 			"@SubstrateTest",
 			"public class ${TM_FILENAME_BASE} extends ${2:${TM_FILENAME_BASE/^Native(.*)IT/$1/}Test} {",


### PR DESCRIPTION
Automatically infer package names when inserting class snippets

See https://github.com/eclipse/lsp4mp/issues/60

Signed-off-by: azerr <azerr@redhat.com>