### PR TITLE
Added refactoring for changing with section to let

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/CodeActionFactory.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/CodeActionFactory.java
@@ -106,6 +106,16 @@ public class CodeActionFactory {
 		return replace(title, Collections.singletonList(replace), document, diagnostic);
 	}
 
+	@SuppressWarnings("null")
+	public static CodeAction replace(String title, List<Range> ranges, String replaceText, TextDocumentItem document,
+			Diagnostic diagnostic) {
+		List<TextEdit> edits = null;
+		for (Range range : ranges) {
+			edits.add(new TextEdit(range, replaceText));
+		}
+		return replace(title, edits, document, diagnostic);
+	}
+
 	public static CodeAction replace(String title, List<TextEdit> replace, TextDocumentItem document,
 			Diagnostic diagnostic) {
 

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/ObjectPartASTVisitor.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/ObjectPartASTVisitor.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.parser.template;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.redhat.qute.parser.expression.ObjectPart;
+
+/**
+ * Collect object part names.
+ *
+ * @author Angelo ZERR
+ *
+ */
+public class ObjectPartASTVisitor extends ASTVisitor {
+
+	private final Set<String> objectPartNames;
+
+	public ObjectPartASTVisitor() {
+		this.objectPartNames = new HashSet<>();
+	}
+
+	@Override
+	public boolean visit(ObjectPart node) {
+		objectPartNames.add(node.getPartName());
+		return true;
+	}
+
+	public Set<String> getObjectPartNames() {
+		return objectPartNames;
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteDiagnostics.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteDiagnostics.java
@@ -54,6 +54,7 @@ import com.redhat.qute.parser.template.SectionKind;
 import com.redhat.qute.parser.template.Template;
 import com.redhat.qute.parser.template.sections.IncludeSection;
 import com.redhat.qute.parser.template.sections.LoopSection;
+import com.redhat.qute.parser.template.sections.WithSection;
 import com.redhat.qute.project.JavaMemberResult;
 import com.redhat.qute.project.QuteProject;
 import com.redhat.qute.project.datamodel.JavaDataModelCache;
@@ -248,6 +249,9 @@ class QuteDiagnostics {
 				case INCLUDE:
 					validateIncludeSection((IncludeSection) section, diagnostics);
 					break;
+				case WITH:
+					validateWithSection((WithSection) section, diagnostics);
+					break;
 				default:
 					validateSectionTag(section, template, resolvingJavaTypeContext, diagnostics);
 				}
@@ -344,6 +348,21 @@ class QuteDiagnostics {
 			// ex: {#include}
 			Range range = QutePositionUtility.selectStartTagName(includeSection);
 			Diagnostic diagnostic = createDiagnostic(range, DiagnosticSeverity.Error, QuteErrorCode.TemplateNotDefined);
+			diagnostics.add(diagnostic);
+		}
+	}
+
+	/**
+	 * Report that `#with` section is deprecated.
+	 *
+	 * @param withSection the with section
+	 * @param diagnostics the diagnostics to fill
+	 */
+	private static void validateWithSection(WithSection withSection, List<Diagnostic> diagnostics) {
+		if (withSection.getObjectParameter() != null) {
+			Range range = QutePositionUtility.createRange(withSection);
+			Diagnostic diagnostic = createDiagnostic(range, DiagnosticSeverity.Warning,
+					QuteErrorCode.NotRecommendedWithSection);
 			diagnostics.add(diagnostic);
 		}
 	}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/diagnostics/DiagnosticDataFactory.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/diagnostics/DiagnosticDataFactory.java
@@ -24,7 +24,7 @@ import com.google.gson.JsonObject;
 
 /**
  * Diagnostic factory.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -55,4 +55,5 @@ public class DiagnosticDataFactory {
 				errorCode != null ? errorCode.getCode() : null);
 		return diagnostic;
 	}
+
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/diagnostics/QuteErrorCode.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/diagnostics/QuteErrorCode.java
@@ -46,7 +46,10 @@ public enum QuteErrorCode implements IQuteErrorCode {
 
 	UndefinedSectionTag("No section helper found for `{0}`."), //
 
-	SyntaxError("Syntax error: `{0}`.");
+	SyntaxError("Syntax error: `{0}`."),
+
+	// Error code for deprecated #with section
+	NotRecommendedWithSection("`with` is not recommended. Use `let` instead.");
 
 	private final String rawMessage;
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithWithSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithWithSectionTest.java
@@ -30,27 +30,62 @@ import org.junit.jupiter.api.Test;
 public class QuteDiagnosticsInExpressionWithWithSectionTest {
 
 	@Test
+	public void missingObject() throws Exception {
+		String template = "{#with}\r\n" + //
+				"{/with}";
+		Diagnostic d = d(0, 6, 0, 6, QuteErrorCode.SyntaxError,
+				"Parser error on line 1: mandatory section parameters not declared for {#with}: [object]",
+				DiagnosticSeverity.Error);
+
+		testDiagnosticsFor(template, d);
+		testCodeActionsFor(template, d);
+	}
+
+	@Test
 	public void undefinedObject() throws Exception {
 		String template = "{#with item}\r\n" + //
 				"{/with}";
 
-		Diagnostic d = d(0, 7, 0, 11, QuteErrorCode.UndefinedObject, "`item` cannot be resolved to an object.",
+		Diagnostic d1 = d(0, 7, 0, 11, QuteErrorCode.UndefinedObject, "`item` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("item", false));
+		d1.setData(DiagnosticDataFactory.createUndefinedVariableData("item", false));
 
-		testDiagnosticsFor(template, d);
-		testCodeActionsFor(template, d, //
-				ca(d, te(0, 0, 0, 0, "{@java.lang.String item}\r\n")));
+		Diagnostic d2 = d(0, 0, 1, 7, QuteErrorCode.NotRecommendedWithSection,
+				"`with` is not recommended. Use `let` instead.", DiagnosticSeverity.Warning);
+
+		testDiagnosticsFor(template, d1, d2);
+		testCodeActionsFor(template, d1, //
+				ca(d1, te(0, 0, 0, 0, "{@java.lang.String item}\r\n")));
+		testCodeActionsFor(template, d2, //
+				ca(d2, te(0, 1, 0, 11, "#let "), te(1, 1, 1, 6, "/let")));
 	}
 
 	@Test
-	public void noError() throws Exception {
+	public void singleSection() throws Exception {
 		String template = "{@org.acme.Item item}\r\n" + //
 				"{#with item}\r\n" + //
 				"  <h1>{name}</h1>  \r\n" + //
 				"  <p>{price}</p> \r\n" + //
 				"{/with}";
-		testDiagnosticsFor(template);
+		Diagnostic d = d(1, 0, 4, 7, QuteErrorCode.NotRecommendedWithSection,
+				"`with` is not recommended. Use `let` instead.", DiagnosticSeverity.Warning);
+		testDiagnosticsFor(template, d);
+		testCodeActionsFor(template, d, //
+				ca(d, te(1, 1, 1, 11, "#let price=item.price name=item.name"), te(4, 1, 4, 6, "/let")));
+	}
+
+	@Test
+	public void nestedParameter() throws Exception {
+		String template = "{@org.acme.Item item}\r\n" + //
+				"{#with item}\r\n" + //
+				"  {#let foo=name} \r\n" + //
+				"  {/let} \r\n" + //
+				"{/with}";
+		Diagnostic d = d(1, 0, 4, 7, QuteErrorCode.NotRecommendedWithSection,
+				"`with` is not recommended. Use `let` instead.", DiagnosticSeverity.Warning);
+		testDiagnosticsFor(template, d);
+		testCodeActionsFor(template, d, //
+				ca(d, te(1, 1, 1, 11, "#let name=item.name"), te(4, 1, 4, 6, "/let")));
 	}
 
 	@Test
@@ -68,13 +103,25 @@ public class QuteDiagnosticsInExpressionWithWithSectionTest {
 				"  {/with}\r\n" + //
 				"{/with}";
 
-		Diagnostic d = d(6, 5, 6, 12, QuteErrorCode.UndefinedObject, "`average` cannot be resolved to an object.",
-				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("average", false));
+		Diagnostic d1 = d(1, 0, 11, 7, QuteErrorCode.NotRecommendedWithSection,
+				"`with` is not recommended. Use `let` instead.", DiagnosticSeverity.Warning);
 
-		testDiagnosticsFor(template, d);
-		testCodeActionsFor(template, d, //
-				ca(d, te(0, 0, 0, 0, "{@java.lang.String average}\r\n")));
+		Diagnostic d2 = d(4, 2, 10, 9, QuteErrorCode.NotRecommendedWithSection,
+				"`with` is not recommended. Use `let` instead.", DiagnosticSeverity.Warning);
+
+		Diagnostic d3 = d(6, 5, 6, 12, QuteErrorCode.UndefinedObject, "`average` cannot be resolved to an object.",
+				DiagnosticSeverity.Warning);
+		d3.setData(DiagnosticDataFactory.createUndefinedVariableData("average", false));
+
+		testDiagnosticsFor(template, d1, d2, d3);
+		testCodeActionsFor(template, d1, //
+				ca(d1, te(1, 1, 1, 11, "#let reviews=item.reviews name=item.name"), te(11, 1, 11, 6, "/let")));
+		testCodeActionsFor(template, d2, //
+				ca(d2, te(4, 3, 4, 16,
+						"#let average=reviews.average size=reviews.size name=reviews.name data:item.name=reviews.data:item.name item.name=reviews.item.name"),
+						te(10, 3, 10, 8, "/let")));
+		testCodeActionsFor(template, d3, //
+				ca(d3, te(0, 0, 0, 0, "{@java.lang.String average}\r\n")));
 
 	}
 }


### PR DESCRIPTION
Added diagnostic for deprecated `#with` section and CodeAction to use `#let`.
![replacewithwithlet2](https://user-images.githubusercontent.com/26389510/156605147-630c6987-9bab-472a-ba25-8dc8fc827701.gif)


Fixes #489 

Signed-off-by: Alexander Chen <alchen@redhat.com>