### PR TITLE
Use SafeConstructor for Yaml parser instantation.

### DIFF
--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/utils/YamlUtils.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/utils/YamlUtils.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 /**
  * Yaml utilities.
@@ -40,7 +41,7 @@ public class YamlUtils {
 	public static Properties loadYamlAsProperties(InputStream input) {
 		Properties properties = new Properties();
 		// Load Yaml document
-		Yaml yaml = new Yaml();
+		Yaml yaml = new Yaml(new SafeConstructor());
 		Object yamlDocument = yaml.load(input);
 		if (yamlDocument != null) {
 			// flattern Yaml document to properties.


### PR DESCRIPTION
- CVE-2021-25738

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

See https://j0vsec.com/post/cve-2021-25738/ . The CVE doesn't really mention snakeyaml directly (opting to mention the dependent library instead), but if you read the post the issue is in snakeyaml.