### PR TITLE
Move application.properties and application.yaml support to quarkus-ls

### DIFF
--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.site/pom.xml
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.site/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>parent</artifactId>
 		<groupId>com.redhat.microprofile</groupId>
-		<version>0.10.2-SNAPSHOT</version>
+		<version>0.11.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>com.microprofile.quarkus.jdt.site</artifactId>
 	<packaging>eclipse-repository</packaging>

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/META-INF/MANIFEST.MF
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: quarkus.jdt.ls Test Plugin
 Bundle-SymbolicName: com.redhat.microprofile.jdt.quarkus.test
-Bundle-Version: 0.10.2.qualifier
+Bundle-Version: 0.11.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit,
  org.apache.commons.io,

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/pom.xml
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>parent</artifactId>
 		<groupId>com.redhat.microprofile</groupId>
-		<version>0.10.2-SNAPSHOT</version>
+		<version>0.11.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>com.redhat.microprofile.jdt.quarkus.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/QuarkusConfigPropertiesTest.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/QuarkusConfigPropertiesTest.java
@@ -25,9 +25,11 @@ import org.eclipse.lsp4mp.jdt.core.project.JDTMicroProfileProject;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.redhat.microprofile.jdt.internal.quarkus.providers.QuarkusConfigSourceProvider;
+
 /**
  * Test collection of Quarkus properties from @ConfigProperties
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -49,7 +51,7 @@ public class QuarkusConfigPropertiesTest extends BasePropertiesManagerTest {
 	public void configPropertiesNoDefaultNamingStrategy() throws Exception {
 		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_properties);
 		// no quarkus.arc.config-properties-default-naming-strategy
-		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE, "", javaProject);
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "", javaProject);
 
 		MicroProfileProjectInfo infoFromJavaSources = PropertiesManager.getInstance().getMicroProfileProjectInfo(
 				javaProject, MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES, ClasspathKind.SRC,
@@ -172,7 +174,7 @@ public class QuarkusConfigPropertiesTest extends BasePropertiesManagerTest {
 	public void configPropertiesVerbatimDefaultNamingStrategy() throws Exception {
 		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_properties);
 		// quarkus.arc.config-properties-default-naming-strategy = verbatim
-		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE,
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE,
 				"quarkus.arc.config-properties-default-naming-strategy = verbatim", javaProject);
 
 		MicroProfileProjectInfo infoFromJavaSources = PropertiesManager.getInstance().getMicroProfileProjectInfo(

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/QuarkusScheduledHoverTest.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/QuarkusScheduledHoverTest.java
@@ -26,6 +26,8 @@ import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest;
 import org.eclipse.lsp4mp.jdt.core.project.JDTMicroProfileProject;
 import org.junit.Test;
 
+import com.redhat.microprofile.jdt.internal.quarkus.providers.QuarkusConfigSourceProvider;
+
 /**
  * Quarkus Scheduled annotation property test for hover in Java file.
  */
@@ -43,7 +45,7 @@ public class QuarkusScheduledHoverTest extends BasePropertiesManagerTest {
 		IFile propertiesFile = project.getFile(new Path("src/main/resources/application.properties"));
 		String propertiesFileUri = fixURI(propertiesFile.getLocation().toFile().toURI());
 
-		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE,
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE,
 				"cron.expr=*/5 * * * * ?\r\n",
 				javaProject);
 
@@ -63,7 +65,7 @@ public class QuarkusScheduledHoverTest extends BasePropertiesManagerTest {
 		IFile propertiesFile = project.getFile(new Path("src/main/resources/application.properties"));
 		String propertiesFileUri = fixURI(propertiesFile.getLocation().toFile().toURI());
 
-		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE,
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE,
 				"every.expr=*/5 * * * * ?\r\n",
 				javaProject);
 

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/YamlUtilsTest.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/YamlUtilsTest.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.microprofile.jdt.quarkus;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Arrays;
+
+import com.redhat.microprofile.jdt.internal.quarkus.utils.YamlUtils;
+
+import org.junit.Test;
+import org.yaml.snakeyaml.Yaml;
+
+public class YamlUtilsTest {
+
+	@Test
+	public void testGetValueNull() {
+		assertNull(YamlUtils.getValueRecursively(Arrays.asList("a", "b", "c"), null));
+	}
+
+	@Test
+	public void testGetValueOneLevel() {
+		Object map = makeYamlMap( //
+				"a: aaa\n");
+		String value = YamlUtils.getValueRecursively(Arrays.asList("a"), map);
+		assertEquals("aaa", value);
+	}
+
+	@Test
+	public void testGetValueMultiLevel() {
+		Object map = makeYamlMap( //
+				"a:\n" + //
+				"  b:\n" + //
+				"    c: hello\n");
+		String value = YamlUtils.getValueRecursively(Arrays.asList("a", "b", "c"), map);
+		assertEquals("hello", value);
+	}
+
+	@Test
+	public void testGetValueMultiLevelFailure() {
+		Object map = makeYamlMap( //
+				"a:\n" + //
+				"  b:\n" + //
+				"    d: hello\n");
+		String value = YamlUtils.getValueRecursively(Arrays.asList("a", "b", "c"), map);
+		assertNull(value);
+	}
+
+	@Test
+	public void testGetValueMultiEntries() {
+		Object map = makeYamlMap( //
+				"a:\n" + //
+				"  b:\n" + //
+				"    c: hello\n" + //
+				"  d:\n" + //
+				"    e: hi\n" + //
+				"    f: salu\n");
+		String value = YamlUtils.getValueRecursively(Arrays.asList("a", "d", "f"), map);
+		assertEquals("salu", value);
+		value = YamlUtils.getValueRecursively(Arrays.asList("a", "d", "e"), map);
+		assertEquals("hi", value);
+	}
+
+	@Test
+	public void testGetValueHandlesNonStrings() {
+		Object map = makeYamlMap( //
+				"a:\n" + //
+				"  b:\n" + //
+				"    c: 50\n");
+		String value = YamlUtils.getValueRecursively(Arrays.asList("a", "b", "c"), map);
+		assertEquals("50", value);
+	}
+
+	private Object makeYamlMap(String yaml) {
+		return new Yaml().load(yaml);
+	}
+
+}

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/config/JavaCodeLensQuarkusRestClientTest.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/config/JavaCodeLensQuarkusRestClientTest.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.microprofile.jdt.quarkus.config;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.lsp4j.CodeLens;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaCodeLensParams;
+import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest;
+import org.eclipse.lsp4mp.jdt.core.PropertiesManagerForJava;
+import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.redhat.microprofile.jdt.internal.quarkus.providers.QuarkusConfigSourceProvider;
+
+public class JavaCodeLensQuarkusRestClientTest extends BasePropertiesManagerTest {
+
+	@Test
+	public void urlCodeLensYaml() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.rest_client_quickstart);
+		IJDTUtils utils = JDT_UTILS;
+
+		// Initialize file
+		initConfigFile(javaProject);
+
+		MicroProfileJavaCodeLensParams params = new MicroProfileJavaCodeLensParams();
+		IFile javaFile = javaProject.getProject()
+				.getFile(new Path("src/main/java/org/acme/restclient/CountriesService.java"));
+		params.setUri(javaFile.getLocation().toFile().toURI().toString());
+		params.setUrlCodeLensEnabled(true);
+
+		// No configuration of base url
+		List<? extends CodeLens> lenses = PropertiesManagerForJava.getInstance().codeLens(params, utils,
+				new NullProgressMonitor());
+		Assert.assertEquals(0, lenses.size());
+
+		// /mp-rest/url
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, "org:\r\n" + //
+				"  acme:\r\n" + //
+				"    restclient:\r\n" + //
+				"      CountriesService/mp-rest/url: https://restcountries.url/rest", javaProject);
+		assertCodeLenses("https://restcountries.url/rest", params, utils);
+
+		// /mp-rest/uri
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, //
+				"org:\r\n" + //
+						"  acme:\r\n" + //
+						"    restclient:\r\n" + //
+						"      CountriesService/mp-rest/url: https://restcountries.url/rest\r\n" + //
+						"      CountriesService/mp-rest/uri: https://restcountries.uri/rest\r\n" + //
+						"", //
+				javaProject);
+		assertCodeLenses("https://restcountries.uri/rest", params, utils);
+	}
+
+	private static void initConfigFile(IJavaProject javaProject) throws JavaModelException, IOException {
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, "", javaProject);
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "", javaProject);
+	}
+
+	private static void assertCodeLenses(String baseURL, MicroProfileJavaCodeLensParams params, IJDTUtils utils)
+			throws JavaModelException {
+		List<? extends CodeLens> lenses = PropertiesManagerForJava.getInstance().codeLens(params, utils,
+				new NullProgressMonitor());
+		Assert.assertEquals(2, lenses.size());
+
+		// @GET
+		// @Path("/name/{name}")
+		// Set<Country> getByName(@PathParam String name);
+		CodeLens lensForGet = lenses.get(0);
+		Assert.assertNotNull(lensForGet.getCommand());
+		Assert.assertEquals(baseURL + "/v2/name/{name}", lensForGet.getCommand().getTitle());
+
+		// @GET
+		// @Path("/name/{name}")
+		// CompletionStage<Set<Country>> getByNameAsync(@PathParam String name);
+		CodeLens lensForGetSingle = lenses.get(1);
+		Assert.assertNotNull(lensForGetSingle.getCommand());
+		Assert.assertEquals(baseURL + "/v2/name/{name}", lensForGetSingle.getCommand().getTitle());
+	}
+
+}

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/config/QuarkusConfigJavaDefinitionTest.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/config/QuarkusConfigJavaDefinitionTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.microprofile.jdt.quarkus.config;
+
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.assertJavaDefinitions;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.def;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.fixURI;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.p;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.r;
+
+import java.io.IOException;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest;
+import org.junit.After;
+import org.junit.Test;
+
+import com.redhat.microprofile.jdt.internal.quarkus.providers.QuarkusConfigSourceProvider;
+
+public class QuarkusConfigJavaDefinitionTest extends BasePropertiesManagerTest {
+
+	private static IJavaProject javaProject;
+
+	@After
+	public void cleanup() throws JavaModelException, IOException {
+		deleteFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, javaProject);
+		deleteFile(QuarkusConfigSourceProvider.APPLICATION_YML_FILE, javaProject);
+		deleteFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, javaProject);
+	}
+
+	@Test
+	public void configPropertyNameDefinitionYml() throws Exception {
+
+		javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/GreetingResource.java"));
+		String javaFileUri = fixURI(javaFile.getLocation().toFile().toURI());
+		IFile applicationYmlFile = project.getFile(new Path("src/main/resources/application.yml"));
+		String applicationYmlFileUri = fixURI(applicationYmlFile.getLocation().toFile().toURI());
+
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YML_FILE, //
+				"greeting:\n" + //
+				"  message: hello\n" + //
+				"  name: quarkus\n" + //
+				"  number: 100\n",
+				javaProject);
+		// Position(14, 40) is the character after the | symbol:
+		// @ConfigProperty(name = "greeting.mes|sage")
+		assertJavaDefinitions(p(14, 40), javaFileUri, JDT_UTILS, //
+				def(r(14, 28, 44), applicationYmlFileUri, "greeting.message"));
+
+	}
+
+}

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/config/QuarkusConfigJavaHoverTest.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/config/QuarkusConfigJavaHoverTest.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.microprofile.jdt.quarkus.config;
+
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.assertJavaHover;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.fixURI;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.h;
+
+import java.io.IOException;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest;
+import org.eclipse.lsp4mp.jdt.internal.core.providers.DefaultMicroProfilePropertiesConfigSourceProvider;
+import org.junit.After;
+import org.junit.Test;
+
+import com.redhat.microprofile.jdt.internal.quarkus.providers.QuarkusConfigSourceProvider;
+
+public class QuarkusConfigJavaHoverTest extends BasePropertiesManagerTest {
+
+	private static IJavaProject javaProject;
+
+	@After
+	public void cleanup() throws JavaModelException, IOException {
+		deleteFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, javaProject);
+		deleteFile(QuarkusConfigSourceProvider.APPLICATION_YML_FILE, javaProject);
+		deleteFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, javaProject);
+	}
+
+	@Test
+	public void configPropertyNameRespectsPrecendence() throws Exception {
+
+		javaProject = loadMavenProject(MicroProfileMavenProjectName.config_quickstart);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/GreetingConstructorResource.java"));
+		String javaFileUri = fixURI(javaFile.getLocation().toFile().toURI());
+		IFile propertiesFile = project.getFile(new Path("src/main/resources/application.properties"));
+		String propertiesFileUri = fixURI(propertiesFile.getLocation().toFile().toURI());
+
+		// microprofile-config.properties exists
+		saveFile(DefaultMicroProfilePropertiesConfigSourceProvider.MICROPROFILE_CONFIG_PROPERTIES_FILE, "greeting.constructor.message = hello 1",
+				javaProject);
+		assertJavaHover(new Position(23, 48), javaFileUri, JDT_UTILS,
+				h("`greeting.constructor.message = hello 1` *in* META-INF/microprofile-config.properties", 23, 36, 64));
+
+		// microprofile-config.properties and application.properties exist
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "greeting.constructor.message = hello 2",
+				javaProject);
+		assertJavaHover(new Position(23, 48), javaFileUri, JDT_UTILS,
+				h("`greeting.constructor.message = hello 2` *in* [application.properties](" + propertiesFileUri + ")",
+						23, 36, 64));
+
+		// microprofile-config.properties, application.properties, and application.yaml
+		// exist
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, //
+				"greeting:\n" + //
+						"  constructor:\n" + //
+						"    message: hello 3", //
+				javaProject);
+		assertJavaHover(new Position(23, 48), javaFileUri, JDT_UTILS,
+				h("`greeting.constructor.message = hello 3` *in* application.yaml", 23, 36, 64));
+
+	}
+
+	@Test
+	public void configPropertyNameYaml() throws Exception {
+
+		javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/GreetingResource.java"));
+		String javaFileUri = fixURI(javaFile.getLocation().toFile().toURI());
+		IFile yamlFile = project.getFile(new Path("src/main/resources/application.yaml"));
+		String yamlFileUri = fixURI(yamlFile.getLocation().toFile().toURI());
+		IFile propertiesFile = project.getFile(new Path("src/main/resources/application.properties"));
+		String propertiesFileUri = fixURI(propertiesFile.getLocation().toFile().toURI());
+
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, //
+				"greeting:\n" + //
+						"  message: message from yaml\n" + //
+						"  number: 2001",
+				javaProject);
+
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, //
+				"greeting.message = hello\r\n" + //
+						"greeting.name = quarkus\r\n" + //
+						"greeting.number = 100",
+				javaProject);
+
+		// Position(14, 40) is the character after the | symbol:
+		// @ConfigProperty(name = "greeting.mes|sage")
+		assertJavaHover(new Position(14, 40), javaFileUri, JDT_UTILS,
+				h("`greeting.message = message from yaml` *in* [application.yaml](" + yamlFileUri + ")", 14, 28, 44));
+
+		// Position(26, 33) is the character after the | symbol:
+		// @ConfigProperty(name = "greet|ing.number", defaultValue="0")
+		assertJavaHover(new Position(26, 33), javaFileUri, JDT_UTILS,
+				h("`greeting.number = 2001` *in* [application.yaml](" + yamlFileUri + ")", 26, 28, 43));
+
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, //
+				"greeting:\n" + //
+						"  message: message from yaml",
+				javaProject);
+		// fallback to application.properties
+		assertJavaHover(new Position(26, 33), javaFileUri, JDT_UTILS,
+				h("`greeting.number = 100` *in* [application.properties](" + propertiesFileUri + ")", 26, 28, 43));
+	}
+
+	@Test
+	public void configPropertyNameYml() throws Exception {
+
+		javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/GreetingResource.java"));
+		String javaFileUri = fixURI(javaFile.getLocation().toFile().toURI());
+		IFile ymlFile = project.getFile(new Path("src/main/resources/application.yml"));
+		String ymlFileUri = fixURI(ymlFile.getLocation().toFile().toURI());
+		IFile propertiesFile = project.getFile(new Path("src/main/resources/application.properties"));
+		String propertiesFileUri = fixURI(propertiesFile.getLocation().toFile().toURI());
+
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YML_FILE, //
+				"greeting:\n" + //
+						"  message: message from yml\n" + //
+						"  number: 2001",
+				javaProject);
+
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, //
+				"greeting.message = hello\r\n" + //
+						"greeting.name = quarkus\r\n" + //
+						"greeting.number = 100",
+				javaProject);
+
+		// Position(14, 40) is the character after the | symbol:
+		// @ConfigProperty(name = "greeting.mes|sage")
+		assertJavaHover(new Position(14, 40), javaFileUri, JDT_UTILS,
+				h("`greeting.message = message from yml` *in* [application.yml](" + ymlFileUri + ")", 14, 28, 44));
+
+		// Position(26, 33) is the character after the | symbol:
+		// @ConfigProperty(name = "greet|ing.number", defaultValue="0")
+		assertJavaHover(new Position(26, 33), javaFileUri, JDT_UTILS,
+				h("`greeting.number = 2001` *in* [application.yml](" + ymlFileUri + ")", 26, 28, 43));
+
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YML_FILE, //
+				"greeting:\n" + //
+						"  message: message from yml",
+				javaProject);
+		// fallback to application.properties
+		assertJavaHover(new Position(26, 33), javaFileUri, JDT_UTILS,
+				h("`greeting.number = 100` *in* [application.properties](" + propertiesFileUri + ")", 26, 28, 43));
+	}
+
+}

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/jaxrs/JaxRsCodeLensTest.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/jaxrs/JaxRsCodeLensTest.java
@@ -24,12 +24,15 @@ import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest;
 import org.eclipse.lsp4mp.jdt.core.PropertiesManagerForJava;
 import org.eclipse.lsp4mp.jdt.core.project.JDTMicroProfileProject;
 import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
+import org.eclipse.lsp4mp.jdt.internal.core.providers.DefaultMicroProfilePropertiesConfigSourceProvider;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.redhat.microprofile.jdt.internal.quarkus.providers.QuarkusConfigSourceProvider;
+
 /**
  * JAX-RS URL Codelens test for Java file.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -51,26 +54,26 @@ public class JaxRsCodeLensTest extends BasePropertiesManagerTest {
 		assertCodeLenses(8080, params, utils);
 
 		// META-INF/microprofile-config.properties : 8081
-		saveFile(JDTMicroProfileProject.MICROPROFILE_CONFIG_PROPERTIES_FILE, "quarkus.http.port = 8081", javaProject);
+		saveFile(DefaultMicroProfilePropertiesConfigSourceProvider.MICROPROFILE_CONFIG_PROPERTIES_FILE, "quarkus.http.port = 8081", javaProject);
 		assertCodeLenses(8081, params, utils);
 
 		// application.properties : 8082 -> it overrides 8081 coming from the
 		// META-INF/microprofile-config.properties
-		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE, "quarkus.http.port = 8082", javaProject);
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "quarkus.http.port = 8082", javaProject);
 		assertCodeLenses(8082, params, utils);
 
 		// application.properties : 8083
 		// META-INF/microprofile-config.properties
-		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE, "quarkus.http.port = 8083", javaProject);
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "quarkus.http.port = 8083", javaProject);
 		assertCodeLenses(8083, params, utils);
 
 		// remove quarkus.http.port from application.properties
-		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE, "", javaProject);
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "", javaProject);
 		assertCodeLenses(8081, params, utils); // here port is 8081 coming from META-INF/microprofile-config.properties
-		
+
 		// Set a different value for the dev profile.
 		// If the dev profile for quarkus.http.port exists, this should be used instead of the default profile
-		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE, "quarkus.http.port = 8080\n%dev.quarkus.http.port = 9090", javaProject);
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "quarkus.http.port = 8080\n%dev.quarkus.http.port = 9090", javaProject);
 		assertCodeLenses(9090, params, utils);
 	}
 
@@ -90,21 +93,21 @@ public class JaxRsCodeLensTest extends BasePropertiesManagerTest {
 		assertCodeLenses(8080, params, utils);
 
 		// application.yaml : 8081
-		saveFile(JDTMicroProfileProject.APPLICATION_YAML_FILE, "quarkus:\n" + "  http:\n" + "    port: 8081",
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, "quarkus:\n" + "  http:\n" + "    port: 8081",
 				javaProject);
 		assertCodeLenses(8081, params, utils);
 
 		// application.properties : 8082 -> application.yaml overrides
 		// application.properties
-		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE, "quarkus.http.port = 8082", javaProject);
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "quarkus.http.port = 8082", javaProject);
 		assertCodeLenses(8081, params, utils);
 
 		// remove quarkus.http.port from application.yaml
-		saveFile(JDTMicroProfileProject.APPLICATION_YAML_FILE, "", javaProject);
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, "", javaProject);
 		assertCodeLenses(8082, params, utils); // here port is 8082 coming from application.properties
 
 		// application.yaml: 8083 with more keys and a prefix related name conflict
-		saveFile(JDTMicroProfileProject.APPLICATION_YAML_FILE, "quarkus:\r\n" + //
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, "quarkus:\r\n" + //
 				"  application:\r\n" + //
 				"    name: name\r\n" + //
 				"    version: version\r\n" + //

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/META-INF/MANIFEST.MF
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: com.redhat.microprofile.jdt.quarkus;singleton:=true
-Bundle-Version: 0.10.2.qualifier
+Bundle-Version: 0.11.0.qualifier
 Require-Bundle: org.eclipse.lsp4mp.jdt.core,
  org.eclipse.core.runtime,
  org.eclipse.jdt.core,
@@ -13,4 +13,9 @@ Require-Bundle: org.eclipse.lsp4mp.jdt.core,
  org.apache.commons.lang3
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
-Export-Package: com.redhat.microprofile.jdt.quarkus
+Export-Package: com.redhat.microprofile.jdt.quarkus,
+ com.redhat.microprofile.jdt.internal.quarkus.providers;x-friends:="com.redhat.microprofile.jdt.quarkus.test",
+ com.redhat.microprofile.jdt.internal.quarkus.utils;x-friends:="com.redhat.microprofile.jdt.quarkus.test",
+ org.yaml.snakeyaml;x-friends:="com.redhat.microprofile.jdt.quarkus.test"
+Bundle-ClassPath: lib/snakeyaml-1.25.jar,
+ .

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/build.properties
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/build.properties
@@ -3,5 +3,6 @@ output.. = target/classes/
 bin.includes = plugin.xml,\
                META-INF/,\
                .,\
+               lib/snakeyaml-1.25.jar,\
                plugin.properties,\
                static-properties/

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/plugin.xml
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/plugin.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.5"?>
 <plugin>
-   
+
+   <extension point="org.eclipse.lsp4mp.jdt.core.configSourceProviders">
+      <provider class="com.redhat.microprofile.jdt.internal.quarkus.providers.QuarkusConfigSourceProvider" />
+   </extension>
+
    <extension point="org.eclipse.lsp4mp.jdt.core.projectLabelProviders">
       <provider class="com.redhat.microprofile.jdt.internal.quarkus.providers.QuarkusProjectLabelProvider"/>
    </extension>

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/pom.xml
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/pom.xml
@@ -5,13 +5,43 @@
 	<parent>
 		<artifactId>parent</artifactId>
 		<groupId>com.redhat.microprofile</groupId>
-		<version>0.10.2-SNAPSHOT</version>
+		<version>0.11.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>com.redhat.microprofile.jdt.quarkus</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	<name>Quarkus JDT LS Extension</name>
 	<description>MicroProfile JDT LS Extension - Quarkus</description>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+              <?m2e execute onConfiguration?>
+						<id>get-libs</id>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+						<phase>validate</phase>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>org.yaml</groupId>
+									<artifactId>snakeyaml</artifactId>
+									<version>1.25</version>
+								</artifactItem>
+							</artifactItems>
+							<skip>false</skip>
+							<outputDirectory>${basedir}/lib/</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 
 	<dependencies>
 		<dependency>

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/providers/QuarkusConfigSourceProvider.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/providers/QuarkusConfigSourceProvider.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.microprofile.jdt.internal.quarkus.providers;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.lsp4mp.jdt.core.project.IConfigSource;
+import org.eclipse.lsp4mp.jdt.core.project.IConfigSourceProvider;
+import org.eclipse.lsp4mp.jdt.core.project.PropertiesConfigSource;
+
+/**
+ * Provides configuration sources specific to Quarkus.
+ *
+ * <ul>
+ * <li><code>application.properties</code></li>
+ * <li><code>application.yaml</code></li>
+ * <li><code>application.yml</code></li>
+ * </ul>
+ *
+ */
+public class QuarkusConfigSourceProvider implements IConfigSourceProvider {
+
+	public static final String APPLICATION_PROPERTIES_FILE = "application.properties";
+	public static final String APPLICATION_YAML_FILE = "application.yaml";
+	public static final String APPLICATION_YML_FILE = "application.yml";
+
+	@Override
+	public List<IConfigSource> getConfigSources(IJavaProject project) {
+		return Arrays.asList(new YamlConfigSource(APPLICATION_YAML_FILE, project),
+				new YamlConfigSource(APPLICATION_YML_FILE, project),
+				new PropertiesConfigSource(APPLICATION_PROPERTIES_FILE, project, 250));
+	}
+
+}

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/providers/YamlConfigSource.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/providers/YamlConfigSource.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.microprofile.jdt.internal.quarkus.providers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.lsp4mp.jdt.core.project.AbstractConfigSource;
+import org.eclipse.lsp4mp.jdt.core.project.MicroProfileConfigPropertyInformation;
+import org.yaml.snakeyaml.Yaml;
+
+import com.redhat.microprofile.jdt.internal.quarkus.utils.YamlUtils;
+
+/**
+ * Yaml config source implementation
+ *
+ * @author dakwon
+ *
+ */
+public class YamlConfigSource extends AbstractConfigSource<Map<String, Object>> {
+
+	public YamlConfigSource(String configFileName, IJavaProject javaProject) {
+		super(configFileName, javaProject);
+	}
+
+	@Override
+	protected Map<String, Object> loadConfig(InputStream input) throws IOException {
+		Yaml yaml = new Yaml();
+		return (Map<String, Object>) yaml.load(input);
+	}
+
+	@Override
+	protected String getProperty(String key, Map<String, Object> config) {
+		String[] keyArray = key.split("\\.");
+		Map<String, Object> curr = config;
+
+		Object value;
+		for (int i = 0; i < keyArray.length - 1; i++) {
+			value = curr.get(keyArray[i]);
+			if (value == null || value instanceof String) {
+				return null;
+			}
+
+			curr = (Map<String, Object>) value;
+		}
+
+		value = curr.get(keyArray[keyArray.length - 1]);
+		if (value instanceof Map) {
+			// In this case:
+			//
+			// cors:
+			// ~: true
+			//
+			// map.get(null) returns the value of ~
+			value = ((Map<String, Object>) value).get(null);
+		}
+
+		if (value == null) {
+			return null;
+		}
+
+		return String.valueOf(value);
+	}
+
+	@Override
+	public Map<String, MicroProfileConfigPropertyInformation> getPropertyInformations(String propertyKey,
+			Map<String, Object> config) {
+
+		Map<String, MicroProfileConfigPropertyInformation> result = new HashMap<>();
+
+		if (config == null) {
+			return result;
+		}
+
+		final List<String> segments = MicroProfileConfigPropertyInformation.getSegments(propertyKey);
+		if (segments.size() < 1) {
+			return result;
+		}
+
+		for (String key : config.keySet()) {
+			if (key.equals(segments.get(0))) {
+				String value = YamlUtils.getValueRecursively(segments, config);
+				if (value != null) {
+					result.put(propertyKey, new MicroProfileConfigPropertyInformation(propertyKey, value,
+							getSourceConfigFileURI(), getConfigFileName()));
+				}
+			} else if (key.charAt(0) == '%') {
+				if (config.get(key) instanceof Map) {
+					String value = YamlUtils.getValueRecursively(segments, config.get(key));
+					if (value != null) {
+						String propertyAndProfile = key + "." + propertyKey;
+						result.put(propertyAndProfile, new MicroProfileConfigPropertyInformation(propertyAndProfile,
+								value, getSourceConfigFileURI(), getConfigFileName()));
+					}
+				}
+			}
+		}
+
+		return result;
+	}
+
+	@Override
+	public int getOrdinal() {
+		// See https://github.com/quarkusio/quarkus/blob/main/extensions/config-yaml/runtime/src/main/java/io/quarkus/config/yaml/runtime/ApplicationYamlConfigSourceLoader.java#L29
+		// (or Quarkus --> yaml config extension --> ApplicationYamlConfigSourceLoader if the link is dead)
+		return 255;
+	}
+
+}

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/utils/YamlUtils.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/utils/YamlUtils.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.microprofile.jdt.internal.quarkus.utils;
+
+import java.util.List;
+import java.util.Map;
+
+public class YamlUtils {
+
+	private YamlUtils() {}
+
+	/**
+	 * Returns the value extracted from the map as a String, or null if the value is
+	 * not in the map
+	 *
+	 * @param segments the keys to use when searching for the value
+	 * @param mapOrValue the map from a property key to another portion of the map, or the
+	 * @return the value extracted from the map as a String, or null if the value is
+	 *         not in the map
+	 */
+	public static String getValueRecursively(List<String> segments, Object mapOrValue) {
+		if (mapOrValue == null) {
+			return null;
+		}
+		if (segments.size() == 0) {
+			return mapOrValue.toString();
+		} else if (segments.size() > 0 && mapOrValue instanceof Map<?, ?>) {
+			Map<String, Object> configMap = (Map<String, Object>) mapOrValue;
+			Object configChild = configMap.get(segments.get(0));
+			return getValueRecursively(segments.subList(1, segments.size()), configChild);
+		} else {
+			return null;
+		}
+	}
+
+}

--- a/quarkus.jdt.ext/pom.xml
+++ b/quarkus.jdt.ext/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.redhat.microprofile</groupId>
   <artifactId>parent</artifactId>
-  <version>0.10.2-SNAPSHOT</version>
+  <version>0.11.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>quarkus.jdt.ls :: parent</name>
   <description>quarkus.jdt.ls parent</description>
@@ -17,8 +17,7 @@
     <jdt.ls.version>0.57.0.20200619102332</jdt.ls.version>
     <tycho.test.platformArgs />
     <tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
-    <lsp4mp.p2.url>http://download.eclipse.org/lsp4mp/releases/0.3.0/repository/</lsp4mp.p2.url>
-
+    <lsp4mp.p2.url>http://download.eclipse.org/lsp4mp/snapshots/0.4.0/repository/</lsp4mp.p2.url>
 
     <!-- Code coverage -->
     <jacoco.version>0.7.9</jacoco.version>

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/pom.xml
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.redhat.microprofile</groupId>
 	<artifactId>com.redhat.quarkus.ls</artifactId>
-	<version>0.10.2-SNAPSHOT</version>
+	<version>0.11.0-SNAPSHOT</version>
 
 	<name>Quarkus Extension for the MicroProfile Language Server</name>
 	<description>Quarkus extension for MicroProfile Language Server</description>
@@ -39,7 +39,7 @@
 		<maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
 		<dev.build.timestamp>${maven.build.timestamp}</dev.build.timestamp>
 		<lsp4j.version>0.9.0</lsp4j.version>
-		<microprofile.ls.version>0.3.0</microprofile.ls.version>
+		<microprofile.ls.version>0.4.0-SNAPSHOT</microprofile.ls.version>
 		<jboss.releases.repo.id>jboss-releases-repository</jboss.releases.repo.id>
 		<jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
 		<jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>


### PR DESCRIPTION
See eclipse/lsp4mp#160

This PR moves the `QuarkusConfigSourceProvider` class into quarkus-ls. It also adds all the necessary supporting classes, and introduces snakeyaml as a dependency. Finally, tests related to `application.proeprties` and `application.yaml` are now a part of quarkus-ls.

Signed-off-by: David Thompson <davthomp@redhat.com>
