### PR TITLE
added quarkus.http.root-path property retrieval to Quarkus JaxRs CodeLens

### DIFF
--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/jaxrs/JaxRsCodeLensTest.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/jaxrs/JaxRsCodeLensTest.java
@@ -51,30 +51,39 @@ public class JaxRsCodeLensTest extends BasePropertiesManagerTest {
 		params.setUrlCodeLensEnabled(true);
 
 		// Default port
-		assertCodeLenses(8080, params, utils);
+		assertCodeLenses(8080, "", params, utils);
 
 		// META-INF/microprofile-config.properties : 8081
 		saveFile(DefaultMicroProfilePropertiesConfigSourceProvider.MICROPROFILE_CONFIG_PROPERTIES_FILE, "quarkus.http.port = 8081", javaProject);
-		assertCodeLenses(8081, params, utils);
+		assertCodeLenses(8081, "", params, utils);
 
 		// application.properties : 8082 -> it overrides 8081 coming from the
 		// META-INF/microprofile-config.properties
 		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "quarkus.http.port = 8082", javaProject);
-		assertCodeLenses(8082, params, utils);
+		assertCodeLenses(8082, "", params, utils);
 
 		// application.properties : 8083
 		// META-INF/microprofile-config.properties
 		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "quarkus.http.port = 8083", javaProject);
-		assertCodeLenses(8083, params, utils);
+		assertCodeLenses(8083, "", params, utils);
 
 		// remove quarkus.http.port from application.properties
 		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "", javaProject);
-		assertCodeLenses(8081, params, utils); // here port is 8081 coming from META-INF/microprofile-config.properties
+		assertCodeLenses(8081, "", params, utils); // here port is 8081 coming from META-INF/microprofile-config.properties
 
 		// Set a different value for the dev profile.
 		// If the dev profile for quarkus.http.port exists, this should be used instead of the default profile
 		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "quarkus.http.port = 8080\n%dev.quarkus.http.port = 9090", javaProject);
-		assertCodeLenses(9090, params, utils);
+		assertCodeLenses(9090, "", params, utils);
+		
+		// quarkus.http.root-path property in application.properties
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "quarkus.http.port = 8080\nquarkus.http.root-path = /foo/bar", javaProject);
+		assertCodeLenses(8080, "/foo/bar", params, utils);
+		
+		// Different value in dev profile
+		// If the dev profile for quarkus.http.root-path exists, this should be used instead of the default profile
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "quarkus.http.port = 8080\nquarkus.http.root-path = /foo/bar\n%dev.quarkus.http.root-path = /bar/foo", javaProject);
+		assertCodeLenses(8080, "/bar/foo", params, utils);
 	}
 
 	@Test
@@ -90,21 +99,21 @@ public class JaxRsCodeLensTest extends BasePropertiesManagerTest {
 		params.setUrlCodeLensEnabled(true);
 
 		// Default port
-		assertCodeLenses(8080, params, utils);
+		assertCodeLenses(8080, "", params, utils);
 
 		// application.yaml : 8081
 		saveFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, "quarkus:\n" + "  http:\n" + "    port: 8081",
 				javaProject);
-		assertCodeLenses(8081, params, utils);
+		assertCodeLenses(8081, "", params, utils);
 
 		// application.properties : 8082 -> application.yaml overrides
 		// application.properties
 		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "quarkus.http.port = 8082", javaProject);
-		assertCodeLenses(8081, params, utils);
+		assertCodeLenses(8081, "", params, utils);
 
 		// remove quarkus.http.port from application.yaml
 		saveFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, "", javaProject);
-		assertCodeLenses(8082, params, utils); // here port is 8082 coming from application.properties
+		assertCodeLenses(8082, "", params, utils); // here port is 8082 coming from application.properties
 
 		// application.yaml: 8083 with more keys and a prefix related name conflict
 		saveFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, "quarkus:\r\n" + //
@@ -115,11 +124,11 @@ public class JaxRsCodeLensTest extends BasePropertiesManagerTest {
 				"    port:\r\n" + //
 				"      ~: 8083\r\n" + //
 				"      unknown_property: 123", javaProject);
-		assertCodeLenses(8083, params, utils);
+		assertCodeLenses(8083, "", params, utils);
 
 	}
 
-	private static void assertCodeLenses(int port, MicroProfileJavaCodeLensParams params, IJDTUtils utils)
+	private static void assertCodeLenses(int port, String rootPath, MicroProfileJavaCodeLensParams params, IJDTUtils utils)
 			throws JavaModelException {
 		List<? extends CodeLens> lenses = PropertiesManagerForJava.getInstance().codeLens(params, utils,
 				new NullProgressMonitor());
@@ -129,14 +138,14 @@ public class JaxRsCodeLensTest extends BasePropertiesManagerTest {
 		// public Fruit[] get() {
 		CodeLens lensForGet = lenses.get(0);
 		Assert.assertNotNull(lensForGet.getCommand());
-		Assert.assertEquals("http://localhost:" + port + "/fruits", lensForGet.getCommand().getTitle());
+		Assert.assertEquals("http://localhost:" + port + rootPath + "/fruits", lensForGet.getCommand().getTitle());
 
 		// @GET
 		// @Path("{id}")
 		// public Fruit getSingle(@PathParam Integer id) {
 		CodeLens lensForGetSingle = lenses.get(1);
 		Assert.assertNotNull(lensForGetSingle.getCommand());
-		Assert.assertEquals("http://localhost:" + port + "/fruits/{id}", lensForGetSingle.getCommand().getTitle());
+		Assert.assertEquals("http://localhost:" + port + rootPath + "/fruits/{id}", lensForGetSingle.getCommand().getTitle());
 	}
 
 }

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/jaxrs/java/QuarkusJaxRsCodeLensParticipant.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/jaxrs/java/QuarkusJaxRsCodeLensParticipant.java
@@ -28,13 +28,15 @@ import org.eclipse.lsp4mp.jdt.core.project.JDTMicroProfileProjectManager;
  * Quarkus JAX-RS CodeLens participant used to update the server port declared
  * with "quarkus.http.port" property.
  *
- * @author Angelo ZERR
+ * @author Angelo ZERR 
  *
  */
 public class QuarkusJaxRsCodeLensParticipant implements IJavaCodeLensParticipant {
 
 	private static final String QUARKUS_DEV_HTTP_PORT = "%dev.quarkus.http.port";
 	private static final String QUARKUS_HTTP_PORT = "quarkus.http.port";
+	private static final String QUARKUS_DEV_HTTP_ROOT_PATH = "%dev.quarkus.http.root-path";
+	private static final String QUARKUS_HTTP_ROOT_PATH = "quarkus.http.root-path";
 
 	@Override
 	public void beginCodeLens(JavaCodeLensContext context, IProgressMonitor monitor) throws CoreException {
@@ -43,9 +45,16 @@ public class QuarkusJaxRsCodeLensParticipant implements IJavaCodeLensParticipant
 		IJavaProject javaProject = context.getJavaProject();
 		JDTMicroProfileProject mpProject = JDTMicroProfileProjectManager.getInstance()
 				.getJDTMicroProfileProject(javaProject);
+		
+		// Retrieve server port from application.properties
 		int serverPort = mpProject.getPropertyAsInteger(QUARKUS_HTTP_PORT, JaxRsContext.DEFAULT_PORT);
 		int devServerPort = mpProject.getPropertyAsInteger(QUARKUS_DEV_HTTP_PORT, serverPort);
 		JaxRsContext.getJaxRsContext(context).setServerPort(devServerPort);
+		
+		// Retrieve HTTP root path from application.properties
+		String httpRootPath = mpProject.getProperty(QUARKUS_HTTP_ROOT_PATH);
+		String devHttpRootPath = mpProject.getProperty(QUARKUS_DEV_HTTP_ROOT_PATH, httpRootPath);
+		JaxRsContext.getJaxRsContext(context).setRootPath(devHttpRootPath);
 	}
 
 	@Override

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/pom.xml
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/pom.xml
@@ -38,7 +38,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
 		<dev.build.timestamp>${maven.build.timestamp}</dev.build.timestamp>
-		<lsp4j.version>0.9.0</lsp4j.version>
+		<lsp4j.version>0.11.0</lsp4j.version>
 		<microprofile.ls.version>0.4.0-SNAPSHOT</microprofile.ls.version>
 		<jboss.releases.repo.id>jboss-releases-repository</jboss.releases.repo.id>
 		<jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>


### PR DESCRIPTION
Added `quarkus.http.root-path` property retrieval to Quarkus JaxRs CodeLens.

References eclipse/lsp4mp/pull/174

Signed-off-by: Alexander Chen <alchen@redhat.com>