### PR TITLE
Replaced `UndefinedVariable` by adding validation severity setting for Qute `UndefinedObject` error

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteCodeActions.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteCodeActions.java
@@ -50,7 +50,7 @@ import com.redhat.qute.utils.QutePositionUtility;
 
 /**
  * Qute code actions support.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -91,13 +91,13 @@ class QuteCodeActions {
 				QuteErrorCode errorCode = QuteErrorCode.getErrorCode(diagnostic.getCode());
 				if (errorCode != null) {
 					switch (errorCode) {
-					case UndefinedVariable:
+					case UndefinedObject:
 						// The following Qute template:
-						// {undefinedVariable}
+						// {undefinedObject}
 						//
 						// will provide a quickfix like:
 						//
-						// Declare `undefinedVariable` with parameter declaration."
+						// Declare `undefinedObject` with parameter declaration."
 						doCodeActionsForUndefinedVariable(template, diagnostic, codeActions);
 						break;
 					case UndefinedSectionTag:
@@ -188,13 +188,13 @@ class QuteCodeActions {
 
 	/**
 	 * Create the configuration update (done on client side) quick fix.
-	 * 
+	 *
 	 * @param title       the displayed name of the QuickFix.
 	 * @param sectionName the section name of the settings to update.
 	 * @param item        the section value of the settings to update.
 	 * @param editType    the configuration edit type.
 	 * @param diagnostic  the diagnostic list that this CodeAction will fix.
-	 * 
+	 *
 	 * @return the configuration update (done on client side) quick fix.
 	 */
 	private static CodeAction createConfigurationUpdateCodeAction(String title, String scopeUri, String sectionName,

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/diagnostics/QuteErrorCode.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/diagnostics/QuteErrorCode.java
@@ -24,10 +24,10 @@ public enum QuteErrorCode implements IQuteErrorCode {
 	UndefinedNamespace("No namespace resolver found for: `{0}`"), //
 
 	// Error code for object, property, method parts
-	UndefinedVariable("`{0}` cannot be resolved to a variable."), //
+	UndefinedObject("`{0}` cannot be resolved to an object."), //
 	UnknownType("`{0}` cannot be resolved to a type."), //
 	UnknownMethod("`{0}` cannot be resolved or is not a method of `{1}` Java type."), //
-	UnkwownNamespaceResolverMethod("`{0}` cannot be resolved or is not a method of `{1}` namespace resolver."), //
+	UnknownNamespaceResolverMethod("`{0}` cannot be resolved or is not a method of `{1}` namespace resolver."), //
 	InvalidMethodVoid("Invalid `{0}` method of `{1}` : void return is not allowed."), //
 	InvalidMethodFromObject("Invalid `{0}` method of `{1}` : method from `java.lang.Object` is not allowed."), //
 	InvalidMethodStatic("Invalid `{0}` method of `{1}` : static method is not allowed."), //

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/QuteValidationSettings.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/QuteValidationSettings.java
@@ -27,14 +27,24 @@ import java.util.stream.Collectors;
  */
 public class QuteValidationSettings {
 
+	public static enum Severity {
+		ignore, error, warning;
+	}
+
 	public static final QuteValidationSettings DEFAULT;
 
+	private static final QuteValidationTypeSettings DEFAULT_UNDEFINED_OBJECT;
+
 	static {
+		DEFAULT_UNDEFINED_OBJECT = new QuteValidationTypeSettings();
+		DEFAULT_UNDEFINED_OBJECT.setSeverity(Severity.warning.name());
 		DEFAULT = new QuteValidationSettings();
 		DEFAULT.updateDefault();
 	}
 
 	private boolean enabled;
+
+	private QuteValidationTypeSettings undefinedObject;
 
 	private List<String> excluded;
 
@@ -90,6 +100,7 @@ public class QuteValidationSettings {
 		if (updated) {
 			return;
 		}
+		setUndefinedObject(undefinedObject != null ? undefinedObject : DEFAULT_UNDEFINED_OBJECT);
 		updated = true;
 	}
 
@@ -101,6 +112,27 @@ public class QuteValidationSettings {
 	public void update(QuteValidationSettings newValidation) {
 		this.setEnabled(newValidation.isEnabled());
 		this.setExcluded(newValidation.getExcluded());
+		this.setUndefinedObject(newValidation.getUndefinedObject());
+	}
+
+	/**
+	 * Returns the settings for Qute undefined object validation.
+	 *
+	 * @return the settings for Qute undefined object validation
+	 */
+	public QuteValidationTypeSettings getUndefinedObject() {
+		updateDefault();
+		return this.undefinedObject;
+	}
+
+	/**
+	 * Set the settings for Qute undefined object validation.
+	 *
+	 * @param undefined the settings for Qute undefined object validation.
+	 */
+	public void setUndefinedObject(QuteValidationTypeSettings undefined) {
+		this.undefinedObject = undefined;
+		this.updated = false;
 	}
 
 	public boolean canValidate(String templateUri) {
@@ -182,6 +214,7 @@ public class QuteValidationSettings {
 		int result = 1;
 		result = prime * result + (enabled ? 1231 : 1237);
 		result = prime * result + ((excluded == null) ? 0 : excluded.hashCode());
+		result = prime * result + ((undefinedObject == null) ? 0 : undefinedObject.hashCode());
 		return result;
 	}
 
@@ -200,6 +233,12 @@ public class QuteValidationSettings {
 			if (other.excluded != null)
 				return false;
 		} else if (!excluded.equals(other.excluded))
+			return false;
+		if (undefinedObject == null) {
+			if (!getUndefinedObject().equals(other.getUndefinedObject())) {
+				return false;
+			}
+		} else if (!undefinedObject.equals(other.undefinedObject))
 			return false;
 		return true;
 	}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/QuteValidationTypeSettings.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/QuteValidationTypeSettings.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.settings;
+
+import org.eclipse.lsp4j.DiagnosticSeverity;
+
+/**
+ * Qute validation type settings.
+ *
+ */
+public class QuteValidationTypeSettings {
+
+	private String severity;
+
+	/**
+	 * Returns the severity of the validation type.
+	 *
+	 * @return the severity of the validation type.
+	 */
+	public String getSeverity() {
+		return severity;
+	}
+
+	/**
+	 * Set the severity of the validation type.
+	 *
+	 * @param severity the severity of the validation type.
+	 */
+	public void setSeverity(String severity) {
+		this.severity = severity;
+	}
+
+	/**
+	 * Returns the diagnostic severity according the given property name and null
+	 * otherwise.
+	 *
+	 * @return the diagnostic severity according the given property name and null
+	 *         otherwise.
+	 */
+
+	public DiagnosticSeverity getDiagnosticSeverity() {
+		DiagnosticSeverity[] severities = DiagnosticSeverity.values();
+		for (DiagnosticSeverity severity : severities) {
+			if (severity.name().toUpperCase().equals(this.severity.toUpperCase())) {
+				return severity;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((severity == null) ? 0 : severity.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		QuteValidationTypeSettings other = (QuteValidationTypeSettings) obj;
+		if (severity == null) {
+			if (other.severity != null)
+				return false;
+		} else if (!severity.equals(other.severity))
+			return false;
+		return true;
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
@@ -78,12 +78,13 @@ import com.redhat.qute.services.diagnostics.IQuteErrorCode;
 import com.redhat.qute.services.diagnostics.ResolvingJavaTypeContext;
 import com.redhat.qute.settings.QuteCompletionSettings;
 import com.redhat.qute.settings.QuteFormattingSettings;
+import com.redhat.qute.settings.QuteValidationSettings;
 import com.redhat.qute.settings.SharedSettings;
 import com.redhat.qute.utils.StringUtils;
 
 /**
  * Qute Assert
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -282,13 +283,23 @@ public class QuteAssert {
 
 	public static void testDiagnosticsFor(String value, String fileUri, String templateId, String projectUri,
 			String templateBaseDir, boolean filter, Diagnostic... expected) {
+		testDiagnosticsFor(value, fileUri, templateId, projectUri, templateBaseDir, filter, null, expected);
+	}
+
+	public static void testDiagnosticsFor(String value, QuteValidationSettings validationSettings,
+			Diagnostic... expected) {
+		testDiagnosticsFor(value, FILE_URI, null, PROJECT_URI, TEMPLATE_BASE_DIR, false, validationSettings, expected);
+	}
+
+	public static void testDiagnosticsFor(String value, String fileUri, String templateId, String projectUri,
+			String templateBaseDir, boolean filter, QuteValidationSettings validationSettings, Diagnostic... expected) {
 		QuteProjectRegistry projectRegistry = new MockQuteProjectRegistry();
 		Template template = createTemplate(value, fileUri, projectUri, templateBaseDir, projectRegistry);
 		template.setTemplateId(templateId);
 
 		QuteLanguageService languageService = new QuteLanguageService(new JavaDataModelCache(projectRegistry));
-		List<Diagnostic> actual = languageService.doDiagnostics(template, null, new ResolvingJavaTypeContext(template),
-				() -> {
+		List<Diagnostic> actual = languageService.doDiagnostics(template, validationSettings,
+				new ResolvingJavaTypeContext(template), () -> {
 				});
 		if (expected == null) {
 			assertTrue(actual.isEmpty());

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionWithSettingsTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionWithSettingsTest.java
@@ -36,7 +36,7 @@ import com.redhat.qute.settings.SharedSettings;
 
 /**
  * Test code action with settings.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -47,8 +47,8 @@ public class QuteCodeActionWithSettingsTest {
 		String template = "{item}";
 
 		Diagnostic d = d(0, 1, 0, 5, //
-				QuteErrorCode.UndefinedVariable, //
-				"`item` cannot be resolved to a variable.", //
+				QuteErrorCode.UndefinedObject, //
+				"`item` cannot be resolved to an object.", //
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("item", false));
 
@@ -63,8 +63,8 @@ public class QuteCodeActionWithSettingsTest {
 		String template = "{item}";
 
 		Diagnostic d = d(0, 1, 0, 5, //
-				QuteErrorCode.UndefinedVariable, //
-				"`item` cannot be resolved to a variable.", //
+				QuteErrorCode.UndefinedObject, //
+				"`item` cannot be resolved to an object.", //
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("item", false));
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test with expressions.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -32,12 +32,12 @@ public class QuteDiagnosticsInExpressionTest {
 	@Test
 	public void invalidIdentifiers() throws Exception {
 
-		Diagnostic d = d(0, 1, 0, 4, QuteErrorCode.UndefinedVariable, "`foo` cannot be resolved to a variable.",
+		Diagnostic d = d(0, 1, 0, 4, QuteErrorCode.UndefinedObject, "`foo` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("foo", false));
 		testDiagnosticsFor("{foo}", d);
 
-		d = d(0, 1, 0, 5, QuteErrorCode.UndefinedVariable, "`_foo` cannot be resolved to a variable.",
+		d = d(0, 1, 0, 5, QuteErrorCode.UndefinedObject, "`_foo` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("_foo", false));
 		testDiagnosticsFor("{_foo}", d);
@@ -54,7 +54,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testDiagnosticsFor(template);
 
 		template = "{trueX}";
-		Diagnostic d = d(0, 1, 0, 6, QuteErrorCode.UndefinedVariable, "`trueX` cannot be resolved to a variable.",
+		Diagnostic d = d(0, 1, 0, 6, QuteErrorCode.UndefinedObject, "`trueX` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("trueX", false));
 		testDiagnosticsFor(template, d);
@@ -66,7 +66,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testDiagnosticsFor(template);
 
 		template = "{falseX}";
-		d = d(0, 1, 0, 7, QuteErrorCode.UndefinedVariable, "`falseX` cannot be resolved to a variable.",
+		d = d(0, 1, 0, 7, QuteErrorCode.UndefinedObject, "`falseX` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("falseX", false));
 		testDiagnosticsFor(template, d);
@@ -81,7 +81,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testDiagnosticsFor(template);
 
 		template = "{nullX}";
-		Diagnostic d = d(0, 1, 0, 6, QuteErrorCode.UndefinedVariable, "`nullX` cannot be resolved to a variable.",
+		Diagnostic d = d(0, 1, 0, 6, QuteErrorCode.UndefinedObject, "`nullX` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("nullX", false));
 		testDiagnosticsFor(template, d);
@@ -105,7 +105,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testDiagnosticsFor(template);
 
 		template = "{123X}";
-		Diagnostic d = d(0, 1, 0, 5, QuteErrorCode.UndefinedVariable, "`123X` cannot be resolved to a variable.",
+		Diagnostic d = d(0, 1, 0, 5, QuteErrorCode.UndefinedObject, "`123X` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("123X", false));
 		testDiagnosticsFor(template, d);
@@ -120,7 +120,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testDiagnosticsFor(template);
 
 		template = "{123LX}";
-		Diagnostic d = d(0, 1, 0, 6, QuteErrorCode.UndefinedVariable, "`123LX` cannot be resolved to a variable.",
+		Diagnostic d = d(0, 1, 0, 6, QuteErrorCode.UndefinedObject, "`123LX` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("123LX", false));
 		testDiagnosticsFor(template, d);
@@ -134,8 +134,8 @@ public class QuteDiagnosticsInExpressionTest {
 		String template = "{item}";
 
 		Diagnostic d = d(0, 1, 0, 5, //
-				QuteErrorCode.UndefinedVariable, //
-				"`item` cannot be resolved to a variable.", //
+				QuteErrorCode.UndefinedObject, //
+				"`item` cannot be resolved to an object.", //
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("item", false));
 
@@ -150,8 +150,8 @@ public class QuteDiagnosticsInExpressionTest {
 		String template = "{nested-content}";
 
 		Diagnostic d = d(0, 1, 0, 15, //
-				QuteErrorCode.UndefinedVariable, //
-				"`nested-content` cannot be resolved to a variable.", //
+				QuteErrorCode.UndefinedObject, //
+				"`nested-content` cannot be resolved to an object.", //
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("nested-content", false));
 
@@ -305,7 +305,7 @@ public class QuteDiagnosticsInExpressionTest {
 	public void elvisOperator() throws Exception {
 		String template = "{person.name ?: 'John'}";
 
-		Diagnostic d = d(0, 1, 0, 7, QuteErrorCode.UndefinedVariable, "`person` cannot be resolved to a variable.",
+		Diagnostic d = d(0, 1, 0, 7, QuteErrorCode.UndefinedObject, "`person` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("person", false));
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithEachSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithEachSectionTest.java
@@ -30,8 +30,8 @@ public class QuteDiagnosticsInExpressionWithEachSectionTest {
 				"	{it.name}    \r\n" + //
 				"{/each}";
 
-		Diagnostic d = d(2, 7, 2, 15, QuteErrorCode.UndefinedVariable, //
-				"`itemsXXX` cannot be resolved to a variable.", DiagnosticSeverity.Warning);
+		Diagnostic d = d(2, 7, 2, 15, QuteErrorCode.UndefinedObject, //
+				"`itemsXXX` cannot be resolved to an object.", DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("itemsXXX", true));
 
 		testDiagnosticsFor(template, d, //

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithForSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithForSectionTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test with #for section
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -48,8 +48,8 @@ public class QuteDiagnosticsInExpressionWithForSectionTest {
 				"	{item.name}    \r\n" + //
 				"{/for}}";
 
-		Diagnostic d = d(4, 2, 4, 6, QuteErrorCode.UndefinedVariable, //
-				"`item` cannot be resolved to a variable.", DiagnosticSeverity.Warning);
+		Diagnostic d = d(4, 2, 4, 6, QuteErrorCode.UndefinedObject, //
+				"`item` cannot be resolved to an object.", DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("item", false));
 
 		testDiagnosticsFor(template, d);
@@ -66,8 +66,8 @@ public class QuteDiagnosticsInExpressionWithForSectionTest {
 				"	{item.name}    \r\n" + //
 				"{/for}";
 
-		Diagnostic d = d(2, 14, 2, 22, QuteErrorCode.UndefinedVariable, //
-				"`itemsXXX` cannot be resolved to a variable.", DiagnosticSeverity.Warning);
+		Diagnostic d = d(2, 14, 2, 22, QuteErrorCode.UndefinedObject, //
+				"`itemsXXX` cannot be resolved to an object.", DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("itemsXXX", true));
 
 		testDiagnosticsFor(template, d, //
@@ -137,7 +137,7 @@ public class QuteDiagnosticsInExpressionWithForSectionTest {
 
 	/**
 	 * @see https://quarkus.io/guides/qute-reference#expression_resolution
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test
@@ -160,7 +160,7 @@ public class QuteDiagnosticsInExpressionWithForSectionTest {
 
 	/**
 	 * @see https://quarkus.io/guides/qute-reference#expression_resolution
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test
@@ -195,7 +195,8 @@ public class QuteDiagnosticsInExpressionWithForSectionTest {
 				"{/for}";
 		testDiagnosticsFor(template, //
 				d(0, 11, 0, 13, QuteErrorCode.IterationError,
-						"Iteration error: {3d} resolved to [java.lang.Double] which is not iterable.", DiagnosticSeverity.Error),
+						"Iteration error: {3d} resolved to [java.lang.Double] which is not iterable.",
+						DiagnosticSeverity.Error),
 				d(1, 2, 1, 3, QuteErrorCode.UnknownType, "`java.lang.Double` cannot be resolved to a type.",
 						DiagnosticSeverity.Error));
 	}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithIfSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithIfSectionTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test with #if section
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -42,11 +42,11 @@ public class QuteDiagnosticsInExpressionWithIfSectionTest {
 		String template = "{#if item.name != '' && item > 0}\r\n" + //
 				"{/if}";
 
-		Diagnostic d1 = d(0, 5, 0, 9, QuteErrorCode.UndefinedVariable, "`item` cannot be resolved to a variable.",
+		Diagnostic d1 = d(0, 5, 0, 9, QuteErrorCode.UndefinedObject, "`item` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
 		d1.setData(DiagnosticDataFactory.createUndefinedVariableData("item", false));
 
-		Diagnostic d2 = d(0, 24, 0, 28, QuteErrorCode.UndefinedVariable, "`item` cannot be resolved to a variable.",
+		Diagnostic d2 = d(0, 24, 0, 28, QuteErrorCode.UndefinedObject, "`item` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
 		d2.setData(DiagnosticDataFactory.createUndefinedVariableData("item", false));
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithLetSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithLetSectionTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test with #let section
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -58,7 +58,7 @@ public class QuteDiagnosticsInExpressionWithLetSectionTest {
 				"  {doubleQuote}\r\n" + //
 				"{/set}\r\n" + //
 				"";
-		Diagnostic d = d(0, 11, 0, 15, QuteErrorCode.UndefinedVariable, "`item` cannot be resolved to a variable.",
+		Diagnostic d = d(0, 11, 0, 15, QuteErrorCode.UndefinedObject, "`item` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("item", false));
 
@@ -79,7 +79,7 @@ public class QuteDiagnosticsInExpressionWithLetSectionTest {
 		template = "{#let name='value' /}\r\n" + //
 				" {name}\r\n" + //
 				"{/let}";
-		Diagnostic d = d(1, 2, 1, 6, QuteErrorCode.UndefinedVariable, "`name` cannot be resolved to a variable.",
+		Diagnostic d = d(1, 2, 1, 6, QuteErrorCode.UndefinedObject, "`name` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("name", false));
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithNamespaceTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithNamespaceTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test with expressions.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -58,7 +58,7 @@ public class QuteDiagnosticsInExpressionWithNamespaceTest {
 
 		template = "{config:propertyXXXX('qute')}";
 		testDiagnosticsFor(template,
-				d(0, 8, 0, 20, QuteErrorCode.UnkwownNamespaceResolverMethod,
+				d(0, 8, 0, 20, QuteErrorCode.UnknownNamespaceResolverMethod,
 						"`propertyXXXX` cannot be resolved or is not a method of `config` namespace resolver.",
 						DiagnosticSeverity.Error));
 	}
@@ -69,18 +69,18 @@ public class QuteDiagnosticsInExpressionWithNamespaceTest {
 		String template = "{config:foo}";
 		testDiagnosticsFor(template);
 	}
-	
+
 	@Test
 	public void invalidInjectNamespaceInFirstPart() {
 		String template = "{inject:foo}";
-		Diagnostic d = d(0, 8, 0, 11, QuteErrorCode.UndefinedVariable, "`foo` cannot be resolved to a variable.",
+		Diagnostic d = d(0, 8, 0, 11, QuteErrorCode.UndefinedObject, "`foo` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("foo", false));
 		testDiagnosticsFor(template, d);
 
 		template = "{inject:foo()}";
 		testDiagnosticsFor(template,
-				d(0, 8, 0, 11, QuteErrorCode.UnkwownNamespaceResolverMethod,
+				d(0, 8, 0, 11, QuteErrorCode.UnknownNamespaceResolverMethod,
 						"`foo` cannot be resolved or is not a method of `inject` namespace resolver.",
 						DiagnosticSeverity.Error));
 	}
@@ -110,22 +110,18 @@ public class QuteDiagnosticsInExpressionWithNamespaceTest {
 		testDiagnosticsFor(template);
 
 	}
-	
+
 	@Test
 	public void badNamespace() {
 		String template = "{X:}";
 		testDiagnosticsFor(template,
-				d(0, 0, 0, 3, QuteErrorCode.SyntaxError,
-						"Parser error on line 1: empty expression found {X:}",
+				d(0, 0, 0, 3, QuteErrorCode.SyntaxError, "Parser error on line 1: empty expression found {X:}",
 						DiagnosticSeverity.Error), //
-				d(0, 1, 0, 2, QuteErrorCode.UndefinedNamespace,
-						"No namespace resolver found for: `X`",
+				d(0, 1, 0, 2, QuteErrorCode.UndefinedNamespace, "No namespace resolver found for: `X`",
 						DiagnosticSeverity.Warning));
-		
+
 		template = "{X:bean}";
-		testDiagnosticsFor(template,
-				d(0, 1, 0, 2, QuteErrorCode.UndefinedNamespace,
-						"No namespace resolver found for: `X`",
-						DiagnosticSeverity.Warning));
+		testDiagnosticsFor(template, d(0, 1, 0, 2, QuteErrorCode.UndefinedNamespace,
+				"No namespace resolver found for: `X`", DiagnosticSeverity.Warning));
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithWithSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithWithSectionTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test with #with section
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -34,7 +34,7 @@ public class QuteDiagnosticsInExpressionWithWithSectionTest {
 		String template = "{#with item}\r\n" + //
 				"{/with}";
 
-		Diagnostic d = d(0, 7, 0, 11, QuteErrorCode.UndefinedVariable, "`item` cannot be resolved to a variable.",
+		Diagnostic d = d(0, 7, 0, 11, QuteErrorCode.UndefinedObject, "`item` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("item", false));
 
@@ -68,7 +68,7 @@ public class QuteDiagnosticsInExpressionWithWithSectionTest {
 				"  {/with}\r\n" + //
 				"{/with}";
 
-		Diagnostic d = d(6, 5, 6, 12, QuteErrorCode.UndefinedVariable, "`average` cannot be resolved to a variable.",
+		Diagnostic d = d(6, 5, 6, 12, QuteErrorCode.UndefinedObject, "`average` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("average", false));
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsSeverityTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsSeverityTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.diagnostics;
+
+import static com.redhat.qute.QuteAssert.d;
+import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
+
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.settings.QuteValidationSettings;
+import com.redhat.qute.settings.QuteValidationSettings.Severity;
+import com.redhat.qute.settings.QuteValidationTypeSettings;
+
+/**
+ * Test with diagnostic severity setting
+ *
+ */
+public class QuteDiagnosticsSeverityTest {
+
+	@Test
+	public void undefinedVariableSeverityDefault() throws Exception {
+		String template = "{foo}";
+		QuteValidationSettings validationSettings = new QuteValidationSettings();
+		Diagnostic d = d(0, 1, 0, 4, QuteErrorCode.UndefinedObject, //
+				"`foo` cannot be resolved to an object.", DiagnosticSeverity.Warning);
+		d.setData(DiagnosticDataFactory.createUndefinedVariableData("foo", false));
+		testDiagnosticsFor(template, validationSettings, d);
+	}
+
+	@Test
+	public void undefinedVariableSeverityIgnore() throws Exception {
+		String template = "{foo}";
+		QuteValidationSettings validationSettings = new QuteValidationSettings();
+		QuteValidationTypeSettings undefinedObject = new QuteValidationTypeSettings();
+		undefinedObject.setSeverity(Severity.ignore.name());
+		validationSettings.setUndefinedObject(undefinedObject);
+		testDiagnosticsFor(template, validationSettings);
+	}
+
+	@Test
+	public void undefinedVariableSeverityWarning() throws Exception {
+		String template = "{foo}";
+		QuteValidationSettings validationSettings = new QuteValidationSettings();
+		QuteValidationTypeSettings undefinedObject = new QuteValidationTypeSettings();
+		undefinedObject.setSeverity(Severity.warning.name());
+		validationSettings.setUndefinedObject(undefinedObject);
+		Diagnostic d = d(0, 1, 0, 4, QuteErrorCode.UndefinedObject, //
+				"`foo` cannot be resolved to an object.", DiagnosticSeverity.Warning);
+		d.setData(DiagnosticDataFactory.createUndefinedVariableData("foo", false));
+		testDiagnosticsFor(template, validationSettings, d);
+	}
+
+	@Test
+	public void undefinedVariableSeverityError() throws Exception {
+		String template = "{foo}";
+		QuteValidationSettings validationSettings = new QuteValidationSettings();
+		QuteValidationTypeSettings undefinedObject = new QuteValidationTypeSettings();
+		undefinedObject.setSeverity(Severity.error.name());
+		validationSettings.setUndefinedObject(undefinedObject);
+		Diagnostic d = d(0, 1, 0, 4, QuteErrorCode.UndefinedObject, //
+				"`foo` cannot be resolved to an object.", DiagnosticSeverity.Error);
+		d.setData(DiagnosticDataFactory.createUndefinedVariableData("foo", false));
+		testDiagnosticsFor(template, validationSettings, d);
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsUserTagTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsUserTagTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * User tag diagnostics.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -34,7 +34,7 @@ public class QuteDiagnosticsUserTagTest {
 	@Test
 	public void undefinedVariableInTemplate() {
 		String template = "{name}";
-		Diagnostic d = d(0, 1, 0, 5, QuteErrorCode.UndefinedVariable, "`name` cannot be resolved to a variable.",
+		Diagnostic d = d(0, 1, 0, 5, QuteErrorCode.UndefinedObject, "`name` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("name", false));
 		testDiagnosticsFor(template, //
@@ -54,7 +54,7 @@ public class QuteDiagnosticsUserTagTest {
 	@Test
 	public void undefinedVariableInUserTagCall() {
 		String template = "{#user name=name /}";
-		Diagnostic d = d(0, 12, 0, 16, QuteErrorCode.UndefinedVariable, "`name` cannot be resolved to a variable.",
+		Diagnostic d = d(0, 12, 0, 16, QuteErrorCode.UndefinedObject, "`name` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("name", false));
 		testDiagnosticsFor(template, d);

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsWithCheckedTemplateTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsWithCheckedTemplateTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for Qute completion with @CkeckedTemplate.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -18,7 +18,7 @@ public class QuteDiagnosticsWithCheckedTemplateTest {
 	@Test
 	public void noCheckedTemplateMatching() throws Exception {
 		String template = "Item: {items}";
-		Diagnostic d = d(0, 7, 0, 12, QuteErrorCode.UndefinedVariable, "`items` cannot be resolved to a variable.",
+		Diagnostic d = d(0, 7, 0, 12, QuteErrorCode.UndefinedObject, "`items` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
 		d.setData(DiagnosticDataFactory.createUndefinedVariableData("items", false));
 		testDiagnosticsFor(template, d);


### PR DESCRIPTION
Replaced `UndefinedVariable` by adding validation severity setting for Qute `UndefinedObject` error.

Part of redhat-developer/vscode-quarkus#473

Signed-off-by: Alexander Chen <alchen@redhat.com>