### PR TITLE
Temporarily use JDT-LS 1.12.0 (instead of SNAPSHOT build)

### DIFF
--- a/quarkus.jdt.ext/pom.xml
+++ b/quarkus.jdt.ext/pom.xml
@@ -38,7 +38,7 @@
     <repository>
       <id>jdt.ls.p2</id>
       <layout>p2</layout>
-      <url>https://download.eclipse.org/jdtls/snapshots/repository/latest/</url>
+      <url>https://download.eclipse.org/jdtls/milestones/1.12.0/repository/</url>
     </repository>
     <repository>
       <id>lsp4mp.p2</id>

--- a/qute.jdt/pom.xml
+++ b/qute.jdt/pom.xml
@@ -39,7 +39,7 @@
 		<repository>
 			<id>jdt.ls.p2</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/jdtls/snapshots/repository/latest/</url>
+			<url>https://download.eclipse.org/jdtls/milestones/1.12.0/repository/</url>
 		</repository>
 		<repository>
 			<id>jdt.ls.maven</id>


### PR DESCRIPTION
- Eventually a proper update to Java 17 will be required

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>