### PR TITLE
fix: prevent NPE in Qute LS if LSP client does not implement getUserTags

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/tags/UserTagRegistry.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/tags/UserTagRegistry.java
@@ -13,6 +13,7 @@ package com.redhat.qute.project.tags;
 
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -114,7 +115,7 @@ public class UserTagRegistry {
 		return getBinaryUserTags(params) //
 				.thenApply(tagInfos -> {
 					if (tagInfos == null) {
-						return null;
+						return Collections.emptyList();
 					}
 					return tagInfos //
 							.stream() //


### PR DESCRIPTION
Fixes #579

Signed-off-by: Jeff MAURY <jmaury@redhat.com>