### PR TITLE
quarkus.hibernate-orm.database.generation values should be enumerated.

### DIFF
--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/QuarkusHibernateORMPropertyTest.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/QuarkusHibernateORMPropertyTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+* Copyright (c) 2020 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.microprofile.jdt.quarkus;
+
+
+import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertProperties;
+import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertPropertiesDuplicate;
+import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.p;
+
+import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
+import org.eclipse.lsp4mp.commons.MicroProfilePropertiesScope;
+import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest;
+import org.junit.Test;
+
+
+/**
+ * Test the availability of the Quarkus Hibernate ORM properties
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class QuarkusHibernateORMPropertyTest extends BasePropertiesManagerTest {
+
+	@Test
+	public void quarkusContainerImages() throws Exception {
+
+		MicroProfileProjectInfo infoFromClasspath = getMicroProfileProjectInfoFromMavenProject(
+				MavenProjectName.hibernate_orm_resteasy, MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES);
+
+		assertProperties(infoFromClasspath,
+
+				p("quarkus-hibernate-orm", "quarkus.hibernate-orm.database.generation", "java.lang.String",
+						"Select whether the database schema is generated or not."
+						+ "\n\n`drop-and-create` is awesome in development mode."
+						+ "\n\nAccepted values: `none`, `create`, `drop-and-create`, `drop`, `update`.", true,
+						"io.quarkus.hibernate.orm.deployment.HibernateOrmConfig.HibernateOrmConfigDatabase", "generation", null, 1,
+						"none"));
+
+		assertPropertiesDuplicate(infoFromClasspath);
+	}
+
+}

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/plugin.xml
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/plugin.xml
@@ -7,7 +7,8 @@
       <provider class="com.redhat.microprofile.jdt.internal.quarkus.providers.QuarkusConfigRootProvider" />
       <provider class="com.redhat.microprofile.jdt.internal.quarkus.providers.QuarkusConfigPropertiesProvider" />
       <provider class="com.redhat.microprofile.jdt.internal.quarkus.providers.QuarkusKubernetesProvider" />
-      <provider class="com.redhat.microprofile.jdt.internal.quarkus.providers.QuarkusContainerImagesProvider" />      
+      <provider class="com.redhat.microprofile.jdt.internal.quarkus.providers.QuarkusContainerImagesProvider" />
+      <provider class="com.redhat.microprofile.jdt.internal.quarkus.providers.QuarkusHibernateORMProvider" />
    </extension>
    
    <extension point="org.eclipse.lsp4mp.jdt.core.projectLabelProviders">

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/providers/QuarkusHibernateORMProvider.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/providers/QuarkusHibernateORMProvider.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+* Copyright (c) 2020 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+* 
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.microprofile.jdt.internal.quarkus.providers;
+
+/**
+ * Properties provider that provides static Quarkus Hibernate ORM properties
+ * 
+ * @author Angelo ZERR
+ * 
+ * @see https://github.com/eclipse/microprofile-health/blob/master/spec/src/main/asciidoc/protocol-wireformat.adoc
+ *
+ */
+public class QuarkusHibernateORMProvider extends AbstractStaticQuarkusPropertiesProvider {
+
+	public QuarkusHibernateORMProvider() {
+		super("/static-properties/quarkus-hibernate-orm-metadata.json");
+	}
+}

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/static-properties/quarkus-hibernate-orm-metadata.json
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/static-properties/quarkus-hibernate-orm-metadata.json
@@ -1,0 +1,29 @@
+{
+	"hints": [
+		{
+			"values": [
+				{
+					"value": "none",
+					"description": "Disable DDL handling."
+				},
+				{
+					"value": "create",
+					"description": "Create the schema and destroy previous data."
+				},
+				{
+					"value": "drop-and-create",
+					"description": "Drop and create the database at startup."
+				},
+				{
+					"value": "drop",
+					"description": "Drop the database."
+				},
+				{
+					"value": "update",
+					"description": "Update the schema if necessary."
+				}
+			],
+			"name": "quarkus.hibernate-orm.database.generation"
+		}
+	]
+}


### PR DESCRIPTION
- Fixes redhat-developer/vscode-quarkus#317

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>