### PR TITLE
Added rename support for Qute templates

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/QuteTextDocumentService.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/QuteTextDocumentService.java
@@ -46,11 +46,13 @@ import org.eclipse.lsp4j.LinkedEditingRanges;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.ReferenceParams;
+import org.eclipse.lsp4j.RenameParams;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.TextDocumentService;
 
@@ -222,6 +224,15 @@ public class QuteTextDocumentService implements TextDocumentService {
 		TextDocumentService service = getTextDocumentService(params.getTextDocument());
 		if (service != null) {
 			return service.references(params);
+		}
+		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public CompletableFuture<WorkspaceEdit> rename(RenameParams params) {
+		TextDocumentService service = getTextDocumentService(params.getTextDocument());
+		if (service != null) {
+			return service.rename(params);
 		}
 		return CompletableFuture.completedFuture(null);
 	}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/template/TemplateFileTextDocumentService.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/template/TemplateFileTextDocumentService.java
@@ -50,8 +50,10 @@ import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.ReferenceParams;
+import org.eclipse.lsp4j.RenameParams;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
@@ -142,6 +144,7 @@ public class TemplateFileTextDocumentService extends AbstractTextDocumentService
 				});
 	}
 
+	@Override
 	public CompletableFuture<List<Either<Command, CodeAction>>> codeAction(CodeActionParams params) {
 		return computeModelAsync2(getDocument(params.getTextDocument().getUri()).getModel(),
 				(cancelChecker, template) -> {
@@ -229,6 +232,14 @@ public class TemplateFileTextDocumentService extends AbstractTextDocumentService
 	public CompletableFuture<List<? extends Location>> references(ReferenceParams params) {
 		return getTemplate(params.getTextDocument(), (cancelChecker, template) -> {
 			return getQuteLanguageService().findReferences(template, params.getPosition(), params.getContext(),
+					cancelChecker);
+		});
+	}
+
+	@Override
+	public CompletableFuture<WorkspaceEdit> rename(RenameParams params) {
+		return getTemplate(params.getTextDocument(), (cancelChecker, template) -> {
+			return getQuteLanguageService().doRename(template, params.getPosition(), params.getNewName(),
 					cancelChecker);
 		});
 	}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteRename.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteRename.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+
+import com.redhat.qute.ls.commons.BadLocationException;
+import com.redhat.qute.parser.template.Node;
+import com.redhat.qute.parser.template.Template;
+import com.redhat.qute.utils.QutePositionUtility;
+import com.redhat.qute.utils.QuteSearchUtils;
+
+/**
+ * Qute rename support.
+ *
+ */
+class QuteRename {
+
+	private static final Logger LOGGER = Logger.getLogger(QuteRename.class.getName());
+
+	public WorkspaceEdit doRename(Template template, Position position, String newText, CancelChecker cancelChecker) {
+		try {
+			int offset = template.offsetAt(position);
+			Node node = template.findNodeAt(offset);
+			if (node == null) {
+				return null;
+			}
+			node = QutePositionUtility.findBestNode(offset, node);
+
+			List<Range> ranges = new ArrayList<>();
+			QuteSearchUtils.searchReferencedObjects(node, offset, //
+					(n, range) -> ranges.add(range), true, cancelChecker);
+			if (ranges.size() <= 1) {
+				return null;
+			}
+			List<TextEdit> textEdits = new ArrayList<>();
+			for (Range r : ranges) {
+				textEdits.add(new TextEdit(r, newText));
+			}
+			return createWorkspaceEdit(template.getUri(), textEdits);
+		} catch (BadLocationException e) {
+			LOGGER.log(Level.SEVERE, "In QuteRename, the client provided Position is at a BadLocation", e);
+			return null;
+		}
+	}
+
+	private static WorkspaceEdit createWorkspaceEdit(String documentURI, List<TextEdit> textEdits) {
+		Map<String, List<TextEdit>> changes = new HashMap<>();
+		changes.put(documentURI, textEdits);
+		return new WorkspaceEdit(changes);
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/capabilities/ClientCapabilitiesWrapper.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/capabilities/ClientCapabilitiesWrapper.java
@@ -100,7 +100,11 @@ public class ClientCapabilitiesWrapper {
 	public boolean isInlayHintDynamicRegistered() {
 		return v3Supported && isDynamicRegistrationSupported(getTextDocument().getInlayHint());
 	}
-	
+
+	public boolean isRenameDynamicRegistered() {
+		return v3Supported && isDynamicRegistrationSupported(getTextDocument().getRename());
+	}
+
 	private boolean isDynamicRegistrationSupported(DynamicRegistrationCapabilities capability) {
 		return capability != null && capability.getDynamicRegistration() != null
 				&& capability.getDynamicRegistration().booleanValue();

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/capabilities/QuteCapabilityManager.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/capabilities/QuteCapabilityManager.java
@@ -25,17 +25,19 @@ import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.
 import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.INLAY_HINT_ID;
 import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.LINKED_EDITING_RANGE_ID;
 import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.REFERENCES_ID;
+import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.RENAME_ID;
 import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_CODE_ACTION;
 import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_CODE_LENS;
 import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_COMPLETION;
 import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_DEFINITION;
+import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_DOCUMENT_LINK;
 import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_DOCUMENT_SYMBOL;
 import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_HIGHLIGHT;
 import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_HOVER;
 import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_INLAY_HINT;
-import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_LINK;
 import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_LINKED_EDITING_RANGE;
 import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_REFERENCES;
+import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_RENAME;
 import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.WORKSPACE_EXECUTE_COMMAND;
 import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.WORKSPACE_EXECUTE_COMMAND_ID;
 import static com.redhat.qute.settings.capabilities.ServerCapabilitiesConstants.WORKSPACE_WATCHED_FILES;
@@ -80,8 +82,11 @@ public class QuteCapabilityManager {
 		if (this.getClientCapabilities().isCodeActionDynamicRegistered()) {
 			registerCapability(CODE_ACTION_ID, TEXT_DOCUMENT_CODE_ACTION);
 		}
-		if (this.getClientCapabilities().isDocumentHighlightDynamicRegistered()) {
-			registerCapability(DOCUMENT_HIGHLIGHT_ID, TEXT_DOCUMENT_HIGHLIGHT);
+		if (this.getClientCapabilities().isCodeLensDynamicRegistered()) {
+			registerCapability(CODE_LENS_ID, TEXT_DOCUMENT_CODE_LENS, DEFAULT_CODELENS_OPTIONS);
+		}
+		if (this.getClientCapabilities().isCompletionDynamicRegistrationSupported()) {
+			registerCapability(COMPLETION_ID, TEXT_DOCUMENT_COMPLETION, DEFAULT_COMPLETION_OPTIONS);
 		}
 		if (this.getClientCapabilities().isDefinitionDynamicRegistered()) {
 			registerCapability(DOCUMENT_DEFINITION_ID, TEXT_DOCUMENT_DEFINITION);
@@ -89,26 +94,26 @@ public class QuteCapabilityManager {
 		if (this.getClientCapabilities().isDocumentLinkDynamicRegistered()) {
 			registerCapability(DOCUMENT_DEFINITION_ID, TEXT_DOCUMENT_DEFINITION);
 		}
+		if (this.getClientCapabilities().isDocumentHighlightDynamicRegistered()) {
+			registerCapability(DOCUMENT_HIGHLIGHT_ID, TEXT_DOCUMENT_HIGHLIGHT);
+		}
+		if (this.getClientCapabilities().isDocumentLinkDynamicRegistered()) {
+			registerCapability(DOCUMENT_LINK_ID, TEXT_DOCUMENT_DOCUMENT_LINK, DEFAULT_DOCUMENT_LINK_OPTIONS);
+		}
 		if (this.getClientCapabilities().isDocumentSymbolDynamicRegistrationSupported()) {
 			registerCapability(DOCUMENT_SYMBOL_ID, TEXT_DOCUMENT_DOCUMENT_SYMBOL);
-		}
-		if (this.getClientCapabilities().isCompletionDynamicRegistrationSupported()) {
-			registerCapability(COMPLETION_ID, TEXT_DOCUMENT_COMPLETION, DEFAULT_COMPLETION_OPTIONS);
-		}
-		if (this.getClientCapabilities().isCodeLensDynamicRegistered()) {
-			registerCapability(CODE_LENS_ID, TEXT_DOCUMENT_CODE_LENS, DEFAULT_CODELENS_OPTIONS);
 		}
 		if (this.getClientCapabilities().isHoverDynamicRegistered()) {
 			registerCapability(HOVER_ID, TEXT_DOCUMENT_HOVER);
 		}
-		if (this.getClientCapabilities().isDocumentLinkDynamicRegistered()) {
-			registerCapability(DOCUMENT_LINK_ID, TEXT_DOCUMENT_LINK, DEFAULT_DOCUMENT_LINK_OPTIONS);
+		if (this.getClientCapabilities().isLinkedEditingRangeDynamicRegistered()) {
+			registerCapability(LINKED_EDITING_RANGE_ID, TEXT_DOCUMENT_LINKED_EDITING_RANGE);
 		}
 		if (this.getClientCapabilities().isReferencesDynamicRegistrationSupported()) {
 			registerCapability(REFERENCES_ID, TEXT_DOCUMENT_REFERENCES);
 		}
-		if (this.getClientCapabilities().isLinkedEditingRangeDynamicRegistered()) {
-			registerCapability(LINKED_EDITING_RANGE_ID, TEXT_DOCUMENT_LINKED_EDITING_RANGE);
+		if (this.getClientCapabilities().isRenameDynamicRegistered()) {
+			registerCapability(RENAME_ID, TEXT_DOCUMENT_RENAME);
 		}
 		if (this.getClientCapabilities().isInlayHintDynamicRegistered()) {
 			registerCapability(INLAY_HINT_ID, TEXT_DOCUMENT_INLAY_HINT);

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/capabilities/ServerCapabilitiesConstants.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/capabilities/ServerCapabilitiesConstants.java
@@ -26,47 +26,47 @@ public class ServerCapabilitiesConstants {
 	private ServerCapabilitiesConstants() {
 	}
 
-	public static final String TEXT_DOCUMENT_COMPLETION = "textDocument/completion";
-	public static final String TEXT_DOCUMENT_HOVER = "textDocument/hover";
-	public static final String TEXT_DOCUMENT_DOCUMENT_SYMBOL = "textDocument/documentSymbol";
-	public static final String TEXT_DOCUMENT_DEFINITION = "textDocument/definition";
-	public static final String TEXT_DOCUMENT_LINK = "textDocument/documentLink";
-	public static final String TEXT_DOCUMENT_FORMATTING = "textDocument/formatting";
-	public static final String TEXT_DOCUMENT_RANGE_FORMATTING = "textDocument/rangeFormatting";
+	/* textDocument/... */
 	public static final String TEXT_DOCUMENT_CODE_ACTION = "textDocument/codeAction";
 	public static final String TEXT_DOCUMENT_CODE_LENS = "textDocument/codeLens";
-
+	public static final String TEXT_DOCUMENT_COMPLETION = "textDocument/completion";
+	public static final String TEXT_DOCUMENT_DEFINITION = "textDocument/definition";
+	public static final String TEXT_DOCUMENT_DOCUMENT_LINK = "textDocument/documentLink";
+	public static final String TEXT_DOCUMENT_DOCUMENT_SYMBOL = "textDocument/documentSymbol";
+	public static final String TEXT_DOCUMENT_FORMATTING = "textDocument/formatting";
 	public static final String TEXT_DOCUMENT_HIGHLIGHT = "textDocument/documentHighlight";
-
-	public static final String TEXT_DOCUMENT_REFERENCES = "textDocument/references";
-
+	public static final String TEXT_DOCUMENT_HOVER = "textDocument/hover";
 	public static final String TEXT_DOCUMENT_LINKED_EDITING_RANGE = "textDocument/linkedEditingRange";
+	public static final String TEXT_DOCUMENT_RANGE_FORMATTING = "textDocument/rangeFormatting";
+	public static final String TEXT_DOCUMENT_REFERENCES = "textDocument/references";
+	public static final String TEXT_DOCUMENT_RENAME = "textDocument/rename";
 	public static final String TEXT_DOCUMENT_INLAY_HINT = "textDocument/inlayHint";
+	/* workspace/... */
 	public static final String WORKSPACE_EXECUTE_COMMAND = "workspace/executeCommand";
-
 	public static final String WORKSPACE_WATCHED_FILES = "workspace/didChangeWatchedFiles";
 
-	public static final String DOCUMENT_HIGHLIGHT_ID = UUID.randomUUID().toString();
-	public static final String COMPLETION_ID = UUID.randomUUID().toString();
-	public static final String HOVER_ID = UUID.randomUUID().toString();
-	public static final String DOCUMENT_SYMBOL_ID = UUID.randomUUID().toString();
-	public static final String DOCUMENT_DEFINITION_ID = UUID.randomUUID().toString();
-	public static final String DOCUMENT_LINK_ID = UUID.randomUUID().toString();
-	public static final String FORMATTING_ID = UUID.randomUUID().toString();
-	public static final String RANGE_FORMATTING_ID = UUID.randomUUID().toString();
-
+	/* UUID */
 	public static final String CODE_ACTION_ID = UUID.randomUUID().toString();
 	public static final String CODE_LENS_ID = UUID.randomUUID().toString();
-
-	public static final String WORKSPACE_EXECUTE_COMMAND_ID = UUID.randomUUID().toString();
-	public static final String REFERENCES_ID = UUID.randomUUID().toString();
-	public static final String WORKSPACE_WATCHED_FILES_ID = UUID.randomUUID().toString();
+	public static final String COMPLETION_ID = UUID.randomUUID().toString();
+	public static final String DOCUMENT_DEFINITION_ID = UUID.randomUUID().toString();
+	public static final String DOCUMENT_HIGHLIGHT_ID = UUID.randomUUID().toString();
+	public static final String DOCUMENT_LINK_ID = UUID.randomUUID().toString();
+	public static final String DOCUMENT_SYMBOL_ID = UUID.randomUUID().toString();
+	public static final String FORMATTING_ID = UUID.randomUUID().toString();
+	public static final String HOVER_ID = UUID.randomUUID().toString();
 	public static final String LINKED_EDITING_RANGE_ID = UUID.randomUUID().toString();
+	public static final String RANGE_FORMATTING_ID = UUID.randomUUID().toString();
+	public static final String REFERENCES_ID = UUID.randomUUID().toString();
+	public static final String RENAME_ID = UUID.randomUUID().toString();
+	public static final String WORKSPACE_EXECUTE_COMMAND_ID = UUID.randomUUID().toString();
+	public static final String WORKSPACE_WATCHED_FILES_ID = UUID.randomUUID().toString();
 	public static final String INLAY_HINT_ID = UUID.randomUUID().toString();
+
+	/* Default Options */
+	public static final CodeLensOptions DEFAULT_CODELENS_OPTIONS = new CodeLensOptions();
 	public static final CompletionOptions DEFAULT_COMPLETION_OPTIONS = new CompletionOptions(false,
 			Arrays.asList("{", "@", "#", ".", ":"));
-
 	public static final DocumentLinkOptions DEFAULT_DOCUMENT_LINK_OPTIONS = new DocumentLinkOptions(true);
 
-	public static final CodeLensOptions DEFAULT_CODELENS_OPTIONS = new CodeLensOptions();
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/capabilities/ServerCapabilitiesInitializer.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/capabilities/ServerCapabilitiesInitializer.java
@@ -28,9 +28,9 @@ public class ServerCapabilitiesInitializer {
 
 	/**
 	 * Returns all server capabilities (with default values) that aren't dynamic.
-	 * 
+	 *
 	 * A service's dynamic capability is indicated by the client.
-	 * 
+	 *
 	 * @param clientCapabilities
 	 * @return ServerCapabilities object
 	 */
@@ -56,6 +56,7 @@ public class ServerCapabilitiesInitializer {
 		serverCapabilities.setReferencesProvider(!clientCapabilities.isReferencesDynamicRegistrationSupported());
 		serverCapabilities.setLinkedEditingRangeProvider(!clientCapabilities.isLinkedEditingRangeDynamicRegistered());
 		serverCapabilities.setInlayHintProvider(!clientCapabilities.isInlayHintDynamicRegistered());
+		serverCapabilities.setRenameProvider(!clientCapabilities.isRenameDynamicRegistered());
 		return serverCapabilities;
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/rename/QuteRenameInForSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/rename/QuteRenameInForSectionTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.rename;
+
+import static com.redhat.qute.QuteAssert.assertRename;
+import static com.redhat.qute.QuteAssert.edits;
+import static com.redhat.qute.QuteAssert.r;
+
+import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.ls.commons.BadLocationException;
+
+/**
+ * Tests for Qute rename inside #for section.
+ *
+ */
+public class QuteRenameInForSectionTest {
+
+	@Test
+	public void fromAlias() throws BadLocationException {
+		String template = //
+				"{#for it|em in items}\r\n" + //
+				"	{item.name}\r\n" + //
+				"{/for}";
+		assertRename(template, "test", //
+				edits("test", //
+						r(0, 6, 0, 10), // {#for it|em in items}
+						r(1, 2, 1, 6) // {item.name}
+				));
+	}
+
+	@Test
+	public void toAlias() throws BadLocationException {
+		String template = //
+				"{#for item in items}\r\n" + //
+				"	{it|em.name}\r\n" + //
+				"{/for}";
+		assertRename(template, "test");
+	}
+
+	@Test
+	public void unbalanced() throws BadLocationException {
+		String template = //
+				"{#for ite|m in items}\r\n" + //
+				"{/each}";
+		assertRename(template, "test");
+	}
+
+	@Test
+	public void fromAliasInElseBlock() throws BadLocationException {
+		String template = //
+				"{#for it|em in items}\r\n" + //
+				"{#else}" + //
+				"	{item.name}\r\n" + //
+				"{/for}";
+		assertRename(template, "test");
+	}
+
+	@Test
+	public void emptyParameterName() throws BadLocationException {
+		String template = //
+				"{#let |=3}\r\n" + //
+				"{/let}";
+		assertRename(template, "test");
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/rename/QuteRenameInForUserTagTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/rename/QuteRenameInForUserTagTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.rename;
+
+import static com.redhat.qute.QuteAssert.assertRename;
+import static com.redhat.qute.QuteAssert.edits;
+import static com.redhat.qute.QuteAssert.r;
+
+import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.ls.commons.BadLocationException;
+
+/**
+ * Tests for Qute rename in user tag.
+ *
+ */
+public class QuteRenameInForUserTagTest {
+
+	@Test
+	public void fromAlias() throws BadLocationException {
+		String template = //
+				"{#for it|em in items}\r\n" + //
+				"	{item.name}\r\n" + //
+				"	{#linkItem item name=item.name item /}\r\n" + //
+				"{/for}";
+		assertRename(template, "test", //
+				edits("test", //
+						r(0, 6, 0, 10), // {#for it|em,
+						r(1, 2, 1, 6), // {it|em.name}
+						r(2, 12, 2, 16), // {#linkItem it|em
+						r(2, 22, 2, 26) // {#linkItem item name=it|em.name
+				));
+	}
+
+	@Test
+	public void toAliasIt() throws BadLocationException {
+		String template = //
+				"{#for item in items}\r\n" + //
+				"	{item.name}\r\n" + //
+				"	{#linkItem it|em name=item.name item /}\r\n" + //
+				"{/for}";
+		assertRename(template, "test");
+	}
+
+	@Test
+	public void toAliasParam() throws BadLocationException {
+		String template = //
+				"{#for item in items}\r\n" + //
+				"	{item.name}\r\n" + //
+				"	{#linkItem item name=ite|m.name item /}\r\n" + //
+				"{/for}";
+		assertRename(template, "test");
+	}
+
+	@Test
+	public void toAliasNoIt() throws BadLocationException {
+		String template = //
+				"{#for item in items}\r\n" + //
+				"	{item.name}\r\n" + //
+				"	{#linkItem item name=item.name it|em /}\r\n" + //
+				"{/for}";
+		assertRename(template, "test");
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/rename/QuteRenameInIfSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/rename/QuteRenameInIfSectionTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.rename;
+
+import static com.redhat.qute.QuteAssert.assertRename;
+import static com.redhat.qute.QuteAssert.edits;
+import static com.redhat.qute.QuteAssert.r;
+
+import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.ls.commons.BadLocationException;
+
+/**
+ * Tests for Qute rename inside #if section.
+ *
+ */
+public class QuteRenameInIfSectionTest {
+
+	@Test
+	public void noOptionalParameter() throws BadLocationException {
+		String template = //
+				"{#if fo|o}\r\n" + //
+				"	{foo}\r\n" + //
+				"{/for}";
+		assertRename(template, null);
+	}
+
+	@Test
+	public void optionalParameter() throws BadLocationException {
+		String template = //
+				"{#if fo|o??}\r\n" + //
+				"	{foo}\r\n" + //
+				"{/for}";
+		assertRename(template, "text", //
+				edits("text", //
+						r(0, 5, 0, 8), // {#if fo|o??}
+						r(1, 2, 1, 5) // {foo}
+				));
+	}
+}


### PR DESCRIPTION
Added rename support for Qute templates
![Peek 2022-06-07 18-48](https://user-images.githubusercontent.com/26389510/172495897-43250aef-a85d-4c24-87be-932a0ced8c93.gif)


Fixes #492 

Signed-off-by: Alexander Chen <alchen@redhat.com>