### PR TITLE
Added CodeAction to set `UndefinedObject` severity to ignore

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteDiagnostics.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteDiagnostics.java
@@ -552,7 +552,7 @@ class QuteDiagnostics {
 			Diagnostic diagnostic = createDiagnostic(range, severity, QuteErrorCode.UndefinedObject,
 					objectPart.getPartName());
 			// Create data information helpful for code action
-			diagnostic.setData(DiagnosticDataFactory.createUndefinedVariableData(objectPart.getPartName(),
+			diagnostic.setData(DiagnosticDataFactory.createUndefinedObjectData(objectPart.getPartName(),
 					ownerSection != null && ownerSection.isIterable()));
 			diagnostics.add(diagnostic);
 			return null;

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/diagnostics/DiagnosticDataFactory.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/diagnostics/DiagnosticDataFactory.java
@@ -30,7 +30,7 @@ import com.google.gson.JsonObject;
  */
 public class DiagnosticDataFactory {
 
-	public static JsonObject createUndefinedVariableData(String partName, boolean iterable) {
+	public static JsonObject createUndefinedObjectData(String partName, boolean iterable) {
 		JsonObject data = new JsonObject();
 		data.addProperty(DIAGNOSTIC_DATA_NAME, partName);
 		data.addProperty(DIAGNOSTIC_DATA_ITERABLE, iterable);

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
@@ -67,6 +67,8 @@ import com.redhat.qute.ls.commons.BadLocationException;
 import com.redhat.qute.ls.commons.TextDocument;
 import com.redhat.qute.ls.commons.client.CommandCapabilities;
 import com.redhat.qute.ls.commons.client.CommandKindCapabilities;
+import com.redhat.qute.ls.commons.client.ConfigurationItemEdit;
+import com.redhat.qute.ls.commons.client.ConfigurationItemEditType;
 import com.redhat.qute.parser.template.Template;
 import com.redhat.qute.parser.template.TemplateParser;
 import com.redhat.qute.project.MockQuteProjectRegistry;
@@ -670,6 +672,17 @@ public class QuteAssert {
 		codeAction.setCommand(c);
 
 		return codeAction;
+	}
+
+	public static Command c(String title, String commandId, String section, String scopeUri,
+			ConfigurationItemEditType edit, Object value, Diagnostic d) {
+		Command command = new Command();
+		command.setTitle(title);
+		command.setCommand(commandId);
+		ConfigurationItemEdit itemEdit = new ConfigurationItemEdit(section, edit, value);
+		itemEdit.setScopeUri(scopeUri);
+		command.setArguments(Collections.singletonList(itemEdit));
+		return command;
 	}
 
 	public static TextDocumentEdit tde(String uri, int version, TextEdit... te) {

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionWithSettingsTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionWithSettingsTest.java
@@ -11,6 +11,7 @@
 *******************************************************************************/
 package com.redhat.qute.services.codeaction;
 
+import static com.redhat.qute.QuteAssert.c;
 import static com.redhat.qute.QuteAssert.ca;
 import static com.redhat.qute.QuteAssert.d;
 import static com.redhat.qute.QuteAssert.te;
@@ -20,14 +21,12 @@ import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.jupiter.api.Test;
 
 import com.redhat.qute.ls.commons.client.CommandCapabilities;
 import com.redhat.qute.ls.commons.client.CommandKindCapabilities;
-import com.redhat.qute.ls.commons.client.ConfigurationItemEdit;
 import com.redhat.qute.ls.commons.client.ConfigurationItemEditType;
 import com.redhat.qute.services.commands.QuteClientCommandConstants;
 import com.redhat.qute.services.diagnostics.DiagnosticDataFactory;
@@ -50,12 +49,18 @@ public class QuteCodeActionWithSettingsTest {
 				QuteErrorCode.UndefinedObject, //
 				"`item` cannot be resolved to an object.", //
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("item", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("item", false));
 
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String item}" + //
-						System.lineSeparator())));
+						System.lineSeparator())), //
+				ca(d, c("Ignore `qute.validation.undefinedObject.severity` problem.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.undefinedObject.severity", //
+						"test.qute", //
+						ConfigurationItemEditType.update, "ignore", //
+						d)));
 	}
 
 	@Test
@@ -66,7 +71,7 @@ public class QuteCodeActionWithSettingsTest {
 				QuteErrorCode.UndefinedObject, //
 				"`item` cannot be resolved to an object.", //
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("item", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("item", false));
 
 		testDiagnosticsFor(template, d);
 
@@ -86,18 +91,13 @@ public class QuteCodeActionWithSettingsTest {
 						ConfigurationItemEditType.add, "test.qute", //
 						d)), //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String item}" + //
-						System.lineSeparator())));
-	}
-
-	private static Command c(String title, String commandId, String section, String scopeUri,
-			ConfigurationItemEditType edit, Object value, Diagnostic d) {
-		Command command = new Command();
-		command.setTitle(title);
-		command.setCommand(commandId);
-		ConfigurationItemEdit itemEdit = new ConfigurationItemEdit(section, edit, value);
-		itemEdit.setScopeUri(scopeUri);
-		command.setArguments(Collections.singletonList(itemEdit));
-		return command;
+						System.lineSeparator())), //
+				ca(d, c("Ignore `qute.validation.undefinedObject.severity` problem.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.undefinedObject.severity", //
+						"test.qute", //
+						ConfigurationItemEditType.update, "ignore", //
+						d)));
 	}
 
 	private static SharedSettings createSharedSettings(String... commandIds) {

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionTest.java
@@ -11,6 +11,7 @@
 *******************************************************************************/
 package com.redhat.qute.services.diagnostics;
 
+import static com.redhat.qute.QuteAssert.c;
 import static com.redhat.qute.QuteAssert.ca;
 import static com.redhat.qute.QuteAssert.d;
 import static com.redhat.qute.QuteAssert.te;
@@ -20,6 +21,9 @@ import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.ls.commons.client.ConfigurationItemEditType;
+import com.redhat.qute.services.commands.QuteClientCommandConstants;
 
 /**
  * Test with expressions.
@@ -34,12 +38,12 @@ public class QuteDiagnosticsInExpressionTest {
 
 		Diagnostic d = d(0, 1, 0, 4, QuteErrorCode.UndefinedObject, "`foo` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("foo", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("foo", false));
 		testDiagnosticsFor("{foo}", d);
 
 		d = d(0, 1, 0, 5, QuteErrorCode.UndefinedObject, "`_foo` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("_foo", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("_foo", false));
 		testDiagnosticsFor("{_foo}", d);
 
 		testDiagnosticsFor("{ foo}");
@@ -56,11 +60,17 @@ public class QuteDiagnosticsInExpressionTest {
 		template = "{trueX}";
 		Diagnostic d = d(0, 1, 0, 6, QuteErrorCode.UndefinedObject, "`trueX` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("trueX", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("trueX", false));
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String trueX}" + //
-						System.lineSeparator())));
+						System.lineSeparator())), //
+				ca(d, c("Ignore `qute.validation.undefinedObject.severity` problem.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.undefinedObject.severity", //
+						"test.qute", //
+						ConfigurationItemEditType.update, "ignore", //
+						d)));
 
 		template = "{false}";
 		testDiagnosticsFor(template);
@@ -68,11 +78,17 @@ public class QuteDiagnosticsInExpressionTest {
 		template = "{falseX}";
 		d = d(0, 1, 0, 7, QuteErrorCode.UndefinedObject, "`falseX` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("falseX", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("falseX", false));
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String falseX}" + //
-						System.lineSeparator())));
+						System.lineSeparator())), //
+				ca(d, c("Ignore `qute.validation.undefinedObject.severity` problem.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.undefinedObject.severity", //
+						"test.qute", //
+						ConfigurationItemEditType.update, "ignore", //
+						d)));
 	}
 
 	@Test
@@ -83,11 +99,17 @@ public class QuteDiagnosticsInExpressionTest {
 		template = "{nullX}";
 		Diagnostic d = d(0, 1, 0, 6, QuteErrorCode.UndefinedObject, "`nullX` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("nullX", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("nullX", false));
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String nullX}" + //
-						System.lineSeparator())));
+						System.lineSeparator())), //
+				ca(d, c("Ignore `qute.validation.undefinedObject.severity` problem.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.undefinedObject.severity", //
+						"test.qute", //
+						ConfigurationItemEditType.update, "ignore", //
+						d)));
 	}
 
 	@Test
@@ -107,11 +129,17 @@ public class QuteDiagnosticsInExpressionTest {
 		template = "{123X}";
 		Diagnostic d = d(0, 1, 0, 5, QuteErrorCode.UndefinedObject, "`123X` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("123X", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("123X", false));
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String 123X}" + //
-						System.lineSeparator())));
+						System.lineSeparator())), //
+				ca(d, c("Ignore `qute.validation.undefinedObject.severity` problem.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.undefinedObject.severity", //
+						"test.qute", //
+						ConfigurationItemEditType.update, "ignore", //
+						d)));
 	}
 
 	@Test
@@ -122,11 +150,17 @@ public class QuteDiagnosticsInExpressionTest {
 		template = "{123LX}";
 		Diagnostic d = d(0, 1, 0, 6, QuteErrorCode.UndefinedObject, "`123LX` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("123LX", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("123LX", false));
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String 123LX}" + //
-						System.lineSeparator())));
+						System.lineSeparator())), //
+				ca(d, c("Ignore `qute.validation.undefinedObject.severity` problem.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.undefinedObject.severity", //
+						"test.qute", //
+						ConfigurationItemEditType.update, "ignore", //
+						d)));
 	}
 
 	@Test
@@ -137,12 +171,18 @@ public class QuteDiagnosticsInExpressionTest {
 				QuteErrorCode.UndefinedObject, //
 				"`item` cannot be resolved to an object.", //
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("item", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("item", false));
 
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String item}" + //
-						System.lineSeparator())));
+						System.lineSeparator())), //
+				ca(d, c("Ignore `qute.validation.undefinedObject.severity` problem.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.undefinedObject.severity", //
+						"test.qute", //
+						ConfigurationItemEditType.update, "ignore", //
+						d)));
 	}
 
 	@Test
@@ -153,12 +193,18 @@ public class QuteDiagnosticsInExpressionTest {
 				QuteErrorCode.UndefinedObject, //
 				"`nested-content` cannot be resolved to an object.", //
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("nested-content", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("nested-content", false));
 
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String nested-content}" + //
-						System.lineSeparator())));
+						System.lineSeparator())), //
+				ca(d, c("Ignore `qute.validation.undefinedObject.severity` problem.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.undefinedObject.severity", //
+						"test.qute", //
+						ConfigurationItemEditType.update, "ignore", //
+						d)));
 	}
 
 	@Test
@@ -307,12 +353,18 @@ public class QuteDiagnosticsInExpressionTest {
 
 		Diagnostic d = d(0, 1, 0, 7, QuteErrorCode.UndefinedObject, "`person` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("person", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("person", false));
 
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String person}" + //
-						System.lineSeparator())));
+						System.lineSeparator())), //
+				ca(d, c("Ignore `qute.validation.undefinedObject.severity` problem.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.undefinedObject.severity", //
+						"test.qute", //
+						ConfigurationItemEditType.update, "ignore", //
+						d)));
 	}
 
 	@Test

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithEachSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithEachSectionTest.java
@@ -1,5 +1,6 @@
 package com.redhat.qute.services.diagnostics;
 
+import static com.redhat.qute.QuteAssert.c;
 import static com.redhat.qute.QuteAssert.ca;
 import static com.redhat.qute.QuteAssert.d;
 import static com.redhat.qute.QuteAssert.te;
@@ -9,6 +10,9 @@ import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.ls.commons.client.ConfigurationItemEditType;
+import com.redhat.qute.services.commands.QuteClientCommandConstants;
 
 public class QuteDiagnosticsInExpressionWithEachSectionTest {
 
@@ -32,14 +36,20 @@ public class QuteDiagnosticsInExpressionWithEachSectionTest {
 
 		Diagnostic d = d(2, 7, 2, 15, QuteErrorCode.UndefinedObject, //
 				"`itemsXXX` cannot be resolved to an object.", DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("itemsXXX", true));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("itemsXXX", true));
 
 		testDiagnosticsFor(template, d, //
 				d(3, 2, 3, 4, QuteErrorCode.UnknownType, //
 						"`it` cannot be resolved to a type.", //
 						DiagnosticSeverity.Error));
 		testCodeActionsFor(template, d, //
-				ca(d, te(0, 0, 0, 0, "{@java.util.List itemsXXX}\r\n")));
+				ca(d, te(0, 0, 0, 0, "{@java.util.List itemsXXX}\r\n")), //
+				ca(d, c("Ignore `qute.validation.undefinedObject.severity` problem.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.undefinedObject.severity", //
+						"test.qute", //
+						ConfigurationItemEditType.update, "ignore", //
+						d)));
 	}
 
 	@Test

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithForSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithForSectionTest.java
@@ -11,6 +11,7 @@
 *******************************************************************************/
 package com.redhat.qute.services.diagnostics;
 
+import static com.redhat.qute.QuteAssert.c;
 import static com.redhat.qute.QuteAssert.ca;
 import static com.redhat.qute.QuteAssert.d;
 import static com.redhat.qute.QuteAssert.te;
@@ -20,6 +21,9 @@ import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.ls.commons.client.ConfigurationItemEditType;
+import com.redhat.qute.services.commands.QuteClientCommandConstants;
 
 /**
  * Test with #for section
@@ -50,11 +54,17 @@ public class QuteDiagnosticsInExpressionWithForSectionTest {
 
 		Diagnostic d = d(4, 2, 4, 6, QuteErrorCode.UndefinedObject, //
 				"`item` cannot be resolved to an object.", DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("item", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("item", false));
 
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
-				ca(d, te(0, 0, 0, 0, "{@java.lang.String item}\r\n")));
+				ca(d, te(0, 0, 0, 0, "{@java.lang.String item}\r\n")), //
+				ca(d, c("Ignore `qute.validation.undefinedObject.severity` problem.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.undefinedObject.severity", //
+						"test.qute", //
+						ConfigurationItemEditType.update, "ignore", //
+						d)));
 
 	}
 
@@ -68,14 +78,20 @@ public class QuteDiagnosticsInExpressionWithForSectionTest {
 
 		Diagnostic d = d(2, 14, 2, 22, QuteErrorCode.UndefinedObject, //
 				"`itemsXXX` cannot be resolved to an object.", DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("itemsXXX", true));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("itemsXXX", true));
 
 		testDiagnosticsFor(template, d, //
 				d(3, 2, 3, 6, QuteErrorCode.UnknownType, //
 						"`item` cannot be resolved to a type.", //
 						DiagnosticSeverity.Error));
 		testCodeActionsFor(template, d, //
-				ca(d, te(0, 0, 0, 0, "{@java.util.List itemsXXX}\r\n")));
+				ca(d, te(0, 0, 0, 0, "{@java.util.List itemsXXX}\r\n")), //
+				ca(d, c("Ignore `qute.validation.undefinedObject.severity` problem.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.undefinedObject.severity", //
+						"test.qute", //
+						ConfigurationItemEditType.update, "ignore", //
+						d)));
 	}
 
 	@Test

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithIfSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithIfSectionTest.java
@@ -11,6 +11,7 @@
 *******************************************************************************/
 package com.redhat.qute.services.diagnostics;
 
+import static com.redhat.qute.QuteAssert.c;
 import static com.redhat.qute.QuteAssert.ca;
 import static com.redhat.qute.QuteAssert.d;
 import static com.redhat.qute.QuteAssert.te;
@@ -20,6 +21,9 @@ import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.ls.commons.client.ConfigurationItemEditType;
+import com.redhat.qute.services.commands.QuteClientCommandConstants;
 
 /**
  * Test with #if section
@@ -44,17 +48,29 @@ public class QuteDiagnosticsInExpressionWithIfSectionTest {
 
 		Diagnostic d1 = d(0, 5, 0, 9, QuteErrorCode.UndefinedObject, "`item` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
-		d1.setData(DiagnosticDataFactory.createUndefinedVariableData("item", false));
+		d1.setData(DiagnosticDataFactory.createUndefinedObjectData("item", false));
 
 		Diagnostic d2 = d(0, 24, 0, 28, QuteErrorCode.UndefinedObject, "`item` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
-		d2.setData(DiagnosticDataFactory.createUndefinedVariableData("item", false));
+		d2.setData(DiagnosticDataFactory.createUndefinedObjectData("item", false));
 
 		testDiagnosticsFor(template, d1, d2);
 		testCodeActionsFor(template, d1, //
-				ca(d1, te(0, 0, 0, 0, "{@java.lang.String item}\r\n")));
+				ca(d1, te(0, 0, 0, 0, "{@java.lang.String item}\r\n")), //
+				ca(d1, c("Ignore `qute.validation.undefinedObject.severity` problem.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.undefinedObject.severity", //
+						"test.qute", //
+						ConfigurationItemEditType.update, "ignore", //
+						d1)));
 		testCodeActionsFor(template, d2, //
-				ca(d2, te(0, 0, 0, 0, "{@java.lang.String item}\r\n")));
+				ca(d2, te(0, 0, 0, 0, "{@java.lang.String item}\r\n")), //
+				ca(d2, c("Ignore `qute.validation.undefinedObject.severity` problem.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.undefinedObject.severity", //
+						"test.qute", //
+						ConfigurationItemEditType.update, "ignore", //
+						d2)));
 	}
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithLetSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithLetSectionTest.java
@@ -11,6 +11,7 @@
 *******************************************************************************/
 package com.redhat.qute.services.diagnostics;
 
+import static com.redhat.qute.QuteAssert.c;
 import static com.redhat.qute.QuteAssert.ca;
 import static com.redhat.qute.QuteAssert.d;
 import static com.redhat.qute.QuteAssert.te;
@@ -20,6 +21,9 @@ import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.ls.commons.client.ConfigurationItemEditType;
+import com.redhat.qute.services.commands.QuteClientCommandConstants;
 
 /**
  * Test with #let section
@@ -60,13 +64,19 @@ public class QuteDiagnosticsInExpressionWithLetSectionTest {
 				"";
 		Diagnostic d = d(0, 11, 0, 15, QuteErrorCode.UndefinedObject, "`item` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("item", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("item", false));
 
 		testDiagnosticsFor(template, d, //
 				d(2, 3, 2, 7, QuteErrorCode.UnknownType, "`name` cannot be resolved to a type.",
 						DiagnosticSeverity.Error));
 		testCodeActionsFor(template, d, //
-				ca(d, te(0, 0, 0, 0, "{@java.lang.String item}\r\n")));
+				ca(d, te(0, 0, 0, 0, "{@java.lang.String item}\r\n")), //
+				ca(d, c("Ignore `qute.validation.undefinedObject.severity` problem.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.undefinedObject.severity", //
+						"test.qute", //
+						ConfigurationItemEditType.update, "ignore", //
+						d)));
 	}
 
 	@Test
@@ -81,13 +91,19 @@ public class QuteDiagnosticsInExpressionWithLetSectionTest {
 				"{/let}";
 		Diagnostic d = d(1, 2, 1, 6, QuteErrorCode.UndefinedObject, "`name` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("name", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("name", false));
 
 		testDiagnosticsFor(template, //
 				d(2, 6, 2, 6, QuteErrorCode.SyntaxError,
 						"Parser error on line 3: no section start tag found for {/let}", DiagnosticSeverity.Error), //
 				d);
 		testCodeActionsFor(template, d, //
-				ca(d, te(0, 0, 0, 0, "{@java.lang.String name}\r\n")));
+				ca(d, te(0, 0, 0, 0, "{@java.lang.String name}\r\n")), //
+				ca(d, c("Ignore `qute.validation.undefinedObject.severity` problem.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.undefinedObject.severity", //
+						"test.qute", //
+						ConfigurationItemEditType.update, "ignore", //
+						d)));
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithNamespaceTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithNamespaceTest.java
@@ -75,7 +75,7 @@ public class QuteDiagnosticsInExpressionWithNamespaceTest {
 		String template = "{inject:foo}";
 		Diagnostic d = d(0, 8, 0, 11, QuteErrorCode.UndefinedObject, "`foo` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("foo", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("foo", false));
 		testDiagnosticsFor(template, d);
 
 		template = "{inject:foo()}";

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithWithSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithWithSectionTest.java
@@ -11,6 +11,7 @@
 *******************************************************************************/
 package com.redhat.qute.services.diagnostics;
 
+import static com.redhat.qute.QuteAssert.c;
 import static com.redhat.qute.QuteAssert.ca;
 import static com.redhat.qute.QuteAssert.d;
 import static com.redhat.qute.QuteAssert.te;
@@ -20,6 +21,9 @@ import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.ls.commons.client.ConfigurationItemEditType;
+import com.redhat.qute.services.commands.QuteClientCommandConstants;
 
 /**
  * Test with #with section
@@ -36,11 +40,17 @@ public class QuteDiagnosticsInExpressionWithWithSectionTest {
 
 		Diagnostic d = d(0, 7, 0, 11, QuteErrorCode.UndefinedObject, "`item` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("item", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("item", false));
 
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
-				ca(d, te(0, 0, 0, 0, "{@java.lang.String item}\r\n")));
+				ca(d, te(0, 0, 0, 0, "{@java.lang.String item}\r\n")), //
+				ca(d, c("Ignore `qute.validation.undefinedObject.severity` problem.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.undefinedObject.severity", //
+						"test.qute", //
+						ConfigurationItemEditType.update, "ignore", //
+						d)));
 	}
 
 	@Test
@@ -70,11 +80,17 @@ public class QuteDiagnosticsInExpressionWithWithSectionTest {
 
 		Diagnostic d = d(6, 5, 6, 12, QuteErrorCode.UndefinedObject, "`average` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("average", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("average", false));
 
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
-				ca(d, te(0, 0, 0, 0, "{@java.lang.String average}\r\n")));
+				ca(d, te(0, 0, 0, 0, "{@java.lang.String average}\r\n")), //
+				ca(d, c("Ignore `qute.validation.undefinedObject.severity` problem.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.undefinedObject.severity", //
+						"test.qute", //
+						ConfigurationItemEditType.update, "ignore", //
+						d)));
 
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsSeverityTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsSeverityTest.java
@@ -34,7 +34,7 @@ public class QuteDiagnosticsSeverityTest {
 		QuteValidationSettings validationSettings = new QuteValidationSettings();
 		Diagnostic d = d(0, 1, 0, 4, QuteErrorCode.UndefinedObject, //
 				"`foo` cannot be resolved to an object.", DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("foo", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("foo", false));
 		testDiagnosticsFor(template, validationSettings, d);
 	}
 
@@ -57,7 +57,7 @@ public class QuteDiagnosticsSeverityTest {
 		validationSettings.setUndefinedObject(undefinedObject);
 		Diagnostic d = d(0, 1, 0, 4, QuteErrorCode.UndefinedObject, //
 				"`foo` cannot be resolved to an object.", DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("foo", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("foo", false));
 		testDiagnosticsFor(template, validationSettings, d);
 	}
 
@@ -70,7 +70,7 @@ public class QuteDiagnosticsSeverityTest {
 		validationSettings.setUndefinedObject(undefinedObject);
 		Diagnostic d = d(0, 1, 0, 4, QuteErrorCode.UndefinedObject, //
 				"`foo` cannot be resolved to an object.", DiagnosticSeverity.Error);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("foo", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("foo", false));
 		testDiagnosticsFor(template, validationSettings, d);
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsUserTagTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsUserTagTest.java
@@ -36,7 +36,7 @@ public class QuteDiagnosticsUserTagTest {
 		String template = "{name}";
 		Diagnostic d = d(0, 1, 0, 5, QuteErrorCode.UndefinedObject, "`name` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("name", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("name", false));
 		testDiagnosticsFor(template, //
 				"src/main/resources/templates/user.html", //
 				"user", //
@@ -56,7 +56,7 @@ public class QuteDiagnosticsUserTagTest {
 		String template = "{#user name=name /}";
 		Diagnostic d = d(0, 12, 0, 16, QuteErrorCode.UndefinedObject, "`name` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("name", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("name", false));
 		testDiagnosticsFor(template, d);
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsWithCheckedTemplateTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsWithCheckedTemplateTest.java
@@ -20,7 +20,7 @@ public class QuteDiagnosticsWithCheckedTemplateTest {
 		String template = "Item: {items}";
 		Diagnostic d = d(0, 7, 0, 12, QuteErrorCode.UndefinedObject, "`items` cannot be resolved to an object.",
 				DiagnosticSeverity.Warning);
-		d.setData(DiagnosticDataFactory.createUndefinedVariableData("items", false));
+		d.setData(DiagnosticDataFactory.createUndefinedObjectData("items", false));
 		testDiagnosticsFor(template, d);
 	}
 


### PR DESCRIPTION
Added CodeAction to set `UndefinedObject` severity to ignore.
![ignoreseverityundefinedobject](https://user-images.githubusercontent.com/26389510/157937990-031bcf22-ded9-44fc-bef6-4f725787746c.gif)

Fixes #594 
Extends: #587 

Signed-off-by: Alexander Chen <alchen@redhat.com>