### PR TITLE
Changed Qute embedded Java completion to use simple types

### DIFF
--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/JavaElementKind.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/JavaElementKind.java
@@ -21,5 +21,6 @@ public enum JavaElementKind {
 
 	TYPE, //
 	FIELD, //
-	METHOD;
+	METHOD, //
+	PARAMETER;
 }

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/JavaMethodInfo.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/JavaMethodInfo.java
@@ -13,12 +13,13 @@ package com.redhat.qute.commons;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.StringJoiner;
 
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * Java method information.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -34,34 +35,61 @@ public class JavaMethodInfo extends JavaMemberInfo {
 
 	/**
 	 * Returns the Java method signature.
-	 * 
+	 *
 	 * Example:
-	 * 
+	 *
 	 * <code>
 	 * find(query : java.lang.String, params : java.util.Map<java.lang.String,java.lang.Object>) : io.quarkus.hibernate.orm.panache.PanacheQuery<T>
 	 * </code>
-	 * 
+	 *
 	 * @return the Java method signature.
 	 */
+	@Override
 	public String getSignature() {
 		return super.getSignature();
 	}
 
 	/**
-	 * Returns the method name.
-	 * 
+	 * Returns the Java method signature with simple names.
+	 *
 	 * Example:
-	 * 
+	 *
+	 * <code>
+	 * find(query : String, params : Map<String,Object>) : PanacheQuery<T>
+	 * </code>
+	 *
+	 * @return the Java method signature.
+	 */
+	public String getSimpleSignature() {
+		StringBuilder simpleSignatureBuilder = new StringBuilder();
+		simpleSignatureBuilder.append(getName());
+		simpleSignatureBuilder.append("(");
+		List<JavaParameterInfo> parameters = getParameters();
+		StringJoiner commaJoiner = new StringJoiner(", ");
+		for (JavaParameterInfo parameter : parameters) {
+			commaJoiner.add(parameter.getSimpleParameter());
+		}
+		simpleSignatureBuilder.append(commaJoiner.toString());
+		simpleSignatureBuilder.append(") : ");
+		simpleSignatureBuilder.append(super.getSimpleType(getReturnType()));
+		return simpleSignatureBuilder.toString();
+	}
+
+	/**
+	 * Returns the method name.
+	 *
+	 * Example:
+	 *
 	 * <code>
 	 *  find
 	 *  </code>
-	 * 
+	 *
 	 * from the given signature:
-	 * 
+	 *
 	 * <code>
 	 * find(query : java.lang.String, params : java.util.Map<java.lang.String,java.lang.Object>) : io.quarkus.hibernate.orm.panache.PanacheQuery<T>
 	 * </code>
-	 * 
+	 *
 	 * @return the method name.
 	 */
 	@Override
@@ -77,22 +105,22 @@ public class JavaMethodInfo extends JavaMemberInfo {
 		}
 		return methodName;
 	}
-	
+
 	/**
 	 * Returns the method return Java type and null otherwise.
-	 * 
+	 *
 	 * Example:
-	 * 
+	 *
 	 * <code>
 	 *  io.quarkus.hibernate.orm.panache.PanacheQuery<T>
 	 *  </code>
-	 * 
+	 *
 	 * from the given signature:
-	 * 
+	 *
 	 * <code>
 	 * find(query : java.lang.String, params : java.util.Map<java.lang.String,java.lang.Object>) : io.quarkus.hibernate.orm.panache.PanacheQuery<T>
 	 * </code>
-	 * 
+	 *
 	 * @return the method return Java type and null otherwise.
 	 */
 	public String getReturnType() {
@@ -107,7 +135,7 @@ public class JavaMethodInfo extends JavaMemberInfo {
 
 	/**
 	 * Returns the getter name of the method name.
-	 * 
+	 *
 	 * @return the getter name of the method name.
 	 */
 	public String getGetterName() {
@@ -136,7 +164,7 @@ public class JavaMethodInfo extends JavaMemberInfo {
 
 	/**
 	 * Returns true if the method have parameters and false otherwise.
-	 * 
+	 *
 	 * @return true if the method have parameters and false otherwise.
 	 */
 	public boolean hasParameters() {
@@ -148,9 +176,9 @@ public class JavaMethodInfo extends JavaMemberInfo {
 
 	/**
 	 * Returns the Java method parameter at the given index and null otherwise.
-	 * 
+	 *
 	 * @param index the method parameter index
-	 * 
+	 *
 	 * @return the Java method parameter at the given index and null otherwise.
 	 */
 	public JavaParameterInfo getParameterAt(int index) {
@@ -160,7 +188,7 @@ public class JavaMethodInfo extends JavaMemberInfo {
 
 	/**
 	 * Returns the method parameters.
-	 * 
+	 *
 	 * @return the method parameters.
 	 */
 	public List<JavaParameterInfo> getParameters() {
@@ -249,3 +277,4 @@ public class JavaMethodInfo extends JavaMemberInfo {
 		return b.toString();
 	}
 }
+

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/JavaParameterInfo.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/JavaParameterInfo.java
@@ -13,11 +13,11 @@ package com.redhat.qute.commons;
 
 /**
  * Java method parameter or type parameter (generic) information.
- * 
+ *
  * @author Angelo ZERR
  *
  */
-public class JavaParameterInfo {
+public class JavaParameterInfo extends JavaElementInfo {
 
 	private final String name;
 
@@ -30,20 +30,50 @@ public class JavaParameterInfo {
 
 	/**
 	 * Returns the parameter name.
-	 * 
+	 *
 	 * @return the parameter name.
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
 
 	/**
 	 * Returns the parameter Java type.
-	 * 
+	 *
 	 * @return the parameter Java type.
 	 */
 	public String getType() {
 		return type;
+	}
+
+	/**
+	 * Returns the Java parameter signature with a simple type.
+	 *
+	 * Example:
+	 *
+	 * <code>
+	 * query : String
+	 * </code>
+	 *
+	 * @return the Java method signature with simple type.
+	 */
+	public String getSimpleParameter() {
+		StringBuilder paramBuilder = new StringBuilder();
+		paramBuilder.append(name);
+		paramBuilder.append(" : ");
+		paramBuilder.append(getSimpleType(type));
+		return paramBuilder.toString();
+	}
+
+	@Override
+	public JavaElementKind getJavaElementKind() {
+		return JavaElementKind.PARAMETER;
+	}
+
+	@Override
+	public String getJavaElementType() {
+		return getType();
 	}
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/JavaElementInfo.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/JavaElementInfo.java
@@ -11,9 +11,11 @@
 *******************************************************************************/
 package com.redhat.qute.commons;
 
+import java.util.StringJoiner;
+
 /**
- * Base class for Java element (Java types, methods, fields)
- * 
+ * Base class for Java element (Java types, methods, fields, parameters)
+ *
  * @author Angelo ZERR
  *
  */
@@ -27,7 +29,7 @@ public abstract class JavaElementInfo {
 
 	/**
 	 * Returns the Java element signature.
-	 * 
+	 *
 	 * @return the Java element signature.
 	 */
 	public String getSignature() {
@@ -36,7 +38,7 @@ public abstract class JavaElementInfo {
 
 	/**
 	 * Set the Java element signature.
-	 * 
+	 *
 	 * @param signature the Java element signature.
 	 */
 	public void setSignature(String signature) {
@@ -45,7 +47,7 @@ public abstract class JavaElementInfo {
 
 	/**
 	 * Returns the Java element documentation and null otherwise.
-	 * 
+	 *
 	 * @return the Java element documentation and null otherwise.
 	 */
 	public String getDocumentation() {
@@ -54,7 +56,7 @@ public abstract class JavaElementInfo {
 
 	/**
 	 * Set the Java element documentation.
-	 * 
+	 *
 	 * @param documentation the Java element documentation.
 	 */
 	public void setDocumentation(String documentation) {
@@ -63,28 +65,28 @@ public abstract class JavaElementInfo {
 
 	/**
 	 * Returns the Java element name.
-	 * 
+	 *
 	 * @return the Java element name.
 	 */
 	public abstract String getName();
 
 	/**
 	 * Returns the Java element kind (type, method, field).
-	 * 
+	 *
 	 * @return the Java element kind (type, method, field).
 	 */
 	public abstract JavaElementKind getJavaElementKind();
 
 	/**
 	 * Returns the Java element type.
-	 * 
+	 *
 	 * @return the Java element type.
 	 */
 	public abstract String getJavaElementType();
 
 	/**
 	 * Returns the simple (without packages) element type and null otherwise.
-	 * 
+	 *
 	 * @return the simple (without packages) element type and null otherwise.
 	 */
 	public String getJavaElementSimpleType() {
@@ -94,19 +96,19 @@ public abstract class JavaElementInfo {
 
 	/**
 	 * Returns the simple type of the given type. Example:
-	 * 
+	 *
 	 * <p>
 	 * java.util.List<org.acme.Item>
 	 * </p>
-	 * 
+	 *
 	 * becomes
-	 * 
+	 *
 	 * <p>
 	 * List<Item>
 	 * </p>
-	 * 
+	 *
 	 * @param type the Java type.
-	 * 
+	 *
 	 * @return the simple type of the given type.
 	 */
 	public static String getSimpleType(String type) {
@@ -116,9 +118,20 @@ public abstract class JavaElementInfo {
 		int startBracketIndex = type.indexOf('<');
 		if (startBracketIndex != -1) {
 			int endBracketIndex = type.indexOf('>', startBracketIndex);
-			String generic = getSimpleTypeWithoutGeneric(type.substring(startBracketIndex + 1, endBracketIndex));
-			String mainType = getSimpleTypeWithoutGeneric(type.substring(0, startBracketIndex));
-			return mainType + '<' + generic + '>';
+			// Main type
+			StringBuilder simpleType = new StringBuilder(
+					getSimpleTypeWithoutGeneric(type.substring(0, startBracketIndex)));
+			// Generic type
+			simpleType.append('<');
+			String[] generics = type.substring(startBracketIndex + 1, endBracketIndex).split(",");
+			StringJoiner commaJoiner = new StringJoiner(",");
+			for (String generic : generics) {
+				commaJoiner.add(getSimpleTypeWithoutGeneric(generic));
+			}
+			simpleType.append(commaJoiner.toString());
+			simpleType.append('>');
+
+			return simpleType.toString();
 		}
 		return getSimpleTypeWithoutGeneric(type);
 	}
@@ -127,4 +140,5 @@ public abstract class JavaElementInfo {
 		int index = type.lastIndexOf('.');
 		return index != -1 ? type.substring(index + 1, type.length()) : type;
 	}
+
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/JavaElementKind.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/JavaElementKind.java
@@ -13,7 +13,7 @@ package com.redhat.qute.commons;
 
 /**
  * Java element kind.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -21,5 +21,6 @@ public enum JavaElementKind {
 
 	TYPE, //
 	FIELD, //
-	METHOD;
+	METHOD, //
+	PARAMETER;
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/JavaFieldInfo.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/JavaFieldInfo.java
@@ -15,7 +15,7 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * Java field information.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -27,34 +27,50 @@ public class JavaFieldInfo extends JavaMemberInfo {
 
 	/**
 	 * Returns the Java field signature.
-	 * 
+	 *
 	 * Example:
-	 * 
+	 *
 	 * <code>
 	 * price : java.math.BigInteger
 	 * </code>
-	 * 
+	 *
 	 * @return the Java field signature.
 	 */
+	@Override
 	public String getSignature() {
 		return super.getSignature();
 	}
 
 	/**
-	 * Returns the field name.
-	 * 
+	 * Returns the simple Java field signature.
+	 *
 	 * Example:
-	 * 
+	 *
+	 * <code>
+	 * price : BigInteger
+	 * </code>
+	 *
+	 * @return the simple Java field signature.
+	 */
+	public String getSimpleSignature() {
+		return name + " : " + getJavaElementSimpleType();
+	}
+
+	/**
+	 * Returns the field name.
+	 *
+	 * Example:
+	 *
 	 * <code>
 	 *  price
 	 *  </code>
-	 * 
+	 *
 	 * from the given signature:
-	 * 
+	 *
 	 * <code>
 	 * price : java.math.BigInteger
 	 * </code>
-	 * 
+	 *
 	 * @return the field name.
 	 */
 	@Override
@@ -73,19 +89,19 @@ public class JavaFieldInfo extends JavaMemberInfo {
 
 	/**
 	 * Returns the field Java type and null otherwise.
-	 * 
+	 *
 	 * Example:
-	 * 
+	 *
 	 * <code>
 	 *  java.math.BigInteger
 	 *  </code>
-	 * 
+	 *
 	 * from the given signature:
-	 * 
+	 *
 	 * <code>
 	 * price : java.math.BigInteger
 	 * </code>
-	 * 
+	 *
 	 * @return the field Java type and null otherwise.
 	 */
 	public String getType() {

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/JavaMethodInfo.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/JavaMethodInfo.java
@@ -13,12 +13,13 @@ package com.redhat.qute.commons;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.StringJoiner;
 
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * Java method information.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -34,34 +35,61 @@ public class JavaMethodInfo extends JavaMemberInfo {
 
 	/**
 	 * Returns the Java method signature.
-	 * 
+	 *
 	 * Example:
-	 * 
+	 *
 	 * <code>
 	 * find(query : java.lang.String, params : java.util.Map<java.lang.String,java.lang.Object>) : io.quarkus.hibernate.orm.panache.PanacheQuery<T>
 	 * </code>
-	 * 
+	 *
 	 * @return the Java method signature.
 	 */
+	@Override
 	public String getSignature() {
 		return super.getSignature();
 	}
 
 	/**
-	 * Returns the method name.
-	 * 
+	 * Returns the Java method signature with simple names.
+	 *
 	 * Example:
-	 * 
+	 *
+	 * <code>
+	 * find(query : String, params : Map<String,Object>) : PanacheQuery<T>
+	 * </code>
+	 *
+	 * @return the Java method signature.
+	 */
+	public String getSimpleSignature() {
+		StringBuilder simpleSignatureBuilder = new StringBuilder();
+		simpleSignatureBuilder.append(getName());
+		simpleSignatureBuilder.append("(");
+		List<JavaParameterInfo> parameters = getParameters();
+		StringJoiner commaJoiner = new StringJoiner(", ");
+		for (JavaParameterInfo parameter : parameters) {
+			commaJoiner.add(parameter.getSimpleParameter());
+		}
+		simpleSignatureBuilder.append(commaJoiner.toString());
+		simpleSignatureBuilder.append(") : ");
+		simpleSignatureBuilder.append(super.getSimpleType(getReturnType()));
+		return simpleSignatureBuilder.toString();
+	}
+
+	/**
+	 * Returns the method name.
+	 *
+	 * Example:
+	 *
 	 * <code>
 	 *  find
 	 *  </code>
-	 * 
+	 *
 	 * from the given signature:
-	 * 
+	 *
 	 * <code>
 	 * find(query : java.lang.String, params : java.util.Map<java.lang.String,java.lang.Object>) : io.quarkus.hibernate.orm.panache.PanacheQuery<T>
 	 * </code>
-	 * 
+	 *
 	 * @return the method name.
 	 */
 	@Override
@@ -77,22 +105,22 @@ public class JavaMethodInfo extends JavaMemberInfo {
 		}
 		return methodName;
 	}
-	
+
 	/**
 	 * Returns the method return Java type and null otherwise.
-	 * 
+	 *
 	 * Example:
-	 * 
+	 *
 	 * <code>
 	 *  io.quarkus.hibernate.orm.panache.PanacheQuery<T>
 	 *  </code>
-	 * 
+	 *
 	 * from the given signature:
-	 * 
+	 *
 	 * <code>
 	 * find(query : java.lang.String, params : java.util.Map<java.lang.String,java.lang.Object>) : io.quarkus.hibernate.orm.panache.PanacheQuery<T>
 	 * </code>
-	 * 
+	 *
 	 * @return the method return Java type and null otherwise.
 	 */
 	public String getReturnType() {
@@ -107,7 +135,7 @@ public class JavaMethodInfo extends JavaMemberInfo {
 
 	/**
 	 * Returns the getter name of the method name.
-	 * 
+	 *
 	 * @return the getter name of the method name.
 	 */
 	public String getGetterName() {
@@ -136,7 +164,7 @@ public class JavaMethodInfo extends JavaMemberInfo {
 
 	/**
 	 * Returns true if the method have parameters and false otherwise.
-	 * 
+	 *
 	 * @return true if the method have parameters and false otherwise.
 	 */
 	public boolean hasParameters() {
@@ -148,9 +176,9 @@ public class JavaMethodInfo extends JavaMemberInfo {
 
 	/**
 	 * Returns the Java method parameter at the given index and null otherwise.
-	 * 
+	 *
 	 * @param index the method parameter index
-	 * 
+	 *
 	 * @return the Java method parameter at the given index and null otherwise.
 	 */
 	public JavaParameterInfo getParameterAt(int index) {
@@ -160,7 +188,7 @@ public class JavaMethodInfo extends JavaMemberInfo {
 
 	/**
 	 * Returns the method parameters.
-	 * 
+	 *
 	 * @return the method parameters.
 	 */
 	public List<JavaParameterInfo> getParameters() {

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/JavaParameterInfo.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/JavaParameterInfo.java
@@ -13,11 +13,11 @@ package com.redhat.qute.commons;
 
 /**
  * Java method parameter or type parameter (generic) information.
- * 
+ *
  * @author Angelo ZERR
  *
  */
-public class JavaParameterInfo {
+public class JavaParameterInfo extends JavaElementInfo {
 
 	private final String name;
 
@@ -30,20 +30,50 @@ public class JavaParameterInfo {
 
 	/**
 	 * Returns the parameter name.
-	 * 
+	 *
 	 * @return the parameter name.
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
 
 	/**
 	 * Returns the parameter Java type.
-	 * 
+	 *
 	 * @return the parameter Java type.
 	 */
 	public String getType() {
 		return type;
+	}
+
+	/**
+	 * Returns the Java parameter signature with a simple type.
+	 *
+	 * Example:
+	 *
+	 * <code>
+	 * query : String
+	 * </code>
+	 *
+	 * @return the Java method signature with simple type.
+	 */
+	public String getSimpleParameter() {
+		StringBuilder paramBuilder = new StringBuilder();
+		paramBuilder.append(name);
+		paramBuilder.append(" : ");
+		paramBuilder.append(getSimpleType(type));
+		return paramBuilder.toString();
+	}
+
+	@Override
+	public JavaElementKind getJavaElementKind() {
+		return JavaElementKind.PARAMETER;
+	}
+
+	@Override
+	public String getJavaElementType() {
+		return getType();
 	}
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/completions/QuteCompletionsForExpression.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/completions/QuteCompletionsForExpression.java
@@ -59,7 +59,7 @@ import com.redhat.qute.utils.StringUtils;
 
 /**
  * Qute completion inside Qute expression.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -74,7 +74,7 @@ public class QuteCompletionsForExpression {
 	/**
 	 * Returns the completion result of the given offset inside the given
 	 * expression.
-	 * 
+	 *
 	 * @param expression         the expression where the completion has been
 	 *                           triggered and null otherwise.
 	 * @param nodeExpression     the node expression where the completion has been
@@ -83,9 +83,9 @@ public class QuteCompletionsForExpression {
 	 * @param offset             the offset where the completion has been triggered.
 	 * @param completionSettings the completion settings.
 	 * @param formattingSettings the formatting settings.
-	 * 
+	 *
 	 * @param cancelChecker      the cancel checker.
-	 * 
+	 *
 	 * @return the completion result as future.
 	 */
 	public CompletableFuture<CompletionList> doCompleteExpression(Expression expression, Node nodeExpression,
@@ -148,13 +148,13 @@ public class QuteCompletionsForExpression {
 	/**
 	 * Returns the completion result for Java fields, methods of the Java type
 	 * class, interface of the given part <code>part</code>
-	 * 
+	 *
 	 * @param part               the part.
 	 * @param parts              the owner parts.
 	 * @param template           the owner template.
 	 * @param completionSettings the completion settings.
 	 * @param formattingSettings the formatting settings.
-	 * 
+	 *
 	 * @return the completion list.
 	 */
 	private CompletableFuture<CompletionList> doCompleteExpressionForMemberPart(Part part, Parts parts,
@@ -194,14 +194,14 @@ public class QuteCompletionsForExpression {
 	/**
 	 * Returns the completion result for Java fields, methods of the given Java type
 	 * class, interface <code>resolvedType</code>
-	 * 
+	 *
 	 * @param resolvedType       the Java class, interface.
 	 * @param start              the part start index to replace.
 	 * @param end                the part end index to replace.
 	 * @param template           the owner Qute template.
 	 * @param completionSettings the completion settings.
 	 * @param formattingSettings the formatting settings.
-	 * 
+	 *
 	 * @return the completion list.
 	 */
 	private CompletionList doCompleteForJavaTypeMembers(ResolvedJavaTypeInfo resolvedType, int start, int end,
@@ -239,7 +239,7 @@ public class QuteCompletionsForExpression {
 	/**
 	 * Fill completion list <code>list</code> with the methods of the given Java
 	 * type <code>resolvedType</code>.
-	 * 
+	 *
 	 * @param resolvedType       the Java type class, interface.
 	 * @param range              the range.
 	 * @param projectUri         the project Uri
@@ -260,8 +260,7 @@ public class QuteCompletionsForExpression {
 			// class B {String foo;}
 			if (!existingProperties.contains(fieldName)) {
 				CompletionItem item = new CompletionItem();
-				item.setLabel(fieldName);
-				item.setLabel(fieldName + " : " + field.getType());
+				item.setLabel(field.getSimpleSignature());
 				item.setFilterText(fieldName);
 				item.setKind(CompletionItemKind.Field);
 				TextEdit textEdit = new TextEdit();
@@ -288,7 +287,7 @@ public class QuteCompletionsForExpression {
 	/**
 	 * Fill completion list <code>list</code> with the methods of the given Java
 	 * type <code>resolvedType</code>.
-	 * 
+	 *
 	 * @param resolvedType       the Java type class, interface.
 	 * @param range              the range.
 	 * @param projectUri         the project Uri
@@ -310,7 +309,7 @@ public class QuteCompletionsForExpression {
 					// It's a getter method, create a completion item for simple property (value)
 					// from the method name (getValue)
 					CompletionItem item = new CompletionItem();
-					item.setLabel(property + " : " + method.getReturnType());
+					item.setLabel(property + " : " + method.getJavaElementSimpleType());
 					item.setFilterText(property);
 					item.setKind(CompletionItemKind.Property);
 					TextEdit textEdit = new TextEdit();
@@ -340,7 +339,7 @@ public class QuteCompletionsForExpression {
 
 	private static CompletionItem fillCompletionMethod(JavaMethodInfo method, Range range,
 			QuteCompletionSettings completionSettings, QuteFormattingSettings formattingSettings, CompletionList list) {
-		String methodSignature = method.getSignature();
+		String methodSignature = method.getSimpleSignature();
 		CompletionItem item = new CompletionItem();
 		item.setLabel(methodSignature);
 		item.setFilterText(method.getName());
@@ -419,12 +418,11 @@ public class QuteCompletionsForExpression {
 	private void doCompleteExpressionForObjectPartWithParentNodes(Node part, Node node, Range range, int offset,
 			String projectUri, Set<String> existingVars, QuteCompletionSettings completionSettings,
 			QuteFormattingSettings formattingSettings, CompletionList list) {
-		Section parent = node != null ? node.getParentSection() : null;
-		if (parent == null) {
+		Section section = node != null ? node.getParentSection() : null;
+		if (section == null) {
 			return;
 		}
-		if (parent.getKind() == NodeKind.Section) {
-			Section section = (Section) parent;
+		if (section.getKind() == NodeKind.Section) {
 			boolean collect = true;
 			if (section.getSectionKind() == SectionKind.FOR || section.getSectionKind() == SectionKind.EACH) {
 				LoopSection iterableSection = ((LoopSection) section);
@@ -510,7 +508,7 @@ public class QuteCompletionsForExpression {
 				}
 			}
 		}
-		doCompleteExpressionForObjectPartWithParentNodes(part, parent, range, offset, projectUri, existingVars,
+		doCompleteExpressionForObjectPartWithParentNodes(part, section, range, offset, projectUri, existingVars,
 				completionSettings, formattingSettings, list);
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/commons/JavaFieldInfoTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/commons/JavaFieldInfoTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link JavaFieldInfo}.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -30,5 +30,6 @@ public class JavaFieldInfoTest {
 		field.setSignature(signature);
 		assertEquals("price", field.getName());
 		assertEquals("java.math.BigInteger", field.getType());
+		assertEquals("price : BigInteger", field.getSimpleSignature());
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/commons/JavaMethodInfoTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/commons/JavaMethodInfoTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link JavaMethodInfo}.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -43,5 +43,7 @@ public class JavaMethodInfoTest {
 		assertEquals("java.util.Map<java.lang.String,java.lang.Object>", parameter.getType());
 
 		assertEquals("io.quarkus.hibernate.orm.panache.PanacheQuery<T>", method.getReturnType());
+		assertEquals("find(query : String, params : Map<String,Object>) : PanacheQuery<T>",
+				method.getSimpleSignature());
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInExpressionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInExpressionTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for Qute completion in expression.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -85,42 +85,42 @@ public class QuteCompletionInExpressionTest {
 		String template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.|}";
 		testCompletionFor(template, //
-				c("base : java.lang.String", "base", r(1, 12, 1, 12)), // comes from BaseItem extended by Item
-				c("name : java.lang.String", "name", r(1, 12, 1, 12)), //
-				c("price : java.math.BigInteger", "price", r(1, 12, 1, 12)), //
-				c("review : org.acme.Review", "review", r(1, 12, 1, 12)), //
-				c("review2 : org.acme.Review", "review2", r(1, 12, 1, 12)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(1, 12, 1, 12)));
+				c("base : String", "base", r(1, 12, 1, 12)), // comes from BaseItem extended by Item
+				c("name : String", "name", r(1, 12, 1, 12)), //
+				c("price : BigInteger", "price", r(1, 12, 1, 12)), //
+				c("review : Review", "review", r(1, 12, 1, 12)), //
+				c("review2 : Review", "review2", r(1, 12, 1, 12)), //
+				c("getReview2() : Review", "getReview2", r(1, 12, 1, 12)));
 
 		template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.n|}";
 		testCompletionFor(template, //
-				c("base : java.lang.String", "base", r(1, 12, 1, 13)), // comes from BaseItem extended by Item
-				c("name : java.lang.String", "name", r(1, 12, 1, 13)), //
-				c("price : java.math.BigInteger", "price", r(1, 12, 1, 13)), //
-				c("review : org.acme.Review", "review", r(1, 12, 1, 13)), //
-				c("review2 : org.acme.Review", "review2", r(1, 12, 1, 13)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(1, 12, 1, 13)));
+				c("base : String", "base", r(1, 12, 1, 13)), // comes from BaseItem extended by Item
+				c("name : String", "name", r(1, 12, 1, 13)), //
+				c("price : BigInteger", "price", r(1, 12, 1, 13)), //
+				c("review : Review", "review", r(1, 12, 1, 13)), //
+				c("review2 : Review", "review2", r(1, 12, 1, 13)), //
+				c("getReview2() : Review", "getReview2", r(1, 12, 1, 13)));
 
 		template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.|n}";
 		testCompletionFor(template, //
-				c("base : java.lang.String", "base", r(1, 12, 1, 13)), // comes from BaseItem extended by Item
-				c("name : java.lang.String", "name", r(1, 12, 1, 13)), //
-				c("price : java.math.BigInteger", "price", r(1, 12, 1, 13)), //
-				c("review : org.acme.Review", "review", r(1, 12, 1, 13)), //
-				c("review2 : org.acme.Review", "review2", r(1, 12, 1, 13)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(1, 12, 1, 13)));
+				c("base : String", "base", r(1, 12, 1, 13)), // comes from BaseItem extended by Item
+				c("name : String", "name", r(1, 12, 1, 13)), //
+				c("price : BigInteger", "price", r(1, 12, 1, 13)), //
+				c("review : Review", "review", r(1, 12, 1, 13)), //
+				c("review2 : Review", "review2", r(1, 12, 1, 13)), //
+				c("getReview2() : Review", "getReview2", r(1, 12, 1, 13)));
 
 		template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.n|a}";
 		testCompletionFor(template, //
-				c("base : java.lang.String", "base", r(1, 12, 1, 14)), // comes from BaseItem extended by Item
-				c("name : java.lang.String", "name", r(1, 12, 1, 14)), //
-				c("price : java.math.BigInteger", "price", r(1, 12, 1, 14)), //
-				c("review : org.acme.Review", "review", r(1, 12, 1, 14)), //
-				c("review2 : org.acme.Review", "review2", r(1, 12, 1, 14)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(1, 12, 1, 14)));
+				c("base : String", "base", r(1, 12, 1, 14)), // comes from BaseItem extended by Item
+				c("name : String", "name", r(1, 12, 1, 14)), //
+				c("price : BigInteger", "price", r(1, 12, 1, 14)), //
+				c("review : Review", "review", r(1, 12, 1, 14)), //
+				c("review2 : Review", "review2", r(1, 12, 1, 14)), //
+				c("getReview2() : Review", "getReview2", r(1, 12, 1, 14)));
 	}
 
 	@Test
@@ -128,38 +128,38 @@ public class QuteCompletionInExpressionTest {
 		String template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.|";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(1, 12, 1, 12)), //
-				c("price : java.math.BigInteger", "price", r(1, 12, 1, 12)), //
-				c("review : org.acme.Review", "review", r(1, 12, 1, 12)), //
-				c("review2 : org.acme.Review", "review2", r(1, 12, 1, 12)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(1, 12, 1, 12)));
+				c("name : String", "name", r(1, 12, 1, 12)), //
+				c("price : BigInteger", "price", r(1, 12, 1, 12)), //
+				c("review : Review", "review", r(1, 12, 1, 12)), //
+				c("review2 : Review", "review2", r(1, 12, 1, 12)), //
+				c("getReview2() : Review", "getReview2", r(1, 12, 1, 12)));
 
 		template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.n|";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(1, 12, 1, 13)), //
-				c("price : java.math.BigInteger", "price", r(1, 12, 1, 13)), //
-				c("review : org.acme.Review", "review", r(1, 12, 1, 13)), //
-				c("review2 : org.acme.Review", "review2", r(1, 12, 1, 13)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(1, 12, 1, 13)));
+				c("name : String", "name", r(1, 12, 1, 13)), //
+				c("price : BigInteger", "price", r(1, 12, 1, 13)), //
+				c("review : Review", "review", r(1, 12, 1, 13)), //
+				c("review2 : Review", "review2", r(1, 12, 1, 13)), //
+				c("getReview2() : Review", "getReview2", r(1, 12, 1, 13)));
 
 		template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.|n";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(1, 12, 1, 13)), //
-				c("price : java.math.BigInteger", "price", r(1, 12, 1, 13)), //
-				c("review : org.acme.Review", "review", r(1, 12, 1, 13)), //
-				c("review2 : org.acme.Review", "review2", r(1, 12, 1, 13)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(1, 12, 1, 13)));
+				c("name : String", "name", r(1, 12, 1, 13)), //
+				c("price : BigInteger", "price", r(1, 12, 1, 13)), //
+				c("review : Review", "review", r(1, 12, 1, 13)), //
+				c("review2 : Review", "review2", r(1, 12, 1, 13)), //
+				c("getReview2() : Review", "getReview2", r(1, 12, 1, 13)));
 
 		template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.n|a";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(1, 12, 1, 14)), //
-				c("price : java.math.BigInteger", "price", r(1, 12, 1, 14)), //
-				c("review : org.acme.Review", "review", r(1, 12, 1, 14)), //
-				c("review2 : org.acme.Review", "review2", r(1, 12, 1, 14)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(1, 12, 1, 14)));
+				c("name : String", "name", r(1, 12, 1, 14)), //
+				c("price : BigInteger", "price", r(1, 12, 1, 14)), //
+				c("review : Review", "review", r(1, 12, 1, 14)), //
+				c("review2 : Review", "review2", r(1, 12, 1, 14)), //
+				c("getReview2() : Review", "getReview2", r(1, 12, 1, 14)));
 	}
 
 	@Test
@@ -167,26 +167,26 @@ public class QuteCompletionInExpressionTest {
 		String template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.review.|}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(1, 19, 1, 19)), //
-				c("average : java.lang.Integer", "average", r(1, 19, 1, 19)));
+				c("name : String", "name", r(1, 19, 1, 19)), //
+				c("average : Integer", "average", r(1, 19, 1, 19)));
 
 		template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.review.n|}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(1, 19, 1, 20)), //
-				c("average : java.lang.Integer", "average", r(1, 19, 1, 20)));
+				c("name : String", "name", r(1, 19, 1, 20)), //
+				c("average : Integer", "average", r(1, 19, 1, 20)));
 
 		template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.review.|n}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(1, 19, 1, 20)), //
-				c("average : java.lang.Integer", "average", r(1, 19, 1, 20)));
+				c("name : String", "name", r(1, 19, 1, 20)), //
+				c("average : Integer", "average", r(1, 19, 1, 20)));
 
 		template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.review.n|a}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(1, 19, 1, 21)), //
-				c("average : java.lang.Integer", "average", r(1, 19, 1, 21)));
+				c("name : String", "name", r(1, 19, 1, 21)), //
+				c("average : Integer", "average", r(1, 19, 1, 21)));
 	}
 
 	@Test
@@ -194,26 +194,26 @@ public class QuteCompletionInExpressionTest {
 		String template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.getReview2().|}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(1, 25, 1, 25)), //
-				c("average : java.lang.Integer", "average", r(1, 25, 1, 25)));
+				c("name : String", "name", r(1, 25, 1, 25)), //
+				c("average : Integer", "average", r(1, 25, 1, 25)));
 
 		template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.getReview2().n|}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(1, 25, 1, 26)), //
-				c("average : java.lang.Integer", "average", r(1, 25, 1, 26)));
+				c("name : String", "name", r(1, 25, 1, 26)), //
+				c("average : Integer", "average", r(1, 25, 1, 26)));
 
 		template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.getReview2().|n}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(1, 25, 1, 26)), //
-				c("average : java.lang.Integer", "average", r(1, 25, 1, 26)));
+				c("name : String", "name", r(1, 25, 1, 26)), //
+				c("average : Integer", "average", r(1, 25, 1, 26)));
 
 		template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.getReview2().n|a}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(1, 25, 1, 27)), //
-				c("average : java.lang.Integer", "average", r(1, 25, 1, 27)));
+				c("name : String", "name", r(1, 25, 1, 27)), //
+				c("average : Integer", "average", r(1, 25, 1, 27)));
 	}
 
 	@Test
@@ -221,26 +221,26 @@ public class QuteCompletionInExpressionTest {
 		String template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.review2.|}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(1, 20, 1, 20)), //
-				c("average : java.lang.Integer", "average", r(1, 20, 1, 20)));
+				c("name : String", "name", r(1, 20, 1, 20)), //
+				c("average : Integer", "average", r(1, 20, 1, 20)));
 
 		template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.review2.n|}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(1, 20, 1, 21)), //
-				c("average : java.lang.Integer", "average", r(1, 20, 1, 21)));
+				c("name : String", "name", r(1, 20, 1, 21)), //
+				c("average : Integer", "average", r(1, 20, 1, 21)));
 
 		template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.review2.|n}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(1, 20, 1, 21)), //
-				c("average : java.lang.Integer", "average", r(1, 20, 1, 21)));
+				c("name : String", "name", r(1, 20, 1, 21)), //
+				c("average : Integer", "average", r(1, 20, 1, 21)));
 
 		template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.review2.n|a}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(1, 20, 1, 22)), //
-				c("average : java.lang.Integer", "average", r(1, 20, 1, 22)));
+				c("name : String", "name", r(1, 20, 1, 22)), //
+				c("average : Integer", "average", r(1, 20, 1, 22)));
 	}
 
 	@Test
@@ -277,6 +277,6 @@ public class QuteCompletionInExpressionTest {
 		String template = "{@org.acme.Item item}\r\n" + //
 				"Item: {item.|}";
 		testCompletionFor(template, //
-				c("discountedPrice(item : org.acme.Item) : java.math.BigDecimal", "discountedPrice", r(1, 12, 1, 12)));
+				c("discountedPrice(item : Item) : BigDecimal", "discountedPrice", r(1, 12, 1, 12)));
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInExpressionWithEachSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInExpressionWithEachSectionTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for Qute completion in expression.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -65,11 +65,11 @@ public class QuteCompletionInExpressionWithEachSectionTest {
 				"		{it.|}\r\n" + //
 				"{/each}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(3, 6, 3, 6)), //
-				c("price : java.math.BigInteger", "price", r(3, 6, 3, 6)), //
-				c("review : org.acme.Review", "review", r(3, 6, 3, 6)), //
-				c("review2 : org.acme.Review", "review2", r(3, 6, 3, 6)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(3, 6, 3, 6)));
+				c("name : String", "name", r(3, 6, 3, 6)), //
+				c("price : BigInteger", "price", r(3, 6, 3, 6)), //
+				c("review : Review", "review", r(3, 6, 3, 6)), //
+				c("review2 : Review", "review2", r(3, 6, 3, 6)), //
+				c("getReview2() : Review", "getReview2", r(3, 6, 3, 6)));
 
 		template = "{@java.util.List<org.acme.Item> items}\r\n" + //
 				" \r\n" + //
@@ -77,11 +77,11 @@ public class QuteCompletionInExpressionWithEachSectionTest {
 				"		{it.n|}\r\n" + //
 				"{/each}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(3, 6, 3, 7)), //
-				c("price : java.math.BigInteger", "price", r(3, 6, 3, 7)), //
-				c("review : org.acme.Review", "review", r(3, 6, 3, 7)), //
-				c("review2 : org.acme.Review", "review2", r(3, 6, 3, 7)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(3, 6, 3, 7)));
+				c("name : String", "name", r(3, 6, 3, 7)), //
+				c("price : BigInteger", "price", r(3, 6, 3, 7)), //
+				c("review : Review", "review", r(3, 6, 3, 7)), //
+				c("review2 : Review", "review2", r(3, 6, 3, 7)), //
+				c("getReview2() : Review", "getReview2", r(3, 6, 3, 7)));
 
 		template = "{@java.util.List<org.acme.Item> items}\r\n" + //
 				" \r\n" + //
@@ -89,11 +89,11 @@ public class QuteCompletionInExpressionWithEachSectionTest {
 				"		{it.|n}\r\n" + //
 				"{/each}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(3, 6, 3, 7)), //
-				c("price : java.math.BigInteger", "price", r(3, 6, 3, 7)), //
-				c("review : org.acme.Review", "review", r(3, 6, 3, 7)), //
-				c("review2 : org.acme.Review", "review2", r(3, 6, 3, 7)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(3, 6, 3, 7)));
+				c("name : String", "name", r(3, 6, 3, 7)), //
+				c("price : BigInteger", "price", r(3, 6, 3, 7)), //
+				c("review : Review", "review", r(3, 6, 3, 7)), //
+				c("review2 : Review", "review2", r(3, 6, 3, 7)), //
+				c("getReview2() : Review", "getReview2", r(3, 6, 3, 7)));
 
 		template = "{@java.util.List<org.acme.Item> items}\r\n" + //
 				" \r\n" + //
@@ -101,11 +101,11 @@ public class QuteCompletionInExpressionWithEachSectionTest {
 				"		{it.n|a}\r\n" + //
 				"{/each}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(3, 6, 3, 8)), //
-				c("price : java.math.BigInteger", "price", r(3, 6, 3, 8)), //
-				c("review : org.acme.Review", "review", r(3, 6, 3, 8)), //
-				c("review2 : org.acme.Review", "review2", r(3, 6, 3, 8)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(3, 6, 3, 8)));
+				c("name : String", "name", r(3, 6, 3, 8)), //
+				c("price : BigInteger", "price", r(3, 6, 3, 8)), //
+				c("review : Review", "review", r(3, 6, 3, 8)), //
+				c("review2 : Review", "review2", r(3, 6, 3, 8)), //
+				c("getReview2() : Review", "getReview2", r(3, 6, 3, 8)));
 	}
 
 	@Test
@@ -130,11 +130,11 @@ public class QuteCompletionInExpressionWithEachSectionTest {
 				"	{/if}	    \r\n" + //
 				"{/each}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(4, 6, 4, 6)), //
-				c("price : java.math.BigInteger", "price", r(4, 6, 4, 6)), //
-				c("review : org.acme.Review", "review", r(4, 6, 4, 6)), //
-				c("review2 : org.acme.Review", "review2", r(4, 6, 4, 6)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(4, 6, 4, 6)));
+				c("name : String", "name", r(4, 6, 4, 6)), //
+				c("price : BigInteger", "price", r(4, 6, 4, 6)), //
+				c("review : Review", "review", r(4, 6, 4, 6)), //
+				c("review2 : Review", "review2", r(4, 6, 4, 6)), //
+				c("getReview2() : Review", "getReview2", r(4, 6, 4, 6)));
 	}
 
 	@Test
@@ -173,8 +173,8 @@ public class QuteCompletionInExpressionWithEachSectionTest {
 				"	{/each}\r\n" + //
 				"{/for}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(4, 6, 4, 6)), //
-				c("average : java.lang.Integer", "average", r(4, 6, 4, 6)));
+				c("name : String", "name", r(4, 6, 4, 6)), //
+				c("average : Integer", "average", r(4, 6, 4, 6)));
 	}
 
 	@Test

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInExpressionWithForSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInExpressionWithForSectionTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for Qute completion in expression.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -76,11 +76,11 @@ public class QuteCompletionInExpressionWithForSectionTest {
 				"	{item.|}    \r\n" + //
 				"{/for}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(3, 7, 3, 7)), //
-				c("price : java.math.BigInteger", "price", r(3, 7, 3, 7)), //
-				c("review : org.acme.Review", "review", r(3, 7, 3, 7)), //
-				c("review2 : org.acme.Review", "review2", r(3, 7, 3, 7)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(3, 7, 3, 7)));
+				c("name : String", "name", r(3, 7, 3, 7)), //
+				c("price : BigInteger", "price", r(3, 7, 3, 7)), //
+				c("review : Review", "review", r(3, 7, 3, 7)), //
+				c("review2 : Review", "review2", r(3, 7, 3, 7)), //
+				c("getReview2() : Review", "getReview2", r(3, 7, 3, 7)));
 
 		template = "{@java.util.List<org.acme.Item> items}\r\n" + //
 				" \r\n" + //
@@ -88,11 +88,11 @@ public class QuteCompletionInExpressionWithForSectionTest {
 				"	{item.n|}    \r\n" + //
 				"{/for}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(3, 7, 3, 8)), //
-				c("price : java.math.BigInteger", "price", r(3, 7, 3, 8)), //
-				c("review : org.acme.Review", "review", r(3, 7, 3, 8)), //
-				c("review2 : org.acme.Review", "review2", r(3, 7, 3, 8)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(3, 7, 3, 8)));
+				c("name : String", "name", r(3, 7, 3, 8)), //
+				c("price : BigInteger", "price", r(3, 7, 3, 8)), //
+				c("review : Review", "review", r(3, 7, 3, 8)), //
+				c("review2 : Review", "review2", r(3, 7, 3, 8)), //
+				c("getReview2() : Review", "getReview2", r(3, 7, 3, 8)));
 
 		template = "{@java.util.List<org.acme.Item> items}\r\n" + //
 				" \r\n" + //
@@ -100,11 +100,11 @@ public class QuteCompletionInExpressionWithForSectionTest {
 				"	{item.|n}    \r\n" + //
 				"{/for}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(3, 7, 3, 8)), //
-				c("price : java.math.BigInteger", "price", r(3, 7, 3, 8)), //
-				c("review : org.acme.Review", "review", r(3, 7, 3, 8)), //
-				c("review2 : org.acme.Review", "review2", r(3, 7, 3, 8)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(3, 7, 3, 8)));
+				c("name : String", "name", r(3, 7, 3, 8)), //
+				c("price : BigInteger", "price", r(3, 7, 3, 8)), //
+				c("review : Review", "review", r(3, 7, 3, 8)), //
+				c("review2 : Review", "review2", r(3, 7, 3, 8)), //
+				c("getReview2() : Review", "getReview2", r(3, 7, 3, 8)));
 
 		template = "{@java.util.List<org.acme.Item> items}\r\n" + //
 				" \r\n" + //
@@ -112,11 +112,11 @@ public class QuteCompletionInExpressionWithForSectionTest {
 				"	{item.n|a}    \r\n" + //
 				"{/for}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(3, 7, 3, 9)), //
-				c("price : java.math.BigInteger", "price", r(3, 7, 3, 9)), //
-				c("review : org.acme.Review", "review", r(3, 7, 3, 9)), //
-				c("review2 : org.acme.Review", "review2", r(3, 7, 3, 9)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(3, 7, 3, 9)));
+				c("name : String", "name", r(3, 7, 3, 9)), //
+				c("price : BigInteger", "price", r(3, 7, 3, 9)), //
+				c("review : Review", "review", r(3, 7, 3, 9)), //
+				c("review2 : Review", "review2", r(3, 7, 3, 9)), //
+				c("getReview2() : Review", "getReview2", r(3, 7, 3, 9)));
 
 	}
 
@@ -142,11 +142,11 @@ public class QuteCompletionInExpressionWithForSectionTest {
 				"	{/if}	    \r\n" + //
 				"{/for}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(4, 8, 4, 8)), //
-				c("price : java.math.BigInteger", "price", r(4, 8, 4, 8)), //
-				c("review : org.acme.Review", "review", r(4, 8, 4, 8)), //
-				c("review2 : org.acme.Review", "review2", r(4, 8, 4, 8)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(4, 8, 4, 8)));
+				c("name : String", "name", r(4, 8, 4, 8)), //
+				c("price : BigInteger", "price", r(4, 8, 4, 8)), //
+				c("review : Review", "review", r(4, 8, 4, 8)), //
+				c("review2 : Review", "review2", r(4, 8, 4, 8)), //
+				c("getReview2() : Review", "getReview2", r(4, 8, 4, 8)));
 	}
 
 	@Test
@@ -185,8 +185,8 @@ public class QuteCompletionInExpressionWithForSectionTest {
 				"	{/for}\r\n" + //
 				"{/for}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(4, 10, 4, 10)), //
-				c("average : java.lang.Integer", "average", r(4, 10, 4, 10)));
+				c("name : String", "name", r(4, 10, 4, 10)), //
+				c("average : Integer", "average", r(4, 10, 4, 10)));
 	}
 
 	@Test

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInExpressionWithLetSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInExpressionWithLetSectionTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for Qute completion in expression for #set/#let section.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -91,11 +91,11 @@ public class QuteCompletionInExpressionWithLetSectionTest {
 				"  Age: {age}\r\n" + //
 				"{/let}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(2, 16, 2, 16)), //
-				c("price : java.math.BigInteger", "price", r(2, 16, 2, 16)), //
-				c("review : org.acme.Review", "review", r(2, 16, 2, 16)), //
-				c("review2 : org.acme.Review", "review2", r(2, 16, 2, 16)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(2, 16, 2, 16)));
+				c("name : String", "name", r(2, 16, 2, 16)), //
+				c("price : BigInteger", "price", r(2, 16, 2, 16)), //
+				c("review : Review", "review", r(2, 16, 2, 16)), //
+				c("review2 : Review", "review2", r(2, 16, 2, 16)), //
+				c("getReview2() : Review", "getReview2", r(2, 16, 2, 16)));
 	}
 
 	@Test
@@ -119,7 +119,7 @@ public class QuteCompletionInExpressionWithLetSectionTest {
 				"  Age: {age}\r\n" + //
 				"{/let}";
 		testCompletionFor(template, //
-				c("name : java.lang.String", "name", r(2, 16, 2, 16)));
+				c("name : String", "name", r(2, 16, 2, 16)));
 	}
 
 	@Test

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInExpressionWithWithSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInExpressionWithWithSectionTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for Qute completion in expression for #with section.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -33,10 +33,10 @@ public class QuteCompletionInExpressionWithWithSectionTest {
 				"{/with}";
 		testCompletionFor(template, //
 				c("item", "item", r(2, 7, 2, 7)), //
-				c("name : java.lang.String", "name", r(2, 7, 2, 7)), //
-				c("price : java.math.BigInteger", "price", r(2, 7, 2, 7)), //
-				c("review : org.acme.Review", "review", r(2, 7, 2, 7)), //
-				c("review2 : org.acme.Review", "review2", r(2, 7, 2, 7)), //
-				c("getReview2() : org.acme.Review", "getReview2", r(2, 7, 2, 7)));
+				c("name : String", "name", r(2, 7, 2, 7)), //
+				c("price : BigInteger", "price", r(2, 7, 2, 7)), //
+				c("review : Review", "review", r(2, 7, 2, 7)), //
+				c("review2 : Review", "review2", r(2, 7, 2, 7)), //
+				c("getReview2() : Review", "getReview2", r(2, 7, 2, 7)));
 	}
 }


### PR DESCRIPTION
Changed Qute embedded Java completion to display simple types instead of resolved name.

Fixes #490 

Signed-off-by: Alexander Chen <alchen@redhat.com>