### PR TITLE
Update Quarkus LS to use LSP4MP 0.5.0 Snapshots.

### DIFF
--- a/quarkus.jdt.ext/pom.xml
+++ b/quarkus.jdt.ext/pom.xml
@@ -17,7 +17,7 @@
     <jdt.ls.version>1.7.0.20211216164144</jdt.ls.version>
     <tycho.test.platformArgs />
     <tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
-    <lsp4mp.p2.url>https://download.eclipse.org/lsp4mp/snapshots/0.4.0/repository/</lsp4mp.p2.url>
+    <lsp4mp.p2.url>https://download.eclipse.org/lsp4mp/snapshots/0.5.0/repository/</lsp4mp.p2.url>
 
     <!-- Code coverage -->
     <jacoco.version>0.7.9</jacoco.version>

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/pom.xml
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/pom.xml
@@ -39,7 +39,7 @@
 		<maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
 		<dev.build.timestamp>${maven.build.timestamp}</dev.build.timestamp>
 		<lsp4j.version>0.11.0</lsp4j.version>
-		<microprofile.ls.version>0.4.0-SNAPSHOT</microprofile.ls.version>
+		<microprofile.ls.version>0.5.0-SNAPSHOT</microprofile.ls.version>
 		<jboss.releases.repo.id>jboss-releases-repository</jboss.releases.repo.id>
 		<jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
 		<jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>


### PR DESCRIPTION
- Update to the next available snapshot release
- The final release of LSP4MP still gets deployed to the snapshot
  location, resulting in a failure to resolve snapshot artifacts
  post-release

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>