### PR TITLE
Settings from workspace folder

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/QuteTextDocumentService.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/QuteTextDocumentService.java
@@ -55,7 +55,6 @@ import com.redhat.qute.commons.datamodel.JavaDataModelChangeEvent;
 import com.redhat.qute.ls.commons.client.ExtendedClientCapabilities;
 import com.redhat.qute.ls.java.JavaFileTextDocumentService;
 import com.redhat.qute.ls.template.TemplateFileTextDocumentService;
-import com.redhat.qute.settings.QuteValidationSettings;
 import com.redhat.qute.settings.SharedSettings;
 
 /**
@@ -70,8 +69,8 @@ public class QuteTextDocumentService implements TextDocumentService {
 
 	private final TemplateFileTextDocumentService templateFileTextDocumentService;
 
-	public QuteTextDocumentService(QuteLanguageServer quteLanguageServer, SharedSettings sharedSettings) {
-		this.sharedSettings = sharedSettings;
+	public QuteTextDocumentService(QuteLanguageServer quteLanguageServer) {
+		this.sharedSettings = quteLanguageServer.getSharedSettings();
 		this.javaFileTextDocumentService = new JavaFileTextDocumentService(quteLanguageServer, sharedSettings);
 		this.templateFileTextDocumentService = new TemplateFileTextDocumentService(quteLanguageServer, sharedSettings);
 	}
@@ -266,11 +265,7 @@ public class QuteTextDocumentService implements TextDocumentService {
 		templateFileTextDocumentService.dataModelChanged(event);
 	}
 
-	public SharedSettings getSharedSettings() {
-		return sharedSettings;
-	}
-
-	public void updateValidationSettings(QuteValidationSettings newValidation) {
-		templateFileTextDocumentService.updateValidationSettings(newValidation);
+	public void validationSettingsChanged() {
+		templateFileTextDocumentService.validationSettingsChanged();
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/template/QuteTextDocument.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/template/QuteTextDocument.java
@@ -107,4 +107,5 @@ public class QuteTextDocument extends ModelTextDocument<Template> implements Tem
 		getProjectInfoFuture().getNow(null);
 		return null;
 	}
+
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/template/TemplateFileTextDocumentService.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/template/TemplateFileTextDocumentService.java
@@ -59,7 +59,6 @@ import com.redhat.qute.parser.template.Template;
 import com.redhat.qute.parser.template.TemplateParser;
 import com.redhat.qute.services.QuteLanguageService;
 import com.redhat.qute.services.diagnostics.ResolvingJavaTypeContext;
-import com.redhat.qute.settings.QuteValidationSettings;
 import com.redhat.qute.settings.SharedSettings;
 import com.redhat.qute.utils.QutePositionUtility;
 
@@ -252,8 +251,8 @@ public class TemplateFileTextDocumentService extends AbstractTextDocumentService
 					// Collect diagnostics
 					ResolvingJavaTypeContext resolvingJavaTypeContext = new ResolvingJavaTypeContext(template);
 					List<Diagnostic> diagnostics = getQuteLanguageService().doDiagnostics(template,
-							getSharedSettings().getValidationSettings(), resolvingJavaTypeContext,
-							() -> template.checkCanceled());
+							getSharedSettings().getValidationSettings(template.getUri()),
+							resolvingJavaTypeContext, () -> template.checkCanceled());
 
 					// Diagnostics has been collected, before diagnostics publishing, check if the
 					// document has changed since diagnostics collect.
@@ -348,16 +347,11 @@ public class TemplateFileTextDocumentService extends AbstractTextDocumentService
 		return result;
 	}
 
-	public void updateValidationSettings(QuteValidationSettings newValidation) {
-		// Update validation settings
-		QuteValidationSettings validation = sharedSettings.getValidationSettings();
-		if (!validation.equals(newValidation)) {
-			validation.update(newValidation);
-			// trigger validation for all opened Qute template files
-			documents.all().stream().forEach(document -> {
-				triggerValidationFor((QuteTextDocument) document);
-			});
-		}
+	public void validationSettingsChanged() {
+		// trigger validation for all opened Qute template files
+		documents.all().stream().forEach(document -> {
+			triggerValidationFor((QuteTextDocument) document);
+		});
 	}
 
 	public void dataModelChanged(JavaDataModelChangeEvent event) {

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/AllQuteSettings.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/AllQuteSettings.java
@@ -37,7 +37,6 @@ public class AllQuteSettings {
 	 * @param qute the qute to set
 	 */
 	public void setQute(Object qute) {
-
 		this.qute = qute;
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/BaseSettings.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/BaseSettings.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.settings;
+
+/**
+ * Base class for settings.
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class BaseSettings {
+
+	private final QuteValidationSettings validationSettings;
+
+	public BaseSettings() {
+		this.validationSettings = new QuteValidationSettings();
+	}
+
+	/**
+	 * Returns the Qute validation settings.
+	 * 
+	 * @return the Qute validation settings.
+	 */
+	public QuteValidationSettings getValidationSettings() {
+		return validationSettings;
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/QuteGeneralClientSettings.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/QuteGeneralClientSettings.java
@@ -11,6 +11,8 @@
 *******************************************************************************/
 package com.redhat.qute.settings;
 
+import java.util.Map;
+
 import com.redhat.qute.utils.JSONUtility;
 
 /**
@@ -29,6 +31,9 @@ import com.redhat.qute.utils.JSONUtility;
  * 
  */
 public class QuteGeneralClientSettings {
+
+	private Map<String, QuteGeneralClientSettings> workspaceFolders;
+
 	private QuteValidationSettings validation;
 
 	/**
@@ -49,6 +54,14 @@ public class QuteGeneralClientSettings {
 		this.validation = validation;
 	}
 
+	public Map<String, QuteGeneralClientSettings> getWorkspaceFolders() {
+		return workspaceFolders;
+	}
+
+	public void setWorkspaceFolders(Map<String, QuteGeneralClientSettings> workspaceFolders) {
+		this.workspaceFolders = workspaceFolders;
+	}
+
 	/**
 	 * Returns the general settings from the given initialization options
 	 * 
@@ -57,5 +70,71 @@ public class QuteGeneralClientSettings {
 	 */
 	public static QuteGeneralClientSettings getGeneralQuteSettings(Object initializationOptionsSettings) {
 		return JSONUtility.toModel(initializationOptionsSettings, QuteGeneralClientSettings.class);
+	}
+
+	/**
+	 * State after an update of the shared settings.
+	 *
+	 */
+	public static class SettingsUpdateState {
+
+		private final boolean validationSettingsChanged;
+
+		public SettingsUpdateState(boolean validationChanged) {
+			this.validationSettingsChanged = validationChanged;
+		}
+
+		/**
+		 * Returns true if validation settings changed and false otherwise.
+		 * 
+		 * @return true if validation settings changed and false otherwise.
+		 */
+		public boolean isValidationSettingsChanged() {
+			return validationSettingsChanged;
+		}
+
+	}
+
+	/**
+	 * Update the given shared settings with the given client settings.
+	 * 
+	 * @param sharedSettings the shared settings to update.
+	 * @param clientSettings the client settings used to update the shared settings.
+	 * 
+	 * @return the state of the update of the shared settings.
+	 */
+	public static SettingsUpdateState update(SharedSettings sharedSettings, QuteGeneralClientSettings clientSettings) {
+		Map<String, QuteGeneralClientSettings> workspaceFolders = clientSettings.getWorkspaceFolders();
+		// Update validation settings
+		boolean validationSettingsChanged = updateValidationSettings(sharedSettings, clientSettings);
+		if (sharedSettings.cleanWorkspaceFolderSettings(workspaceFolders != null ? workspaceFolders.keySet() : null)) {
+			validationSettingsChanged = true;
+		}
+		return new SettingsUpdateState(validationSettingsChanged);
+	}
+
+	private static boolean updateValidationSettings(SharedSettings sharedSettings,
+			QuteGeneralClientSettings clientSettings) {
+		// Global validation settings
+		boolean validationSettingsChanged = updateValidationSettings(sharedSettings, clientSettings.getValidation());
+		// Workspace folder validation settings
+		Map<String, QuteGeneralClientSettings> workspaceFolders = clientSettings.getWorkspaceFolders();
+		if (workspaceFolders != null) {
+			for (Map.Entry<String /* workspace folder Uri */, QuteGeneralClientSettings> entry : workspaceFolders
+					.entrySet()) {
+				String workspaceFolderUri = entry.getKey();
+				BaseSettings settings = sharedSettings.getWorkspaceFolderSettings(workspaceFolderUri);
+				validationSettingsChanged |= updateValidationSettings(settings, entry.getValue().getValidation());
+			}
+		}
+		return validationSettingsChanged;
+	}
+
+	private static boolean updateValidationSettings(BaseSettings sharedSettings, QuteValidationSettings validation) {
+		if (validation != null && !validation.equals(sharedSettings.getValidationSettings())) {
+			sharedSettings.getValidationSettings().update(validation);
+			return true;
+		}
+		return false;
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/SharedSettings.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/SharedSettings.java
@@ -11,25 +11,31 @@
 *******************************************************************************/
 package com.redhat.qute.settings;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 /**
  * Qute shared settings.
  * 
  * @author Angelo ZERR
  *
  */
-public class SharedSettings {
+public class SharedSettings extends BaseSettings {
 	private final QuteCompletionSettings completionSettings;
 	private final QuteCodeLensSettings codeLensSettings;
 	private final QuteFormattingSettings formattingSettings;
-	private final QuteValidationSettings validationSettings;
 	private final QuteHoverSettings hoverSettings;
 	private final QuteCommandCapabilities commandCapabilities;
+
+	private Map<String /* workspace folder Uri */, BaseSettings> workspaceFolders;
 
 	public SharedSettings() {
 		this.completionSettings = new QuteCompletionSettings();
 		this.codeLensSettings = new QuteCodeLensSettings();
 		this.formattingSettings = new QuteFormattingSettings();
-		this.validationSettings = new QuteValidationSettings();
 		this.hoverSettings = new QuteHoverSettings();
 		this.commandCapabilities = new QuteCommandCapabilities();
 	}
@@ -62,12 +68,14 @@ public class SharedSettings {
 	}
 
 	/**
-	 * Returns the validation settings.
+	 * Returns the validation settings for the given Qute template file Uri.
 	 * 
-	 * @return the validation settings.
+	 * @param templateFileUri the Qute template file Uri.
+	 * 
+	 * @return the validation settings for the given Qute template file Uri.
 	 */
-	public QuteValidationSettings getValidationSettings() {
-		return validationSettings;
+	public QuteValidationSettings getValidationSettings(String templateFileUri) {
+		return getSettings(templateFileUri).getValidationSettings();
 	}
 
 	/**
@@ -86,5 +94,80 @@ public class SharedSettings {
 	 */
 	public QuteCommandCapabilities getCommandCapabilities() {
 		return commandCapabilities;
+	}
+
+	/**
+	 * Returns the settings for the given Qute template file Uri.
+	 * 
+	 * @param templateFileUri the Qute template file Uri.
+	 * 
+	 * @return the settings for the given Qute template file Uri.
+	 */
+	private BaseSettings getSettings(String templateFileUri) {
+		if (workspaceFolders != null) {
+			for (Map.Entry<String /* workspace folder Uri */, BaseSettings> entry : workspaceFolders.entrySet()) {
+				String workspaceFolderUri = entry.getKey();
+				if (templateFileUri.startsWith(workspaceFolderUri)) {
+					return entry.getValue();
+				}
+			}
+		}
+		return this;
+	}
+
+	/**
+	 * Returns the settings for the given workspace folder Uri.
+	 * 
+	 * @param workspaceFolderUri the workspace folder Uri.
+	 * 
+	 * @return the settings for the given workspace folder Uri.
+	 */
+	public BaseSettings getWorkspaceFolderSettings(String workspaceFolderUri) {
+		if (workspaceFolders == null) {
+			workspaceFolders = new HashMap<String, BaseSettings>();
+		}
+		if (!workspaceFolders.containsKey(workspaceFolderUri)) {
+			workspaceFolders.put(workspaceFolderUri, new BaseSettings());
+		}
+		return workspaceFolders.get(workspaceFolderUri);
+	}
+
+	/**
+	 * Clean unused workspace folder settings.
+	 * 
+	 * @param existingWorkspaceFolderUris the existing workspace folder uris.
+	 * 
+	 * @return true if a workspace folder settings is clear and false otherwise.
+	 */
+	public boolean cleanWorkspaceFolderSettings(Set<String> existingWorkspaceFolderUris) {
+		if (workspaceFolders == null) {
+			return false;
+		}
+		if (existingWorkspaceFolderUris == null) {
+			workspaceFolders.clear();
+			return true;
+		} else {
+			boolean changed = false;
+			Set<String> uris = new HashSet<String>(getWorkspaceFolderSettingsUris());
+			for (String uri : uris) {
+				if (!existingWorkspaceFolderUris.contains(uri)) {
+					workspaceFolders.remove(uri);
+					changed = true;
+				}
+			}
+			return changed;
+		}
+	}
+
+	/**
+	 * Returns the workspace folder settings Uris.
+	 * 
+	 * @return the workspace folder settings Uris.
+	 */
+	public Set<String> getWorkspaceFolderSettingsUris() {
+		if (workspaceFolders == null) {
+			return Collections.emptySet();
+		}
+		return workspaceFolders.keySet();
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionWithSettingsTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionWithSettingsTest.java
@@ -73,21 +73,23 @@ public class QuteCodeActionWithSettingsTest {
 		SharedSettings settings = createSharedSettings(QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE);
 		testCodeActionsFor(template, d, //
 				settings, //
-				ca(d, c("Disable Qute validation.", //
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
 						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
 						"qute.validation.enabled", //
+						"test.qute", //						
 						ConfigurationItemEditType.update, false, //
 						d)), //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String item}" + //
 						System.lineSeparator())));
 	}
 
-	private static Command c(String title, String commandId, String section, ConfigurationItemEditType edit,
-			Object value, Diagnostic d) {
+	private static Command c(String title, String commandId, String section, String scopeUri,
+			ConfigurationItemEditType edit, Object value, Diagnostic d) {
 		Command command = new Command();
 		command.setTitle(title);
 		command.setCommand(commandId);
 		ConfigurationItemEdit itemEdit = new ConfigurationItemEdit(section, edit, value);
+		itemEdit.setScopeUri(scopeUri);
 		command.setArguments(Collections.singletonList(itemEdit));
 		return command;
 	}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/settings/SettingsTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/settings/SettingsTest.java
@@ -11,21 +11,27 @@
 *******************************************************************************/
 package com.redhat.qute.settings;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
 
 import org.eclipse.lsp4j.InitializeParams;
 import org.junit.jupiter.api.Test;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.redhat.qute.settings.QuteGeneralClientSettings.SettingsUpdateState;
 
 /**
  * Tests for settings.
  */
 public class SettingsTest {
 
-	private final String json = "{\r\n" + //
+	private static final String globalSettings = "{\r\n" + //
 			"    \"settings\": {\r\n" + //
 			"        \"qute\": {\r\n" + //
 			"            \"validation\": {\r\n" + //
@@ -35,25 +41,194 @@ public class SettingsTest {
 			"    }\r\n" + //
 			"}";
 
+	private static final String workspaceFoldersSettings = "{\r\n" + //
+			"	\"settings\": {\r\n" + //
+			"		\"qute\": {\r\n" + //
+			"			\"workspaceFolders\": {\r\n" + //
+			"				\"file:///c%3A/qute-1\": {\r\n" + //
+			"					\"validation\": {\r\n" + //
+			"						\"enabled\": false\r\n" + //
+			"					}\r\n" + //
+			"				},\r\n" + //
+			"				\"file:///c%3A/qute-2\": {\r\n" + //
+			"					\"validation\": {\r\n" + //
+			"						\"enabled\": true\r\n" + //
+			"					}\r\n" + //
+			"				}\r\n" + //
+			"			}\r\n" + //
+			"		}\r\n" + //
+			"	}\r\n" + //
+			"}";
+
+	private static final String oneWorkspaceFoldersSettings = "{\r\n" + //
+			"	\"settings\": {\r\n" + //
+			"		\"qute\": {\r\n" + //
+			"			\"workspaceFolders\": {\r\n" + //
+			"				\"file:///c%3A/qute-1\": {\r\n" + //
+			"					\"validation\": {\r\n" + //
+			"						\"enabled\": false\r\n" + //
+			"					}\r\n" + //
+			"				}\r\n" + //
+			"			}\r\n" + //
+			"		}\r\n" + //
+			"	}\r\n" + //
+			"}";
+
 	@Test
-	public void initializationOptionsSettings() {
+	public void globalClientSettings() {
 
 		// Emulate InitializeParams#getInitializationOptions() object created as
 		// JSONObject when QuteLanguageServer#initialize(InitializeParams
 		// params) is
 		// called
-		InitializeParams params = createInitializeParams(json);
+		QuteGeneralClientSettings settings = createGlobalSettings();
+		assertNotNull(settings);
+
+		// No workspace folders settings
+		assertNull(settings.getWorkspaceFolders());
+
+		// Validation
+		QuteValidationSettings validation = settings.getValidation();
+		assertNotNull(validation);
+		assertTrue(validation.isEnabled(), "Validation enabled");
+	}
+
+	private static QuteGeneralClientSettings createGlobalSettings() {
+		InitializeParams params = createInitializeParams(globalSettings);
 		Object initializationOptionsSettings = InitializationOptionsSettings.getSettings(params);
 
 		// Test client commons settings
 		initializationOptionsSettings = AllQuteSettings.getQuteSettings(initializationOptionsSettings);
 		QuteGeneralClientSettings settings = QuteGeneralClientSettings
 				.getGeneralQuteSettings(initializationOptionsSettings);
+		return settings;
+	}
+
+	@Test
+	public void workspaceFoldersClientSettings() {
+
+		QuteGeneralClientSettings settings = createWorkspaceFoldersSettings();
 		assertNotNull(settings);
 
-		// Validation
-		assertNotNull(settings.getValidation());
-		assertTrue(settings.getValidation().isEnabled(), "Validation enabled");
+		// No global settings
+		assertNull(settings.getValidation());
+
+		Map<String, QuteGeneralClientSettings> workspaceFolders = settings.getWorkspaceFolders();
+		assertNotNull(workspaceFolders);
+
+		assertEquals(2, workspaceFolders.keySet().size());
+
+		// file:///c%3A/qute-1 workspace folder settings
+		QuteGeneralClientSettings settings1 = workspaceFolders.get("file:///c%3A/qute-1");
+		assertNotNull(settings1);
+		QuteValidationSettings validation1 = settings1.getValidation();
+		assertNotNull(validation1);
+		assertFalse(validation1.isEnabled(), "Validation disabled");
+
+		// file:///c%3A/qute-2 workspace folder settings
+		QuteGeneralClientSettings settings2 = workspaceFolders.get("file:///c%3A/qute-2");
+		assertNotNull(settings2);
+		QuteValidationSettings validation2 = settings2.getValidation();
+		assertNotNull(validation2);
+		assertTrue(validation2.isEnabled(), "Validation enabled");
+
+	}
+
+	@Test
+	public void workspaceFoldersSharedSettings() {
+
+		// Client settings load 1
+		QuteGeneralClientSettings clientSettings = createWorkspaceFoldersSettings();
+		assertNotNull(clientSettings);
+
+		SharedSettings sharedSettings = new SharedSettings();
+		SettingsUpdateState result = QuteGeneralClientSettings.update(sharedSettings, clientSettings);
+		assertTrue(result.isValidationSettingsChanged());
+
+		QuteValidationSettings defaultValidation = sharedSettings
+				.getValidationSettings("file:///c%3A/XXXX/src/main/resources/items.qute.html");
+		assertNotNull(defaultValidation);
+		assertTrue(defaultValidation.isEnabled(), "Validation enabled");
+
+		QuteValidationSettings validation1 = sharedSettings
+				.getValidationSettings("file:///c%3A/qute-1/src/main/resources/items.qute.html");
+		assertNotNull(validation1);
+		assertFalse(validation1.isEnabled(), "Validation disabled");
+
+		QuteValidationSettings validation2 = sharedSettings
+				.getValidationSettings("file:///c%3A/qute-2/src/main/resources/items.qute.html");
+		assertNotNull(validation2);
+		assertTrue(validation2.isEnabled(), "Validation enabled");
+
+		// Client settings load 2
+		clientSettings = createWorkspaceFoldersSettings();
+		result = QuteGeneralClientSettings.update(sharedSettings, clientSettings);
+		assertFalse(result.isValidationSettingsChanged());
+
+		// Client settings load 3
+		clientSettings = createWorkspaceFoldersSettings();
+		QuteGeneralClientSettings settings = clientSettings.getWorkspaceFolders().get("file:///c%3A/qute-1");
+		assertNotNull(settings);
+		// Update the validation enabled for the first workspace folder settings.
+		settings.getValidation().setEnabled(true);
+		result = QuteGeneralClientSettings.update(sharedSettings, clientSettings);
+		assertTrue(result.isValidationSettingsChanged());
+
+		validation1 = sharedSettings.getValidationSettings("file:///c%3A/qute-1/src/main/resources/items.qute.html");
+		assertNotNull(validation1);
+		assertTrue(validation1.isEnabled(), "Validation enabled");
+
+	}
+
+	@Test
+	public void workspaceFoldersSharedSettingsChanged() {
+
+		// 2 workspace settings
+		QuteGeneralClientSettings clientSettings = createWorkspaceFoldersSettings();
+		assertNotNull(clientSettings);
+
+		SharedSettings sharedSettings = new SharedSettings();
+		SettingsUpdateState result = QuteGeneralClientSettings.update(sharedSettings, clientSettings);
+		assertTrue(result.isValidationSettingsChanged());
+		assertEquals(2, sharedSettings.getWorkspaceFolderSettingsUris().size());
+
+		// 1 workspace settings
+		clientSettings = createOneWorkspaceFoldersSettings();
+		assertNotNull(clientSettings);
+
+		result = QuteGeneralClientSettings.update(sharedSettings, clientSettings);
+		assertTrue(result.isValidationSettingsChanged());
+		assertEquals(1, sharedSettings.getWorkspaceFolderSettingsUris().size());
+
+		// 0 workspace settings
+		clientSettings = createGlobalSettings();
+		assertNotNull(clientSettings);
+
+		result = QuteGeneralClientSettings.update(sharedSettings, clientSettings);
+		assertTrue(result.isValidationSettingsChanged());
+		assertEquals(0, sharedSettings.getWorkspaceFolderSettingsUris().size());
+	}
+
+	private static QuteGeneralClientSettings createWorkspaceFoldersSettings() {
+		InitializeParams params = createInitializeParams(workspaceFoldersSettings);
+		Object initializationOptionsSettings = InitializationOptionsSettings.getSettings(params);
+
+		// Test client commons settings
+		initializationOptionsSettings = AllQuteSettings.getQuteSettings(initializationOptionsSettings);
+		QuteGeneralClientSettings settings = QuteGeneralClientSettings
+				.getGeneralQuteSettings(initializationOptionsSettings);
+		return settings;
+	}
+
+	private static QuteGeneralClientSettings createOneWorkspaceFoldersSettings() {
+		InitializeParams params = createInitializeParams(oneWorkspaceFoldersSettings);
+		Object initializationOptionsSettings = InitializationOptionsSettings.getSettings(params);
+
+		// Test client commons settings
+		initializationOptionsSettings = AllQuteSettings.getQuteSettings(initializationOptionsSettings);
+		QuteGeneralClientSettings settings = QuteGeneralClientSettings
+				.getGeneralQuteSettings(initializationOptionsSettings);
+		return settings;
 	}
 
 	private static InitializeParams createInitializeParams(String json) {


### PR DESCRIPTION
Settings from workspace folder

Signed-off-by: azerr <azerr@redhat.com>

This PR provides the capability to manage settings per workspace folder. It means that when you disable the validation with code action, it stores the disable setting in the settings.json of the project (and not in the workspace). It means that:

 * you can have several projects in a workspace and validation can be enabled / disabled for some project. The disabled is not global of the workspace.
 * As the disables setting is store in settings.json of the project, it's very portable (you can push the .vscode/settings.json in the git and share this settings with the team.