### PR TITLE
added definition support for `@Scheduled` annotation

### DIFF
--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/projects/maven/scheduler-quickstart/src/main/resources/application.properties
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/projects/maven/scheduler-quickstart/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 cron.expr=*/5 * * * * ?
 every.expr=*/5 * * * * ?
- 
+

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/scheduler/QuarkusScheduledDefinitionTest.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/scheduler/QuarkusScheduledDefinitionTest.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.microprofile.jdt.quarkus.scheduler;
+
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.assertJavaDefinitions;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.def;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.fixURI;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.r;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest;
+import org.junit.Test;
+
+import com.redhat.microprofile.jdt.internal.quarkus.providers.QuarkusConfigSourceProvider;
+import com.redhat.microprofile.jdt.quarkus.QuarkusMavenProjectName;
+
+/**
+ * Quarkus Scheduled annotation property test for definition in properties file.
+ */
+public class QuarkusScheduledDefinitionTest extends BasePropertiesManagerTest {
+
+	private static IJavaProject javaProject;
+
+	@Test
+	public void configCronPropertyDefinition() throws Exception {
+
+		javaProject = loadMavenProject(QuarkusMavenProjectName.scheduler_quickstart);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/scheduler/CounterBean.java"));
+		String javaFileUri = fixURI(javaFile.getLocation().toFile().toURI());
+		IFile propertiesFile = project.getFile(new Path("src/main/resources/application.properties"));
+		String propertiesFileUri = fixURI(propertiesFile.getLocation().toFile().toURI());
+
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "cron.expr=*/5 * * * * ?\r\n", javaProject);
+
+		// Position(29, 25) is the character after the | symbol:
+		// @Scheduled(cron = "{c|ron.expr}", every = "{every.expr}")
+		assertJavaDefinitions(new Position(29, 25), javaFileUri, JDT_UTILS,
+				def(r(29, 23, 34), propertiesFileUri, "cron.expr"));
+	}
+
+	@Test
+	public void configEveryPropertyNameDefinition() throws Exception {
+
+		javaProject = loadMavenProject(QuarkusMavenProjectName.scheduler_quickstart);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/scheduler/CounterBean.java"));
+		String javaFileUri = fixURI(javaFile.getLocation().toFile().toURI());
+		IFile propertiesFile = project.getFile(new Path("src/main/resources/application.properties"));
+		String propertiesFileUri = fixURI(propertiesFile.getLocation().toFile().toURI());
+
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "every.expr=*/5 * * * * ?\r\n", javaProject);
+
+		// Position(29, 48) is the character after the | symbol:
+		// @Scheduled(cron = "{cron.expr}", every = "{e|very.expr}")
+		assertJavaDefinitions(new Position(29, 48), javaFileUri, JDT_UTILS,
+				def(r(29, 46, 58), propertiesFileUri, "every.expr"));
+	}
+
+	@Test
+	public void configPropertyExpressionDefinition() throws Exception {
+
+		javaProject = loadMavenProject(QuarkusMavenProjectName.scheduler_quickstart);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/scheduler/CounterBean.java"));
+		String javaFileUri = fixURI(javaFile.getLocation().toFile().toURI());
+		IFile propertiesFile = project.getFile(new Path("src/main/resources/application.properties"));
+		String propertiesFileUri = fixURI(propertiesFile.getLocation().toFile().toURI());
+
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "cron.expr=*/5 * * * * ?\r\n", javaProject);
+
+		// Position(35, 26) is the character after the | symbol:
+		// @Scheduled(cron = "${c|ron.expr}", every = "${every.expr}")
+		assertJavaDefinitions(new Position(35, 26), javaFileUri, JDT_UTILS,
+				def(r(35, 23, 35), propertiesFileUri, "cron.expr"));
+
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "every.expr=*/5 * * * * ?\r\n", javaProject);
+
+		// Position(35, 50) is the character after the | symbol:
+		// @Scheduled(cron = "{cron.expr}", every = "{e|very.expr}")
+		assertJavaDefinitions(new Position(35, 50), javaFileUri, JDT_UTILS,
+				def(r(35, 47, 60), propertiesFileUri, "every.expr"));
+	}
+
+}

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/plugin.xml
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/plugin.xml
@@ -34,6 +34,8 @@
    <!-- Quarkus @Scheduled annotation support -->
    
    <extension point="org.eclipse.lsp4mp.jdt.core.javaFeatureParticipants">
+         <!-- Java definition for the Quarkus @Scheduled annotation -->
+      <definition class="com.redhat.microprofile.jdt.internal.quarkus.scheduler.java.QuarkusScheduledDefinitionParticipant" />
        <!-- Java hover for the Quarkus @Scheduled annotation -->
       <hover class="com.redhat.microprofile.jdt.internal.quarkus.scheduler.java.QuarkusScheduledHoverParticipant" />   
    </extension>

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/QuarkusConstants.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/QuarkusConstants.java
@@ -55,6 +55,11 @@ public class QuarkusConstants {
 	public static final String SCHEDULED_ANNOTATION_DELAY = "delay";
 	public static final String SCHEDULED_ANNOTATION_DELAY_UNIT = "delayUnit";
 	public static final String SCHEDULED_ANNOTATION_DELAYED = "delayed";
+
+	public static final String[] SCHEDULED_SUPPORTED_PARTICIPANT_MEMBERS = {
+			SCHEDULED_ANNOTATION_CRON, SCHEDULED_ANNOTATION_EVERY, SCHEDULED_ANNOTATION_DELAY,
+			SCHEDULED_ANNOTATION_DELAYED, SCHEDULED_ANNOTATION_DELAY_UNIT
+	};
 	public static final String SCHEDULED_ANNOTATION_CONCURRENT_EXECUTION = "concurrentExecution";
 	public static final String SCHEDULED_ANNOTATION_SKIP_EXECUTION_IF = "skipExecutionIf";
 

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/scheduler/java/QuarkusScheduledDefinitionParticipant.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/scheduler/java/QuarkusScheduledDefinitionParticipant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 Red Hat Inc. and others.
+* Copyright (c) 2021 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,24 +13,21 @@
 *******************************************************************************/
 package com.redhat.microprofile.jdt.internal.quarkus.scheduler.java;
 
+import static com.redhat.microprofile.jdt.internal.quarkus.QuarkusConstants.SCHEDULED_ANNOTATION;
 import static com.redhat.microprofile.jdt.internal.quarkus.QuarkusConstants.SCHEDULED_SUPPORTED_PARTICIPANT_MEMBERS;
 import static org.eclipse.lsp4mp.commons.PropertyReplacerStrategy.EXPRESSION_REPLACER;
 
-import org.eclipse.jdt.core.IJavaElement;
-import org.eclipse.lsp4mp.jdt.core.java.hover.PropertiesHoverParticipant;
+import org.eclipse.lsp4mp.jdt.core.java.definition.PropertiesDefinitionParticipant;
 
-import com.redhat.microprofile.jdt.internal.quarkus.QuarkusConstants;
+/**
+ * Quarkus applocation.properties Definition to navigate from Java
+ * file @Scheduled/cron, every to properties, yaml files where the property is
+ * declared.
+ *
+ */
+public class QuarkusScheduledDefinitionParticipant extends PropertiesDefinitionParticipant {
 
-public class QuarkusScheduledHoverParticipant extends PropertiesHoverParticipant {
-
-	public QuarkusScheduledHoverParticipant() {
-		super(QuarkusConstants.SCHEDULED_ANNOTATION, SCHEDULED_SUPPORTED_PARTICIPANT_MEMBERS, null,
-				EXPRESSION_REPLACER);
+	public QuarkusScheduledDefinitionParticipant() {
+		super(SCHEDULED_ANNOTATION, SCHEDULED_SUPPORTED_PARTICIPANT_MEMBERS, EXPRESSION_REPLACER);
 	}
-
-	@Override
-	protected boolean isAdaptableFor(IJavaElement hoverElement) {
-		return hoverElement.getElementType() == IJavaElement.METHOD;
-	}
-
 }


### PR DESCRIPTION
Added definition support for `@Scheduled` annotation members which have hover support.

Fixes #377

Signed-off-by: Alexander Chen <alchen@redhat.com>

Expected behaviour:
![Screenshot from 2021-11-26 18-11-22](https://user-images.githubusercontent.com/26389510/143660492-55f6bc37-6ec7-4f90-a15e-dca98af92022.png)

Requires https://github.com/eclipse/lsp4mp/pull/214
