### PR TITLE
Delay revalidation after edit and improve cancel checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,5 +112,6 @@ buildNumber.properties
 
 # End of https://www.gitignore.io/api/java,maven,eclipse
 
+# Ignore config for Eclipse PDE in VS Code until we get remote repositories working
 javaConfig.json
 **/*.target

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/ModelTextDocument.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/ModelTextDocument.java
@@ -22,7 +22,7 @@ import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
 
 /**
  * A {@link TextDocument} which is associate to a model loaded in async.
- * 
+ *
  * @author Angelo ZERR
  *
  * @param <T> the model type (ex : DOM Document)
@@ -33,7 +33,7 @@ public class ModelTextDocument<T> extends TextDocument {
 
 	private final BiFunction<TextDocument, CancelChecker, T> parse;
 
-	private CompletableFuture<T> model;
+	private T model;
 
 	public ModelTextDocument(TextDocumentItem document, BiFunction<TextDocument, CancelChecker, T> parse) {
 		super(document);
@@ -46,33 +46,55 @@ public class ModelTextDocument<T> extends TextDocument {
 	}
 
 	/**
-	 * Returns the completable future which loads the model. The process of parse od
-	 * the model is stopped as soon as possible when text content changed.
-	 * 
-	 * @return the completable future which loads the model.
+	 * Returns the existing parsed model synchronized with last version of the text
+	 * document and null otherwise.
+	 *
+	 * @return the existing parsed model synchronized with last version of the text
+	 *         document and null otherwise.
 	 */
-	public CompletableFuture<T> getModel() {
+	public T getExistingModel() {
+		return model;
+	}
+
+	/**
+	 * Returns the parsed model synchronized with last version of the text document.
+	 *
+	 * @return the parsed model synchronized with last version of the text document.
+	 */
+	public T getModel() {
 		if (model == null) {
-			int version = super.getVersion();
-			model = CompletableFutures.computeAsync((requestCancelChecker) -> {
-				long start = System.currentTimeMillis();
-				try {
-					LOGGER.fine("Start parsing of model with version '" + version);
-					// Stop of parse process can be done when completable future is canceled or when
-					// version of document changes
-					MultiCancelChecker cancelChecker = new MultiCancelChecker(requestCancelChecker,
-							new TextDocumentVersionChecker(this, version));
-					// parse the model
-					return parse.apply(this, cancelChecker);
-				} catch (CancellationException e) {
-					LOGGER.fine("Stop parsing parsing of model with version '" + version + "' in "
-							+ (System.currentTimeMillis() - start) + "ms");
-					throw e;
-				} finally {
-					LOGGER.fine("End parse of model with version '" + version + "' in "
-							+ (System.currentTimeMillis() - start) + "ms");
-				}
-			});
+			return getSynchronizedModel();
+		}
+		return model;
+	}
+
+	/**
+	 * Return the existing parsed model synchronized with last version of the text
+	 * document or parse the model.
+	 *
+	 * @return the existing parsed model synchronized with last version of the text
+	 *         document or parse the model.
+	 */
+	private synchronized T getSynchronizedModel() {
+		if (model != null) {
+			return model;
+		}
+		int version = super.getVersion();
+		long start = System.currentTimeMillis();
+		try {
+			LOGGER.fine("Start parsing of model with version '" + version);
+			// Stop of parse process can be done when completable future is canceled or when
+			// version of document changes
+			CancelChecker cancelChecker = new TextDocumentVersionChecker(this, version);
+			// parse the model
+			model = parse.apply(this, cancelChecker);
+		} catch (CancellationException e) {
+			LOGGER.fine("Stop parsing parsing of model with version '" + version + "' in "
+					+ (System.currentTimeMillis() - start) + "ms");
+			throw e;
+		} finally {
+			LOGGER.fine("End parse of model with version '" + version + "' in " + (System.currentTimeMillis() - start)
+					+ "ms");
 		}
 		return model;
 	}
@@ -87,18 +109,15 @@ public class ModelTextDocument<T> extends TextDocument {
 	@Override
 	public void setVersion(int version) {
 		super.setVersion(version);
-		// version changed, cancel the completable future which load the model
+		// version changed, mark the model as dirty
 		cancelModel();
 	}
 
 	/**
-	 * Cancel the completable future which loads the model.
+	 * Mark the model as dirty
 	 */
 	private void cancelModel() {
-		if (model != null) {
-			model.cancel(true);
-			model = null;
-		}
+		model = null;
 	}
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/ModelTextDocuments.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/ModelTextDocuments.java
@@ -11,14 +11,18 @@
 *******************************************************************************/
 package com.redhat.qute.ls.commons;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 
+import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
+import org.eclipse.lsp4j.jsonrpc.messages.Tuple;
 
 /**
  * The cache of {@link TextDocument} linked to a model.
- * 
+ *
  * @author Angelo ZERR
  *
  * @param <T> the model type (ex : DOM Document)
@@ -36,5 +40,109 @@ public class ModelTextDocuments<T> extends TextDocuments<ModelTextDocument<T>> {
 		ModelTextDocument<T> doc = new ModelTextDocument<T>(document, parse);
 		doc.setIncremental(isIncremental());
 		return doc;
+	}
+
+	/**
+	 * Returns the model of the given text document Uri and null otherwise.
+	 *
+	 * @param uri the text document uri.
+	 *
+	 * @return the model of the given text document Uri and null otherwise.
+	 */
+	public T getExistingModel(TextDocumentIdentifier documentIdentifier) {
+		return getExistingModel(documentIdentifier.getUri());
+	}
+
+	/**
+	 * Returns the model of the given text document Uri and null otherwise.
+	 *
+	 * @param uri the text document uri.
+	 *
+	 * @return the model of the given text document Uri and null otherwise.
+	 */
+	public T getExistingModel(String uri) {
+		ModelTextDocument<T> document = get(uri);
+		if (document != null) {
+			return document.getExistingModel();
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the model of the given text document Uri and null otherwise.
+	 *
+	 * @param uri the text document uri.
+	 *
+	 * @return the model of the given text document Uri and null otherwise.
+	 */
+	public T getModel(TextDocumentIdentifier documentIdentifier) {
+		return getModel(documentIdentifier.getUri());
+	}
+
+	/**
+	 * Returns the model of the given text document Uri and null otherwise.
+	 *
+	 * @param uri the text document uri.
+	 *
+	 * @return the model of the given text document Uri and null otherwise.
+	 */
+	public T getModel(String uri) {
+		ModelTextDocument<T> document = get(uri);
+		if (document != null) {
+			return document.getModel();
+		}
+		return null;
+	}
+
+	/**
+	 * Get or parse the model and apply the code function which expects the model.
+	 *
+	 * @param <R>
+	 * @param documentIdentifier the document identifier.
+	 * @param code               a bi function that accepts the parsed model and
+	 *                           {@link CancelChecker} and returns the to be
+	 *                           computed value
+	 * @return the model for a given uri in a future and then apply the given
+	 *         function.
+	 */
+	public <R> CompletableFuture<R> computeModelAsync(TextDocumentIdentifier documentIdentifier,
+			BiFunction<T, CancelChecker, R> code) {
+		return CompletableFutures.computeAsync(cancelChecker -> {
+			// Get or parse the model.
+			T model = getModel(documentIdentifier);
+			if (model == null) {
+				return null;
+			}
+			cancelChecker.checkCanceled();
+			// Apply the function code by using the parsed model.
+			return code.apply(model, cancelChecker);
+		});
+	}
+
+	/**
+	 * Get or parse the model and apply the code function which expects the model.
+	 *
+	 * @param <R>
+	 * @param documentIdentifier the document identifier.
+	 * @param code               a bi function that accepts the parsed model and
+	 *                           {@link CancelChecker} and returns as future the to
+	 *                           be computed value
+	 * @return the model for a given uri in a future and then apply the given
+	 *         function.
+	 */
+	public <R> CompletableFuture<R> computeModelAsyncCompose(TextDocumentIdentifier documentIdentifier,
+			BiFunction<T, CancelChecker, CompletableFuture<R>> code) {
+		return CompletableFutures.computeAsync(cancelChecker -> {
+			// Get or parse the model.
+			T model = getModel(documentIdentifier);
+			if (model == null) {
+				return null;
+			}
+			cancelChecker.checkCanceled();
+			// Apply the function code by using the parsed model.
+			return Tuple.two(model, cancelChecker);
+		}).thenCompose((tuple) -> {
+			return code.apply(tuple.getFirst(), tuple.getSecond());
+		});
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/ModelValidatorDelayer.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/ModelValidatorDelayer.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.ls.commons;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * Validate a given model document with delay.
+ *
+ * @author Angelo ZERR
+ *
+ * @param <T>
+ */
+public class ModelValidatorDelayer<T> {
+
+    private static final long DEFAULT_VALIDATION_DELAY_MS = 500;
+
+    private final ScheduledExecutorService executorService;
+
+    private final Consumer<ModelTextDocument<T>> validator;
+
+    private final Map<String, Future<?>> pendingValidationRequests;
+
+    private final long validationDelayMs;
+
+    public ModelValidatorDelayer(Consumer<ModelTextDocument<T>> validator) {
+        this(Executors.newScheduledThreadPool(2), validator, DEFAULT_VALIDATION_DELAY_MS);
+    }
+
+    public ModelValidatorDelayer(ScheduledExecutorService executorService, Consumer<ModelTextDocument<T>> validator,
+            long validationDelayMs) {
+        this.executorService = executorService;
+        this.validator = validator;
+        this.pendingValidationRequests = new HashMap<>();
+        this.validationDelayMs = validationDelayMs;
+    }
+
+    /**
+     * Validate the given model <code>document</code> identified by the given
+     * <code>uri</code> with a delay.
+     *
+     * @param uri      the document URI.
+     * @param document the document model to validate.
+     */
+    public void validateWithDelay(ModelTextDocument<T> document) {
+        String uri = document.getUri();
+        cleanPendingValidation(uri);
+        int version = document.getVersion();
+        Future<?> request = executorService.schedule(() -> {
+            synchronized (pendingValidationRequests) {
+                pendingValidationRequests.remove(uri);
+            }
+            if (version == document.getVersion()) {
+                validator.accept(document);
+            }
+        }, validationDelayMs, TimeUnit.MILLISECONDS);
+        synchronized (pendingValidationRequests) {
+            pendingValidationRequests.put(uri, request);
+        }
+    }
+
+    public void cleanPendingValidation(String uri) {
+        synchronized (pendingValidationRequests) {
+            Future<?> request = pendingValidationRequests.get(uri);
+            if (request != null) {
+                request.cancel(true);
+                pendingValidationRequests.remove(uri);
+            }
+        }
+    }
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/template/QuteTextDocument.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/template/QuteTextDocument.java
@@ -53,21 +53,19 @@ public class QuteTextDocument extends ModelTextDocument<Template> implements Tem
 	}
 
 	@Override
-	public CompletableFuture<Template> getModel() {
-		return super.getModel() //
-				.thenApply(template -> {
-					if (template != null && template.getProjectUri() == null) {
-						template.setTemplateInfoProvider(this);
-						ProjectInfo projectInfo = getProjectInfoFuture().getNow(null);
-						if (projectInfo != null) {
-							QuteProject project = projectRegistry.getProject(projectInfo);
-							template.setProjectUri(project.getUri());
-							template.setTemplateId(templateId);
-						}
-						template.setProjectRegistry(projectRegistry);
-					}
-					return template;
-				});
+	public Template getModel() {
+		var template = super.getModel();
+		if (template != null && template.getProjectUri() == null) {
+			template.setTemplateInfoProvider(this);
+			ProjectInfo projectInfo = getProjectInfoFuture().getNow(null);
+			if (projectInfo != null) {
+				QuteProject project = projectRegistry.getProject(projectInfo);
+				template.setProjectUri(project.getUri());
+				template.setTemplateId(templateId);
+			}
+			template.setProjectRegistry(projectRegistry);
+		}
+		return template;
 	}
 
 	@Override
@@ -90,7 +88,7 @@ public class QuteTextDocument extends ModelTextDocument<Template> implements Tem
 	}
 
 	@Override
-	public CompletableFuture<Template> getTemplate() {
+	public Template getTemplate() {
 		return getModel();
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/QuteProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/QuteProject.java
@@ -134,7 +134,7 @@ public class QuteProject {
 	public List<QuteIndex> findInsertTagParameter(String templateId, String insertParamater) {
 		TemplateInfoProvider provider = openedDocuments.get(templateId);
 		if (provider != null) {
-			Template template = provider.getTemplate().getNow(null);
+			Template template = provider.getTemplate();
 			if (template != null) {
 				List<QuteIndex> indexes = new ArrayList<>();
 				collectInsert(insertParamater, template, template, indexes);
@@ -316,7 +316,7 @@ public class QuteProject {
 
 	/**
 	 * Returns the src/main/resources/templates/tags directory.
-	 * 
+	 *
 	 * @return the src/main/resources/templates/tags directory.
 	 */
 	public Path getTagsDir() {
@@ -327,7 +327,7 @@ public class QuteProject {
 		if (getJavaTypesSupportedInNativeMode().contains(javaTypeName)) {
 			return JavaTypeAccessibiltyRule.ALLOWED_WITHOUT_RESTRICTION;
 		}
-		
+
 		// Native images mode : the java reflection is supported only if the Java type
 		// is
 		// annotated with:

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/TemplateInfoProvider.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/TemplateInfoProvider.java
@@ -18,7 +18,7 @@ import com.redhat.qute.parser.template.Template;
 
 /**
  * Template information provider for a given template.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -26,28 +26,28 @@ public interface TemplateInfoProvider {
 
 	/**
 	 * Returns the current parsed template.
-	 * 
+	 *
 	 * @return the current parsed template
 	 */
-	CompletableFuture<Template> getTemplate();
+	Template getTemplate();
 
 	/**
 	 * Returns the owner project information of the template.
-	 * 
+	 *
 	 * @return the owner project information of the template.
 	 */
 	CompletableFuture<ProjectInfo> getProjectInfoFuture();
 
 	/**
 	 * Returns the owner project uri of the template.
-	 * 
+	 *
 	 * @return the owner project uri of the template.
 	 */
 	String getProjectUri();
 
 	/**
 	 * Returns the template id.
-	 * 
+	 *
 	 * @return the template id.
 	 */
 	String getTemplateId();

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteCodeActions.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteCodeActions.java
@@ -30,6 +30,7 @@ import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
 import com.google.gson.JsonObject;
 import com.redhat.qute.ls.commons.BadLocationException;

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteCodeLens.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteCodeLens.java
@@ -42,7 +42,7 @@ import com.redhat.qute.utils.UserTagUtils;
 
 /**
  * Qute code lens support.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -59,6 +59,7 @@ class QuteCodeLens {
 			CancelChecker cancelChecker) {
 		return javaCache.getDataModelTemplate(template) //
 				.thenApply(templateDataModel -> {
+					cancelChecker.checkCanceled();
 					List<CodeLens> lenses = new ArrayList<>();
 
 					// #insert code lens references

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteCompletions.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteCompletions.java
@@ -157,7 +157,7 @@ public class QuteCompletions {
 			}
 		} else if (node.getKind() == NodeKind.ParameterDeclaration) {
 			return completionsForParameterDeclaration.doCollectJavaClassesSuggestions((ParameterDeclaration) node,
-					template, offset, completionSettings);
+					template, offset, completionSettings, cancelChecker);
 		} else if (node.getKind() == NodeKind.Section) {
 			// {#|}
 			return completionForTagSection.doCompleteTagSection(completionRequest, completionSettings,

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/completions/QuteCompletionsForExpression.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/completions/QuteCompletionsForExpression.java
@@ -122,33 +122,34 @@ public class QuteCompletionsForExpression {
 		if (nodeExpression.getKind() == NodeKind.ExpressionPart) {
 			Part part = (Part) nodeExpression;
 			switch (part.getPartKind()) {
-			case Object:
-				// ex : { ite|m }
-				return doCompleteExpressionForObjectPart(null, expression, part.getNamespace(), part, offset, template,
-						completionSettings, formattingSettings, nativeImagesSettings, cancelChecker);
-			case Property: {
-				// ex : { item.n| }
-				// ex : { item.n|ame }
-				Parts parts = part.getParent();
-				return doCompleteExpressionForMemberPart(part, parts, template, false, completionSettings,
-						formattingSettings, nativeImagesSettings);
-			}
-			case Method: {
-				// ex : { item.getN|ame() }
-				// ex : { item.getName(|) }
-				MethodPart methodPart = (MethodPart) part;
-				if (methodPart.isInParameters(offset)) {
+				case Object:
+					// ex : { ite|m }
+					return doCompleteExpressionForObjectPart(null, expression, part.getNamespace(), part, offset,
+							template,
+							completionSettings, formattingSettings, nativeImagesSettings, cancelChecker);
+				case Property: {
+					// ex : { item.n| }
+					// ex : { item.n|ame }
+					Parts parts = part.getParent();
+					return doCompleteExpressionForMemberPart(part, parts, template, false, completionSettings,
+							formattingSettings, nativeImagesSettings, cancelChecker);
+				}
+				case Method: {
+					// ex : { item.getN|ame() }
 					// ex : { item.getName(|) }
-					return doCompleteExpressionForObjectPart(null, expression, null, null, offset, template,
+					MethodPart methodPart = (MethodPart) part;
+					if (methodPart.isInParameters(offset)) {
+						// ex : { item.getName(|) }
+						return doCompleteExpressionForObjectPart(null, expression, null, null, offset, template,
+								completionSettings, formattingSettings, nativeImagesSettings, cancelChecker);
+					}
+					// ex : { item.getN|ame() }
+					Parts parts = part.getParent();
+					return doCompleteExpressionForMemberPart(part, parts, template, methodPart.isInfixNotation(),
 							completionSettings, formattingSettings, nativeImagesSettings, cancelChecker);
 				}
-				// ex : { item.getN|ame() }
-				Parts parts = part.getParent();
-				return doCompleteExpressionForMemberPart(part, parts, template, methodPart.isInfixNotation(),
-						completionSettings, formattingSettings, nativeImagesSettings);
-			}
-			default:
-				break;
+				default:
+					break;
 			}
 			return EMPTY_FUTURE_COMPLETION;
 		}
@@ -156,42 +157,43 @@ public class QuteCompletionsForExpression {
 		if (nodeExpression.getKind() == NodeKind.ExpressionParts) {
 			char previous = template.getText().charAt(offset - 1);
 			switch (previous) {
-			case ':': {
-				// ex : { data:| }
-				// ex : { data:|name }
-				Parts parts = (Parts) nodeExpression;
-				Part part = parts.getPartAt(offset + 1);
-				return doCompleteExpressionForObjectPart(null, expression, parts.getNamespace(), part, offset, template,
-						completionSettings, formattingSettings, nativeImagesSettings, cancelChecker);
-			}
-			case '.': {
-				// ex : { item.| }
-				// ex : { item.|name }
-				// ex : { item.|getName() }
-				Parts parts = (Parts) nodeExpression;
-				Part part = parts.getPartAt(offset + 1);
-				return doCompleteExpressionForMemberPart(part, parts, template, false, completionSettings,
-						formattingSettings, nativeImagesSettings);
-			}
-			case ' ': {
-				// Infix notation
-				// ex : { item | }
-				// ex : { item |name }
-				// ex : { item ?: |name }
-				Parts parts = (Parts) nodeExpression;
-				Part part = parts.getPartAt(offset + 1);
-				Part previousPart = parts.getPreviousPart(part);
-				if (previousPart != null && previousPart.getPartKind() == PartKind.Method
-						&& ((MethodPart) previousPart).isOperator()) {
-					// ex : { item ?: |name }
+				case ':': {
+					// ex : { data:| }
+					// ex : { data:|name }
+					Parts parts = (Parts) nodeExpression;
+					Part part = parts.getPartAt(offset + 1);
 					return doCompleteExpressionForObjectPart(null, expression, parts.getNamespace(), part, offset,
-							template, completionSettings, formattingSettings, nativeImagesSettings, cancelChecker);
+							template,
+							completionSettings, formattingSettings, nativeImagesSettings, cancelChecker);
 				}
-				// ex : { item | }
-				// ex : { item |name }
-				return doCompleteExpressionForMemberPart(part, parts, template, true, completionSettings,
-						formattingSettings, nativeImagesSettings);
-			}
+				case '.': {
+					// ex : { item.| }
+					// ex : { item.|name }
+					// ex : { item.|getName() }
+					Parts parts = (Parts) nodeExpression;
+					Part part = parts.getPartAt(offset + 1);
+					return doCompleteExpressionForMemberPart(part, parts, template, false, completionSettings,
+							formattingSettings, nativeImagesSettings, cancelChecker);
+				}
+				case ' ': {
+					// Infix notation
+					// ex : { item | }
+					// ex : { item |name }
+					// ex : { item ?: |name }
+					Parts parts = (Parts) nodeExpression;
+					Part part = parts.getPartAt(offset + 1);
+					Part previousPart = parts.getPreviousPart(part);
+					if (previousPart != null && previousPart.getPartKind() == PartKind.Method
+							&& ((MethodPart) previousPart).isOperator()) {
+						// ex : { item ?: |name }
+						return doCompleteExpressionForObjectPart(null, expression, parts.getNamespace(), part, offset,
+								template, completionSettings, formattingSettings, nativeImagesSettings, cancelChecker);
+					}
+					// ex : { item | }
+					// ex : { item |name }
+					return doCompleteExpressionForMemberPart(part, parts, template, true, completionSettings,
+							formattingSettings, nativeImagesSettings, cancelChecker);
+				}
 			}
 		}
 		return EMPTY_FUTURE_COMPLETION;
@@ -210,18 +212,22 @@ public class QuteCompletionsForExpression {
 	 * @param completionSettings   the completion settings.
 	 * @param formattingSettings   the formatting settings.
 	 * @param nativeImagesSettings the native image settings.
+	 * @param cancelChecker        the cancel checker
 	 *
 	 * @return the completion list.
 	 */
 	private CompletableFuture<CompletionList> doCompleteExpressionForMemberPart(Part part, Parts parts,
 			Template template, boolean infixNotation, QuteCompletionSettings completionSettings,
-			QuteFormattingSettings formattingSettings, QuteNativeSettings nativeImagesSettings) {
+			QuteFormattingSettings formattingSettings, QuteNativeSettings nativeImagesSettings,
+			CancelChecker cancelChecker) {
 		int start = part != null ? part.getStart() : parts.getEnd();
 		int end = part != null ? part.getEnd() : parts.getEnd();
 		String projectUri = template.getProjectUri();
 		Part previousPart = parts.getPreviousPart(part);
 		return javaCache.resolveJavaType(previousPart, projectUri) //
 				.thenCompose(resolvedType -> {
+					cancelChecker.checkCanceled();
+
 					if (resolvedType == null) {
 						return EMPTY_FUTURE_COMPLETION;
 					}
@@ -232,6 +238,7 @@ public class QuteCompletionsForExpression {
 						// 'java.util.List<org.acme.Item>' Java class iterable
 						return javaCache.resolveJavaType(resolvedType.getIterableType(), projectUri) //
 								.thenApply(resolvedIterableType -> {
+									cancelChecker.checkCanceled();
 									if (resolvedIterableType == null) {
 										return EMPTY_COMPLETION;
 									}
@@ -316,16 +323,6 @@ public class QuteCompletionsForExpression {
 	 * Fill completion list <code>list</code> with the methods of the given Java
 	 * type <code>resolvedType</code>.
 	 *
-<<<<<<< Upstream, based on origin/master
-	 * @param rootBaseType       the Java root type class, interface.
-	 * @param baseType           the Java type class, interface.
-	 * @param range              the range.
-	 * @param ignoreSuperclasses
-	 * @param projectUri         the project Uri
-	 * @param existingProperties the existing properties and method, field
-	 *                           signature.
-	 * @param list               the completion list.
-=======
 	 * @param baseType              the Java type class, interface.
 	 * @param javaTypeAccessibility the Java type accessibility.
 	 * @param filter                the Java type filter.
@@ -334,7 +331,6 @@ public class QuteCompletionsForExpression {
 	 * @param existingProperties    the existing properties and method, field
 	 *                              signature.
 	 * @param list                  the completion list.
->>>>>>> 1480772 Support missing attributes for @TemplateData / @RegisterForReflection
 	 */
 	private void fillCompletionFields(ResolvedJavaTypeInfo baseType, JavaTypeAccessibiltyRule javaTypeAccessibility,
 			JavaTypeFilter filter, Range range, String projectUri, Set<String> existingProperties,
@@ -641,14 +637,14 @@ public class QuteCompletionsForExpression {
 
 	private static CompletionItemKind getCompletionKind(ValueResolver globalVariable) {
 		switch (globalVariable.getJavaElementKind()) {
-		case FIELD:
-			return CompletionItemKind.Field;
-		case METHOD:
-			return CompletionItemKind.Method;
-		case TYPE:
-			return CompletionItemKind.Class;
-		case PARAMETER:
-			return CompletionItemKind.TypeParameter;
+			case FIELD:
+				return CompletionItemKind.Field;
+			case METHOD:
+				return CompletionItemKind.Method;
+			case TYPE:
+				return CompletionItemKind.Class;
+			case PARAMETER:
+				return CompletionItemKind.TypeParameter;
 		}
 		return CompletionItemKind.Class;
 	}
@@ -692,27 +688,28 @@ public class QuteCompletionsForExpression {
 				}
 			} else {
 				switch (resolver.getJavaElementKind()) {
-				case METHOD: {
-					MethodValueResolver method = (MethodValueResolver) resolver;
-					CompletionItem item = fillCompletionMethod(method, method.getNamespace(), useNamespaceInTextEdit,
-							range, false, completionSettings, formattingSettings, list);
-					item.setKind(CompletionItemKind.Function);
-					// Display namespace resolvers (ex : config:getConfigProperty(...)) after
-					// declared objects
-					item.setSortText("Zc" + item.getLabel());
-					break;
-				}
-				case FIELD: {
-					FieldValueResolver field = (FieldValueResolver) resolver;
-					CompletionItem item = fillCompletionField(field, field.getNamespace(), namespace == null, range,
-							list);
-					item.setKind(CompletionItemKind.Field);
-					// Display namespace resolvers (ex : inject:bean) after
-					// declared objects
-					item.setSortText("Zb" + item.getLabel());
-					break;
-				}
-				default:
+					case METHOD: {
+						MethodValueResolver method = (MethodValueResolver) resolver;
+						CompletionItem item = fillCompletionMethod(method, method.getNamespace(),
+								useNamespaceInTextEdit,
+								range, false, completionSettings, formattingSettings, list);
+						item.setKind(CompletionItemKind.Function);
+						// Display namespace resolvers (ex : config:getConfigProperty(...)) after
+						// declared objects
+						item.setSortText("Zc" + item.getLabel());
+						break;
+					}
+					case FIELD: {
+						FieldValueResolver field = (FieldValueResolver) resolver;
+						CompletionItem item = fillCompletionField(field, field.getNamespace(), namespace == null, range,
+								list);
+						item.setKind(CompletionItemKind.Field);
+						// Display namespace resolvers (ex : inject:bean) after
+						// declared objects
+						item.setSortText("Zb" + item.getLabel());
+						break;
+					}
+					default:
 				}
 			}
 		}
@@ -758,50 +755,29 @@ public class QuteCompletionsForExpression {
 
 				// 2) Completion for aliases section
 				switch (section.getSectionKind()) {
-				case EACH:
-				case FOR:
-					LoopSection iterableSection = ((LoopSection) section);
-					// Completion for iterable section like #each, #for
-					String alias = iterableSection.getAlias();
-					if (!StringUtils.isEmpty(alias)) {
-						if (!existingVars.contains(alias)) {
-							existingVars.add(alias);
-							CompletionItem item = new CompletionItem();
-							item.setLabel(alias);
-							item.setKind(CompletionItemKind.Reference);
-							TextEdit textEdit = new TextEdit(range, alias);
-							item.setTextEdit(Either.forLeft(textEdit));
-							list.getItems().add(item);
-						}
-					}
-					break;
-				case LET:
-				case SET: {
-					// completion for parameters coming from #let, #set
-					List<Parameter> parameters = section.getParameters();
-					if (parameters != null) {
-						for (Parameter parameter : parameters) {
-							String parameterName = parameter.getName();
-							if (!existingVars.contains(parameterName)) {
-								existingVars.add(parameterName);
+					case EACH:
+					case FOR:
+						LoopSection iterableSection = ((LoopSection) section);
+						// Completion for iterable section like #each, #for
+						String alias = iterableSection.getAlias();
+						if (!StringUtils.isEmpty(alias)) {
+							if (!existingVars.contains(alias)) {
+								existingVars.add(alias);
 								CompletionItem item = new CompletionItem();
-								item.setLabel(parameterName);
+								item.setLabel(alias);
 								item.setKind(CompletionItemKind.Reference);
-								TextEdit textEdit = new TextEdit(range, parameterName);
+								TextEdit textEdit = new TextEdit(range, alias);
 								item.setTextEdit(Either.forLeft(textEdit));
 								list.getItems().add(item);
 							}
 						}
-					}
-					break;
-				}
-				case IF: {
-					// completion for parameters coming from #if
-					List<Parameter> parameters = section.getParameters();
-					if (parameters != null) {
-						for (Parameter parameter : parameters) {
-							if (parameter.isOptional()) {
-								// {#if foo??}
+						break;
+					case LET:
+					case SET: {
+						// completion for parameters coming from #let, #set
+						List<Parameter> parameters = section.getParameters();
+						if (parameters != null) {
+							for (Parameter parameter : parameters) {
 								String parameterName = parameter.getName();
 								if (!existingVars.contains(parameterName)) {
 									existingVars.add(parameterName);
@@ -814,28 +790,51 @@ public class QuteCompletionsForExpression {
 								}
 							}
 						}
+						break;
 					}
-					break;
-				}
-				case WITH:
-					// Completion for properties/methods of with object from #with
-					Parameter object = ((WithSection) section).getObjectParameter();
-					if (object != null) {
-						String projectUri = template.getProjectUri();
-						ResolvedJavaTypeInfo withJavaTypeInfo = javaCache.resolveJavaType(object, projectUri)
-								.getNow(null);
-						if (withJavaTypeInfo != null) {
-							JavaTypeFilter filter = javaCache.getJavaTypeFilter(projectUri, nativeImagesSettings);
-							JavaTypeAccessibiltyRule javaTypeAccessibility = filter.getJavaTypeAccessibility(
-									withJavaTypeInfo, template.getJavaTypesSupportedInNativeMode());
-							fillCompletionFields(withJavaTypeInfo, javaTypeAccessibility, filter, range, projectUri,
-									existingVars, list);
-							fillCompletionMethods(withJavaTypeInfo, javaTypeAccessibility, filter, range, projectUri,
-									false, completionSettings, formattingSettings, existingVars, new HashSet<>(), list);
+					case IF: {
+						// completion for parameters coming from #if
+						List<Parameter> parameters = section.getParameters();
+						if (parameters != null) {
+							for (Parameter parameter : parameters) {
+								if (parameter.isOptional()) {
+									// {#if foo??}
+									String parameterName = parameter.getName();
+									if (!existingVars.contains(parameterName)) {
+										existingVars.add(parameterName);
+										CompletionItem item = new CompletionItem();
+										item.setLabel(parameterName);
+										item.setKind(CompletionItemKind.Reference);
+										TextEdit textEdit = new TextEdit(range, parameterName);
+										item.setTextEdit(Either.forLeft(textEdit));
+										list.getItems().add(item);
+									}
+								}
+							}
 						}
+						break;
 					}
-					break;
-				default:
+					case WITH:
+						// Completion for properties/methods of with object from #with
+						Parameter object = ((WithSection) section).getObjectParameter();
+						if (object != null) {
+							String projectUri = template.getProjectUri();
+							ResolvedJavaTypeInfo withJavaTypeInfo = javaCache.resolveJavaType(object, projectUri)
+									.getNow(null);
+							if (withJavaTypeInfo != null) {
+								JavaTypeFilter filter = javaCache.getJavaTypeFilter(projectUri, nativeImagesSettings);
+								JavaTypeAccessibiltyRule javaTypeAccessibility = filter.getJavaTypeAccessibility(
+										withJavaTypeInfo, template.getJavaTypesSupportedInNativeMode());
+								fillCompletionFields(withJavaTypeInfo, javaTypeAccessibility, filter, range, projectUri,
+										existingVars, list);
+								fillCompletionMethods(withJavaTypeInfo, javaTypeAccessibility, filter, range,
+										projectUri,
+										false, completionSettings, formattingSettings, existingVars, new HashSet<>(),
+										list);
+							}
+						}
+						break;
+					default:
 				}
 			}
 		}


### PR DESCRIPTION
Delays revalidation of edited Qute templates to prevent excessive validation requests. Improves cancel checking in completion.

Signed-off-by: David Thompson <davthomp@redhat.com>
