### PR TITLE
added `@ApplicationPath` cache to JaxRsContext for CodeLens URL

### DIFF
--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/jaxrs/java/QuarkusJaxRsCodeLensParticipant.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/jaxrs/java/QuarkusJaxRsCodeLensParticipant.java
@@ -11,17 +11,30 @@
 *******************************************************************************/
 package com.redhat.microprofile.jdt.internal.quarkus.jaxrs.java;
 
+import static org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsUtils.getJaxRsApplicationPathValue;
+import static org.eclipse.lsp4mp.jdt.internal.jaxrs.JaxRsConstants.JAVAX_WS_RS_APPLICATIONPATH_ANNOTATION;
+
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+import org.eclipse.jdt.core.search.SearchEngine;
+import org.eclipse.jdt.core.search.SearchMatch;
+import org.eclipse.jdt.core.search.SearchParticipant;
+import org.eclipse.jdt.core.search.SearchPattern;
+import org.eclipse.jdt.core.search.SearchRequestor;
 import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4mp.jdt.core.java.codelens.IJavaCodeLensParticipant;
 import org.eclipse.lsp4mp.jdt.core.java.codelens.JavaCodeLensContext;
 import org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsContext;
 import org.eclipse.lsp4mp.jdt.core.project.JDTMicroProfileProject;
 import org.eclipse.lsp4mp.jdt.core.project.JDTMicroProfileProjectManager;
+import org.eclipse.lsp4mp.jdt.core.utils.AnnotationUtils;
 
 /**
  *
@@ -55,11 +68,54 @@ public class QuarkusJaxRsCodeLensParticipant implements IJavaCodeLensParticipant
 		String httpRootPath = mpProject.getProperty(QUARKUS_HTTP_ROOT_PATH);
 		String devHttpRootPath = mpProject.getProperty(QUARKUS_DEV_HTTP_ROOT_PATH, httpRootPath);
 		JaxRsContext.getJaxRsContext(context).setRootPath(devHttpRootPath);
+		
+		IType applicationPathType = javaProject
+				.findType(JAVAX_WS_RS_APPLICATIONPATH_ANNOTATION, monitor);
+		String applicationPath = validateInterfaceType(applicationPathType,
+				context, monitor);
+		JaxRsContext.getJaxRsContext(context).setRootPath(devHttpRootPath);
 	}
 
 	@Override
 	public List<CodeLens> collectCodeLens(JavaCodeLensContext context, IProgressMonitor monitor) throws CoreException {
 		// Do nothing
 		return null;
+	}
+	
+	private static String validateAnnotationType(IType annotationType,
+			JavaCodeLensContext context, IProgressMonitor monitor)
+			throws CoreException {
+		AtomicReference<String> applicationPathRef = new AtomicReference<String>();
+		SearchPattern pattern = SearchPattern.createPattern(
+				JAVAX_WS_RS_APPLICATIONPATH_ANNOTATION,
+				IJavaSearchConstants.ANNOTATION_TYPE,
+				IJavaSearchConstants.ANNOTATION_TYPE_REFERENCE,
+				SearchPattern.R_EXACT_MATCH);
+		SearchEngine engine = new SearchEngine();
+		engine.search(pattern,
+				new SearchParticipant[]{
+						SearchEngine.getDefaultSearchParticipant()},
+				createSearchScope(annotationType.getJavaProject()),
+				new SearchRequestor() {
+
+					@Override
+					public void acceptSearchMatch(SearchMatch match)
+							throws CoreException {
+						Object o = match.getElement();
+						if (o instanceof IType) {
+							validateApplicationPath((IType) o);
+						}
+					}
+
+					private void validateApplicationPath(IType type)
+							throws CoreException {
+						if (AnnotationUtils.hasAnnotation(type,
+								JAVAX_WS_RS_APPLICATIONPATH_ANNOTATION)) {
+							applicationPathRef
+									.set(getJaxRsApplicationPathValue(type));
+						}
+					}
+				}, monitor);
+		return applicationPathRef.get();
 	}
 }


### PR DESCRIPTION
Added `@ApplicationPath` cache to JaxRsContext for CodeLens URL.

References eclipse/lsp4mp/pull/195 

Signed-off-by: Alexander Chen <alchen@redhat.com>