### PR TITLE
Added support for Qute `raw` and `safe` character escape value resolvers

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/resources/com/redhat/qute/project/datamodel/qute-resolvers.jsonc
+++ b/qute.ls/com.redhat.qute.ls/src/main/resources/com/redhat/qute/project/datamodel/qute-resolvers.jsonc
@@ -88,6 +88,24 @@
 			],
 			"url": "https://quarkus.io/guides/qute-reference#arrays"
 		},
+		// ------------- Character Escapes Resolvers --------------
+		// See https://quarkus.io/guides/qute-reference#character-escapes
+		{
+			"signature": "raw(base : java.lang.Object) : io.quarkus.qute.RawString",
+			"description": "Marks the object so that character escape is not needed and can be rendered as is.",
+			"sample": [
+				"{paragraph.raw}"
+			],
+			"url": "https://quarkus.io/guides/qute-reference#character-escapes"
+		},
+		{
+			"signature": "safe(base : java.lang.Object) : io.quarkus.qute.RawString",
+			"description": "Marks the object so that character escape is not needed and can be rendered as is.",
+			"sample": [
+				"{paragraph.safe}"
+			],
+			"url": "https://quarkus.io/guides/qute-reference#character-escapes"
+		},
 		// ------------- Collections Resolvers --------------
 		// See https://quarkus.io/guides/qute-reference#collections
 		{

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/QuteQuickStartProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/QuteQuickStartProject.java
@@ -27,7 +27,7 @@ import com.redhat.qute.ls.api.QuteDataModelProjectProvider;
 
 /**
  * Qute quick start project.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -101,6 +101,11 @@ public class QuteQuickStartProject extends MockQuteProject {
 
 		ResolvedJavaTypeInfo itemResource = createResolvedJavaTypeInfo("org.acme.ItemResource", cache);
 		registerMethod("discountedPrice(item : org.acme.Item) : java.math.BigDecimal", itemResource);
+
+		// RRawString for raw and safe resolver tests
+		ResolvedJavaTypeInfo rawString = createResolvedJavaTypeInfo("io.quarkus.qute.RawString", cache);
+		registerMethod("getValue() : java.lang.String", rawString);
+		registerMethod("toString() : java.lang.String", rawString);
 
 		return cache;
 	}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/arrays/ArrayIntegerValueResolverTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/arrays/ArrayIntegerValueResolverTest.java
@@ -47,12 +47,14 @@ public class ArrayIntegerValueResolverTest {
 		// test to check @java.lang.Integer(base : T[]) : T is not returned by the
 		// completion
 		testCompletionFor(template, //
-				5, //
+				7, //
 				c("length(base : T[]) : int", "length", r(1, 13, 1, 13)), //
 				c("size(base : T[]) : int", "size", r(1, 13, 1, 13)), //
 				c("get(base : T[], index : int) : T", "get(${1:index})$0", r(1, 13, 1, 13)), //
 				c("take(base : T[], n : int) : T[]", "take(${1:n})$0", r(1, 13, 1, 13)), //
-				c("takeLast(base : T[], n : int) : T[]", "takeLast(${1:n})$0", r(1, 13, 1, 13)));
+				c("takeLast(base : T[], n : int) : T[]", "takeLast(${1:n})$0", r(1, 13, 1, 13)), //
+				c("raw(base : Object) : RawString", "raw", r(1, 13, 1, 13)), //
+				c("safe(base : Object) : RawString", "safe", r(1, 13, 1, 13)));
 
 		template = "{@org.acme.Item[] items}\r\n" + //
 				"Item: {items.0.|}";

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/characterescapes/RawValueResolverTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/characterescapes/RawValueResolverTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+
+package com.redhat.qute.resolvers.characterescapes;
+
+import static com.redhat.qute.QuteAssert.assertHover;
+import static com.redhat.qute.QuteAssert.c;
+import static com.redhat.qute.QuteAssert.r;
+import static com.redhat.qute.QuteAssert.testCompletionFor;
+import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for 'raw' value resolver.
+ *
+ * @see https://quarkus.io/guides/qute-reference#character-escapes
+ *
+ */
+public class RawValueResolverTest {
+	@Test
+	public void diagnostics() throws Exception {
+		String template = "{@org.acme.Item item}\r\n" + //
+				"{item.name.raw}";
+		testDiagnosticsFor(template);
+		template = "{@org.acme.Item item}\r\n" + //
+				"{item.name.raw.value}";
+		testDiagnosticsFor(template);
+	}
+
+	@Test
+	public void completion() throws Exception {
+		String template = "{@org.acme.Item item}\r\n" + //
+				"{item.name.|}";
+		testCompletionFor(template, //
+				c("raw(base : Object) : RawString", "raw", r(1, 11, 1, 11)));
+		template = "{@org.acme.Item item}\r\n" + //
+				"{item.name.raw.|}";
+		testCompletionFor(template, //
+				c("getValue() : String", "getValue", r(1, 15, 1, 15)), //
+				c("toString() : String", "toString", r(1, 15, 1, 15)));
+	}
+
+	@Test
+	public void hover() throws Exception {
+		String template = "{@org.acme.Item item}\r\n" + //
+				" \r\n" + //
+				"{item.name.r|aw}";
+		assertHover(template, "```java" + //
+				System.lineSeparator() + //
+				"RawString raw()" + //
+				System.lineSeparator() + //
+				"```" + //
+				System.lineSeparator() + //
+				"Marks the object so that character escape is not needed and can be rendered as is." + //
+				System.lineSeparator() + //
+				System.lineSeparator() + //
+				"`Sample`:" + //
+				System.lineSeparator() + //
+				"```qute-html" + //
+				System.lineSeparator() + //
+				"{paragraph.raw}" + //
+				System.lineSeparator() + //
+				"```" + //
+				System.lineSeparator() + //
+				"See [here](https://quarkus.io/guides/qute-reference#character-escapes) for more informations.", //
+				r(2, 11, 2, 14));
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/characterescapes/SafeValueResolverTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/characterescapes/SafeValueResolverTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+
+package com.redhat.qute.resolvers.characterescapes;
+
+import static com.redhat.qute.QuteAssert.assertHover;
+import static com.redhat.qute.QuteAssert.c;
+import static com.redhat.qute.QuteAssert.r;
+import static com.redhat.qute.QuteAssert.testCompletionFor;
+import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for 'raw' value resolver.
+ *
+ * @see https://quarkus.io/guides/qute-reference#character-escapes
+ *
+ */
+public class SafeValueResolverTest {
+	@Test
+	public void diagnostics() throws Exception {
+		String template = "{@org.acme.Item item}\r\n" + //
+				"{item.name.safe}";
+		testDiagnosticsFor(template);
+		template = "{@org.acme.Item item}\r\n" + //
+				"{item.name.safe.value}";
+		testDiagnosticsFor(template);
+	}
+
+	@Test
+	public void completion() throws Exception {
+		String template = "{@org.acme.Item item}\r\n" + //
+				"{item.name.|}";
+		testCompletionFor(template, //
+				c("safe(base : Object) : RawString", "safe", r(1, 11, 1, 11)));
+		template = "{@org.acme.Item item}\r\n" + //
+				"{item.name.safe.|}";
+		testCompletionFor(template, //
+				c("getValue() : String", "getValue", r(1, 16, 1, 16)), //
+				c("toString() : String", "toString", r(1, 16, 1, 16)));
+	}
+
+	@Test
+	public void hover() throws Exception {
+		String template = "{@org.acme.Item item}\r\n" + //
+				" \r\n" + //
+				"{item.name.s|afe}";
+		assertHover(template, "```java" + //
+				System.lineSeparator() + //
+				"RawString safe()" + //
+				System.lineSeparator() + //
+				"```" + //
+				System.lineSeparator() + //
+				"Marks the object so that character escape is not needed and can be rendered as is." + //
+				System.lineSeparator() + //
+				System.lineSeparator() + //
+				"`Sample`:" + //
+				System.lineSeparator() + //
+				"```qute-html" + //
+				System.lineSeparator() + //
+				"{paragraph.safe}" + //
+				System.lineSeparator() + //
+				"```" + //
+				System.lineSeparator() + //
+				"See [here](https://quarkus.io/guides/qute-reference#character-escapes) for more informations.", //
+				r(2, 11, 2, 15));
+	}
+}


### PR DESCRIPTION
Added support for Qute `raw` and `safe` character escape value resolvers.

Fixes #533 

Signed-off-by: Alexander Chen <alchen@redhat.com>