### PR TITLE
template validation complains about strings containing spaces

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/expression/scanner/ExpressionScanner.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/expression/scanner/ExpressionScanner.java
@@ -205,8 +205,15 @@ public class ExpressionScanner extends AbstractScanner<TokenType, ScannerState> 
 	private void nextJavaIdentifierPart() {
 		TokenType lastTokenType = getTokenType();
 		if (canSupportInfixNotation && lastTokenType == TokenType.Whitespace) {
-			// foo or| bar
-			stream.advanceUntilAnyOfChars(' ', '.', '[');
+			int c = stream.peekChar();
+			if (c == '"' || c == '\'') {
+				// foo or "bar baz"
+				stream.advance(1);
+				stream.advanceUntilChar(c);
+			} else {
+				// foo or| bar
+				stream.advanceUntilAnyOfChars(' ', '.', '[');
+			}
 		}
 		// foo.or|
 		stream.advanceUntilAnyOfChars(' ', '.', '[', '(', ':');

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/parser/expression/scanner/ExpressionScannerTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/parser/expression/scanner/ExpressionScannerTest.java
@@ -293,6 +293,17 @@ public class ExpressionScannerTest {
 		assertOffsetAndToken(4, TokenType.InfixMethodPart, "getBytes()");
 		assertOffsetAndToken(14, TokenType.EOS, "");
 	}
+
+	@Test
+	public void elvisOperator() {
+		scanner = createInfixNotationScanner("name ?: \"Quarkus Insights\"");
+		assertOffsetAndToken(0, TokenType.ObjectPart, "name");
+		assertOffsetAndToken(4, TokenType.Whitespace, " ");
+		assertOffsetAndToken(5, TokenType.InfixMethodPart, "?:");
+		assertOffsetAndToken(7, TokenType.Whitespace, " ");
+		assertOffsetAndToken(8, TokenType.InfixParameter, "\"Quarkus Insights\"");
+		assertOffsetAndToken(26, TokenType.EOS, "");
+	}
 	
 	private void assertOffsetAndToken(int tokenOffset, TokenType tokenType, String tokenText) {
 		TokenType token = scanner.scan();

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInfixNotationTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInfixNotationTest.java
@@ -146,6 +146,13 @@ public class QuteDiagnosticsInfixNotationTest {
 	}
 	
 	@Test
+	public void elvisOperatorWithStringSpace() throws Exception {
+		String template = "{@java.lang.String foo}\r\n" + //
+				"{foo ?: foo : 'hello word'}"; //
+		testDiagnosticsFor(template);
+	}
+	
+	@Test
 	public void twoParts() throws Exception {
 		String template = "{@java.lang.String foo}\r\n" + //
 				"{foo 'word'}"; //


### PR DESCRIPTION
template validation complains about strings containing spaces

Fixes #639

Signed-off-by: azerr <azerr@redhat.com>