### PR TITLE
Validate that @ConfigMapping annotation can only be placed in interfaces

### DIFF
--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/projects/maven/config-mapping/src/main/java/org/acme/validation/ServerClass.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/projects/maven/config-mapping/src/main/java/org/acme/validation/ServerClass.java
@@ -1,0 +1,9 @@
+package org.acme.validation;
+
+import io.smallrye.config.ConfigMapping;
+
+@ConfigMapping("prefix")
+public class ServerClass {
+
+	String host;
+}

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/configmapping/QuarkusConfigMappingASTVisitorTest.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/configmapping/QuarkusConfigMappingASTVisitorTest.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.microprofile.jdt.quarkus.configmapping;
+
+import static com.redhat.microprofile.jdt.internal.quarkus.QuarkusConstants.QUARKUS_PREFIX;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.assertJavaDiagnostics;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.d;
+
+import java.util.Arrays;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4mp.commons.DocumentFormat;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaDiagnosticsParams;
+import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest;
+import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
+import org.junit.Test;
+
+import com.redhat.microprofile.jdt.quarkus.QuarkusMavenProjectName;
+
+/**
+ * @ConfigMapping validation.
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class QuarkusConfigMappingASTVisitorTest extends BasePropertiesManagerTest {
+
+	@Test
+	public void expectedInterface() throws Exception {
+
+		IJavaProject javaProject = loadMavenProject(QuarkusMavenProjectName.config_mapping);
+		IJDTUtils utils = JDT_UTILS;
+		MicroProfileJavaDiagnosticsParams diagnosticsParams = new MicroProfileJavaDiagnosticsParams();
+
+		IFile javaFile = javaProject.getProject()
+				.getFile(new Path("src/main/java/org/acme/validation/ServerClass.java"));
+		diagnosticsParams.setUris(Arrays.asList(javaFile.getLocation().toFile().toURI().toString()));
+		diagnosticsParams.setDocumentFormat(DocumentFormat.Markdown);
+		assertJavaDiagnostics(diagnosticsParams, utils, //
+				d(4, 0, 24,
+						"The @ConfigMapping annotation can only be placed in interfaces, class `ServerClass` is a class",
+						DiagnosticSeverity.Error, QUARKUS_PREFIX, null));
+	}
+}

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/plugin.xml
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/plugin.xml
@@ -18,6 +18,11 @@
       <provider class="com.redhat.microprofile.jdt.internal.quarkus.core.properties.QuarkusConfigPropertiesProvider" />
       <provider class="com.redhat.microprofile.jdt.internal.quarkus.core.properties.QuarkusConfigMappingProvider" />      
    </extension>
+
+   <extension point="org.eclipse.lsp4mp.jdt.core.javaASTValidators">
+      <!-- Java validation for the Quarkus @ConfigMapping annotation -->
+      <validator class="com.redhat.microprofile.jdt.internal.quarkus.core.java.QuarkusConfigMappingASTVisitor" />
+   </extension>
    
    <!-- Quarkus JAX-RS support -->
    

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/QuarkusConstants.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/QuarkusConstants.java
@@ -94,7 +94,7 @@ public class QuarkusConstants {
 	public static final String WITH_DEFAULT_ANNOTATION = "io.smallrye.config.WithDefault";
 
 	public static final String WITH_DEFAULT_ANNOTATION_VALUE = "value";
-	
+
 	/**
 	 * The Quarkus @ConfigProperties annotation
 	 */

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/core/java/QuarkusConfigMappingASTVisitor.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/core/java/QuarkusConfigMappingASTVisitor.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.microprofile.jdt.internal.quarkus.core.java;
+
+import static org.eclipse.lsp4mp.jdt.core.utils.AnnotationUtils.isMatchAnnotation;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4mp.jdt.core.java.diagnostics.JavaDiagnosticsContext;
+import org.eclipse.lsp4mp.jdt.core.java.validators.JavaASTValidator;
+import org.eclipse.lsp4mp.jdt.core.utils.JDTTypeUtils;
+
+import com.redhat.microprofile.jdt.internal.quarkus.QuarkusConstants;
+
+/**
+ * Quarkus @ConfigMapping validator.
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class QuarkusConfigMappingASTVisitor extends JavaASTValidator {
+
+	private static final Logger LOGGER = Logger.getLogger(QuarkusConfigMappingASTVisitor.class.getName());
+
+	private static final String EXPECTED_INTERFACE_ERROR = "The @ConfigMapping annotation can only be placed in interfaces, class `{0}` is a class";
+
+	@Override
+	public boolean isAdaptedForDiagnostics(JavaDiagnosticsContext context, IProgressMonitor monitor)
+			throws CoreException {
+		IJavaProject javaProject = context.getJavaProject();
+		return JDTTypeUtils.findType(javaProject, QuarkusConstants.CONFIG_MAPPING_ANNOTATION) != null;
+	}
+
+	@Override
+	public boolean visit(TypeDeclaration node) {
+		try {
+			@SuppressWarnings("rawtypes")
+			List modifiers = node.modifiers();
+			for (Object modifier : modifiers) {
+				if (modifier instanceof Annotation) {
+					Annotation annotation = (Annotation) modifier;
+					if (isMatchAnnotation(annotation, QuarkusConstants.CONFIG_MAPPING_ANNOTATION)) {
+						validateConfigMappingAnnotation(node, annotation);
+					}
+				}
+			}
+		} catch (JavaModelException e) {
+			LOGGER.log(Level.WARNING, "An exception occurred when attempting to validate the annotation marked type");
+		}
+		super.visit(node);
+		return true;
+	}
+
+	/**
+	 * Checks if the given type declaration annotated with @ConfigMapping annotation
+	 * is an interface.
+	 *
+	 * @param node       The type declaration to validate
+	 * @param annotation The @ConfigMapping annotation
+	 * @throws JavaModelException
+	 */
+	private void validateConfigMappingAnnotation(TypeDeclaration node, Annotation annotation)
+			throws JavaModelException {
+		if (!node.isInterface()) {
+			super.addDiagnostic(MessageFormat.format(EXPECTED_INTERFACE_ERROR, node.getName()),
+					QuarkusConstants.QUARKUS_PREFIX, annotation, null, DiagnosticSeverity.Error);
+		}
+	}
+
+}


### PR DESCRIPTION
Validate that @ConfigMapping annotation can only be placed in interfaces

Fixes #424

Signed-off-by: azerr <azerr@redhat.com>