### PR TITLE
Fix bug with super method.

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/JavaDataModelCache.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/JavaDataModelCache.java
@@ -109,7 +109,7 @@ public class JavaDataModelCache implements DataModelTemplateProvider {
 
 	private CompletionStage<ResolvedJavaTypeInfo> resolveJavaType(Part part, String projectUri,
 			ResolvedJavaTypeInfo resolvedType) {
-		JavaMemberInfo member = projectRegistry.findMember(part, resolvedType, projectUri);
+		JavaMemberInfo member = findMember(part, resolvedType, projectUri);
 		if (member == null) {
 			return RESOLVED_JAVA_TYPE_INFO_NULL_FUTURE;
 		}
@@ -249,12 +249,12 @@ public class JavaDataModelCache implements DataModelTemplateProvider {
 		return null;
 	}
 
-	public JavaMemberInfo findMember(Part part, ResolvedJavaTypeInfo previousResolvedType, String projectUri) {
-		return projectRegistry.findMember(part, previousResolvedType, projectUri);
+	public JavaMemberInfo findMember(Part part, ResolvedJavaTypeInfo baseType, String projectUri) {
+		return findMember(baseType, part.getPartName(), projectUri);
 	}
 
-	public JavaMemberInfo findMember(ResolvedJavaTypeInfo resolvedType, String property) {
-		return projectRegistry.findMember(resolvedType, property);
+	public JavaMemberInfo findMember(ResolvedJavaTypeInfo baseType, String property, String projectUri) {
+		return projectRegistry.findMember(baseType, property, projectUri);
 	}
 
 	public boolean hasNamespace(String namespace, String projectUri) {

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteDiagnostics.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteDiagnostics.java
@@ -113,13 +113,13 @@ class QuteDiagnostics {
 					ResolvedJavaTypeInfo resolvedIterableType = javaCache.resolveJavaType(iterableType, projectUri)
 							.getNow(null);
 					if (resolvedIterableType != null) {
-						JavaMemberInfo member = javaCache.findMember(resolvedIterableType, property);
+						JavaMemberInfo member = javaCache.findMember(resolvedIterableType, property, projectUri);
 						if (member != null) {
 							return member;
 						}
 					}
 				} else {
-					JavaMemberInfo member = javaCache.findMember(withObject, property);
+					JavaMemberInfo member = javaCache.findMember(withObject, property, projectUri);
 					if (member != null) {
 						return member;
 					}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/QuteQuickStartProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/QuteQuickStartProject.java
@@ -77,6 +77,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 
 		// Item <- BaseItem <- AbstractItem
 		ResolvedJavaTypeInfo abstractItem = createResolvedJavaTypeInfo("org.acme.AbstractItem", cache);
+		registerField("abstractName : java.lang.String", abstractItem);
 		registerMethod("convert(item : org.acme.AbstractItem) : int", abstractItem);
 		
 		ResolvedJavaTypeInfo baseItem = createResolvedJavaTypeInfo("org.acme.BaseItem", cache, abstractItem);

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionTest.java
@@ -608,8 +608,35 @@ public class QuteDiagnosticsInExpressionTest {
 	}
 
 	@Test
-	public void parameterSuperType() {
+	public void methodSuperType() {
+		String template = "{@org.acme.Item item}\r\n" + //
+				"		{item.convert(item)}";
+		testDiagnosticsFor(template);
 
+		template = "{@org.acme.Item item}\r\n" + //
+				"		{item.convert(1)}";
+		testDiagnosticsFor(template, //
+				d(1, 8, 1, 15, QuteErrorCode.InvalidMethodParameter,
+						"The method `convert(AbstractItem)` in the type `AbstractItem` is not applicable for the arguments `(Integer)`.",
+						DiagnosticSeverity.Error));
+	}
+
+	@Test
+	public void fieldSuperType() {
+		String template = "{@org.acme.Item item}\r\n" + //
+				"		{item.abstractName}"; // from super class org.acme.AbstractItem#abstractName
+		testDiagnosticsFor(template);
+
+		template = "{@org.acme.Item item}\r\n" + //
+				"		{item.XXXX}";
+		testDiagnosticsFor(template, //
+				d(1, 8, 1, 12, QuteErrorCode.UnknownProperty,
+						"`XXXX` cannot be resolved or is not a field of `org.acme.Item` Java type.",
+						DiagnosticSeverity.Error));
+	}
+
+	@Test
+	public void parameterSuperType() {
 		String template = "{@org.acme.Item item}\r\n" + //
 				"		{@org.acme.BaseItem baseItem}\r\n" + //
 				"		{@org.acme.AbstractItem abstractItem}\r\n" + //
@@ -622,6 +649,5 @@ public class QuteDiagnosticsInExpressionTest {
 				d(4, 16, 4, 23, QuteErrorCode.InvalidMethodParameter,
 						"The method `convert(AbstractItem)` in the type `AbstractItem` is not applicable for the arguments `(Integer)`.",
 						DiagnosticSeverity.Error));
-
 	}
 }


### PR DESCRIPTION
Fix bug with super method.

Signed-off-by: azerr <azerr@redhat.com>

This PR fixes the follwoing problem, if you have :
```java
public class SmallItem{}
public class Item extends SmallItem{}
public class BigItem extends Item{}
```
and have an `smalItem.convert(SmallItem o)` method. then calling `item.convert(bigItem)` fails with:

```
`convert` cannot be resolved or is not a method of `org.acme.Item` Java type.
```