### PR TITLE
Bump nexus-staging-maven-plugin from 1.6.8 to 1.6.12

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
       when { not { equals expected: '', actual: VERSION } }
       steps {
         sh '''
-          export JAVA_HOME="${NATIVE_TOOLS}${SEP}openjdk17_last"
+          export JAVA_HOME="${NATIVE_TOOLS}${SEP}jdk11_last"
           MVN="${COMMON_TOOLS}${SEP}maven3-latest/bin/mvn -V -Dmaven.repo.local=${WORKSPACE}/.repository/ -B -ntp"
           ${MVN} -f ${WORKSPACE}/quarkus.jdt.ext/pom.xml org.eclipse.tycho:tycho-versions-plugin:1.7.0:set-version -DnewVersion=${VERSION}-SNAPSHOT -Dtycho.mode=maven
           ${MVN} -f ${WORKSPACE}/quarkus.ls.ext/com.redhat.quarkus.ls/pom.xml versions:set -DnewVersion=$VERSION -DnewVersion=${VERSION} -Dtycho.mode=maven
@@ -26,7 +26,7 @@ pipeline {
       steps {
         sh '''
           WORKSPACE_SAV=${WORKSPACE}
-          export JAVA_HOME="${NATIVE_TOOLS}${SEP}openjdk17_last"
+          export JAVA_HOME="${NATIVE_TOOLS}${SEP}jdk11_last"
           MVN="${COMMON_TOOLS}${SEP}maven3-latest/bin/mvn -V -Dmaven.repo.local=${WORKSPACE}/.repository/ -B -ntp"
           BUILD_TIMESTAMP=`date -u +%Y-%m-%d_%H-%M-%S`
 		
@@ -56,7 +56,7 @@ pipeline {
       steps {
         sh '''
           mvnFlags="-B -ntp -DaltSnapshotDeploymentRepository=origin-repository.jboss.org"
-          export JAVA_HOME="${NATIVE_TOOLS}${SEP}openjdk17_last"
+          export JAVA_HOME="${NATIVE_TOOLS}${SEP}jdk11_last"
           MVN="${COMMON_TOOLS}${SEP}maven3-latest/bin/mvn -V -Dmaven.repo.local=${WORKSPACE}/.repository/"
 
           pom=${WORKSPACE}/quarkus.ls.ext/com.redhat.quarkus.ls/pom.xml

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.site/pom.xml
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.site/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>parent</artifactId>
 		<groupId>com.redhat.microprofile</groupId>
-		<version>0.11.0-SNAPSHOT</version>
+		<version>0.11.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>com.microprofile.quarkus.jdt.site</artifactId>
 	<packaging>eclipse-repository</packaging>

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/META-INF/MANIFEST.MF
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: quarkus.jdt.ls Test Plugin
 Bundle-SymbolicName: com.redhat.microprofile.jdt.quarkus.test
-Bundle-Version: 0.11.0.qualifier
+Bundle-Version: 0.11.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit,
  org.apache.commons.io,

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/pom.xml
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>parent</artifactId>
 		<groupId>com.redhat.microprofile</groupId>
-		<version>0.11.0-SNAPSHOT</version>
+		<version>0.11.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>com.redhat.microprofile.jdt.quarkus.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/META-INF/MANIFEST.MF
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: com.redhat.microprofile.jdt.quarkus;singleton:=true
-Bundle-Version: 0.11.0.qualifier
+Bundle-Version: 0.11.1.qualifier
 Require-Bundle: org.eclipse.lsp4mp.jdt.core,
  org.eclipse.core.runtime,
  org.eclipse.jdt.core,

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/pom.xml
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>parent</artifactId>
 		<groupId>com.redhat.microprofile</groupId>
-		<version>0.11.0-SNAPSHOT</version>
+		<version>0.11.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>com.redhat.microprofile.jdt.quarkus</artifactId>

--- a/quarkus.jdt.ext/pom.xml
+++ b/quarkus.jdt.ext/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.redhat.microprofile</groupId>
   <artifactId>parent</artifactId>
-  <version>0.11.0-SNAPSHOT</version>
+  <version>0.11.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>quarkus.jdt.ls :: parent</name>
   <description>quarkus.jdt.ls parent</description>

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/pom.xml
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.redhat.microprofile</groupId>
 	<artifactId>com.redhat.quarkus.ls</artifactId>
-	<version>0.11.0-SNAPSHOT</version>
+	<version>0.11.1-SNAPSHOT</version>
 
 	<name>Quarkus Extension for the MicroProfile Language Server</name>
 	<description>Quarkus extension for MicroProfile Language Server</description>
@@ -120,7 +120,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.8</version>
+				<version>1.6.12</version>
 				<extensions>true</extensions>
 				<configuration>
 					<nexusUrl>${jbossNexus}/nexus/</nexusUrl>

--- a/qute.jdt/com.redhat.qute.jdt.site/pom.xml
+++ b/qute.jdt/com.redhat.qute.jdt.site/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>parent-qute</artifactId>
 		<groupId>com.redhat.microprofile</groupId>
-		<version>0.11.0-SNAPSHOT</version>
+		<version>0.11.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>com.redhat.qute.jdt.site</artifactId>
 	<packaging>eclipse-repository</packaging>

--- a/qute.jdt/com.redhat.qute.jdt.test/META-INF/MANIFEST.MF
+++ b/qute.jdt/com.redhat.qute.jdt.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: com.redhat.qute.jdt.test;singleton:=true
-Bundle-Version: 0.11.0.qualifier
+Bundle-Version: 0.11.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit,
  org.apache.commons.io,

--- a/qute.jdt/com.redhat.qute.jdt.test/pom.xml
+++ b/qute.jdt/com.redhat.qute.jdt.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>parent-qute</artifactId>
 		<groupId>com.redhat.microprofile</groupId>
-		<version>0.11.0-SNAPSHOT</version>
+		<version>0.11.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>com.redhat.qute.jdt.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>

--- a/qute.jdt/com.redhat.qute.jdt/META-INF/MANIFEST.MF
+++ b/qute.jdt/com.redhat.qute.jdt/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: com.redhat.qute.jdt;singleton:=true
-Bundle-Version: 0.11.0.qualifier
+Bundle-Version: 0.11.1.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.ls.core;resolution:=optional,
  org.eclipse.jdt.core,

--- a/qute.jdt/com.redhat.qute.jdt/pom.xml
+++ b/qute.jdt/com.redhat.qute.jdt/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>parent-qute</artifactId>
 		<groupId>com.redhat.microprofile</groupId>
-		<version>0.11.0-SNAPSHOT</version>
+		<version>0.11.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>com.redhat.qute.jdt</artifactId>

--- a/qute.jdt/pom.xml
+++ b/qute.jdt/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.redhat.microprofile</groupId>
 	<artifactId>parent-qute</artifactId>
-	<version>0.11.0-SNAPSHOT</version>
+	<version>0.11.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>qute.jdt.ls :: parent</name>
 	<description>qute.jdt.ls parent</description>

--- a/qute.ls/com.redhat.qute.ls/pom.xml
+++ b/qute.ls/com.redhat.qute.ls/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.redhat.microprofile</groupId>
 	<artifactId>com.redhat.qute.ls</artifactId>
-	<version>0.11.0-SNAPSHOT</version>
+	<version>0.11.1-SNAPSHOT</version>
 
 	<name>Qute Language Server</name>
 	<description>Qute Language Server</description>
@@ -116,7 +116,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.8</version>
+				<version>1.6.12</version>
 				<extensions>true</extensions>
 				<configuration>
 					<nexusUrl>${jbossNexus}/nexus/</nexusUrl>


### PR DESCRIPTION
- Use JDK 11 on builds to satisfy deploy plugin requirements

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>