### PR TITLE
Improved completion when nested in Qute `for`, `each`, `switch` and `when` sections

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/snippets/AbstractSnippetContext.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/snippets/AbstractSnippetContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 Red Hat Inc. and others.
+* Copyright (c) 2022 Red Hat Inc. and others.
 * All rights reserved. This program and the accompanying materials
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v20.html
@@ -12,27 +12,23 @@
 package com.redhat.qute.ls.commons.snippets;
 
 import java.util.List;
-import java.util.Map;
 
 /**
- * Snippet context used to filter the snippet.
- *
- * @author Angelo ZERR
+ * Abstract snippet context used to retrieve the prefix.
  *
  * @param <T> the value type waited by the snippet context.
  */
-public interface ISnippetContext<T> {
+public abstract class AbstractSnippetContext<T> implements ISnippetContext<T> {
 
-	/**
-	 * Return true if the given value match the snippet context and false otherwise.
-	 *
-	 * @param value the value to check.
-	 * @return true if the given value match the snippet context and false
-	 *         otherwise.
-	 */
-	boolean isMatch(T value, Map<String, String> model);
+	private List<String> prefixes;
 
-	void setPrefixes(List<String> prefixes);
+	@Override
+	public void setPrefixes(List<String> prefixes) {
+		this.prefixes = prefixes;
+	}
 
-	List<String> getPrefixes();
+	@Override
+	public List<String> getPrefixes() {
+		return prefixes;
+	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/snippets/Snippet.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/snippets/Snippet.java
@@ -5,7 +5,7 @@
 * http://www.eclipse.org/legal/epl-v20.html
 *
 * SPDX-License-Identifier: EPL-2.0
-* 
+*
 * Contributors:
 *     Red Hat Inc. - initial API and implementation
 *******************************************************************************/
@@ -17,7 +17,7 @@ import java.util.function.BiPredicate;
 
 /**
  * Snippet description (like vscode snippet).
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -101,6 +101,7 @@ public class Snippet {
 
 	public void setContext(ISnippetContext<?> context) {
 		this.context = context;
+		this.context.setPrefixes(getPrefixes());
 	}
 
 	public boolean hasContext() {

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/completions/QuteCompletionsForSnippets.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/completions/QuteCompletionsForSnippets.java
@@ -26,7 +26,7 @@ import com.redhat.qute.ls.commons.snippets.SnippetRegistry;
 import com.redhat.qute.ls.commons.snippets.SnippetRegistryProvider;
 import com.redhat.qute.parser.template.Node;
 import com.redhat.qute.parser.template.Template;
-import com.redhat.qute.services.snippets.IQuteSnippetContext;
+import com.redhat.qute.services.snippets.AbstractQuteSnippetContext;
 import com.redhat.qute.utils.QutePositionUtility;
 
 public class QuteCompletionsForSnippets<T extends Snippet> {
@@ -41,9 +41,9 @@ public class QuteCompletionsForSnippets<T extends Snippet> {
 
 	public QuteCompletionsForSnippets(SnippetRegistryProvider<T> snippetRegistryProvider) {
 		this(snippetRegistryProvider, false);
-		
+
 	}
-	
+
 	public QuteCompletionsForSnippets() {
 		this(true);
 	}
@@ -51,7 +51,7 @@ public class QuteCompletionsForSnippets<T extends Snippet> {
 	public QuteCompletionsForSnippets(boolean loadDefault) {
 		this(null, loadDefault);
 	}
-	
+
 	private QuteCompletionsForSnippets(SnippetRegistryProvider<T> snippetRegistryProvider, boolean loadDefault) {
 		this.loadDefault = loadDefault;
 		this.snippetRegistryProvider = snippetRegistryProvider;
@@ -83,8 +83,8 @@ public class QuteCompletionsForSnippets<T extends Snippet> {
 			List<CompletionItem> snippets = getSnippetRegistry().getCompletionItems(replaceRange, lineDelimiter,
 					completionRequest.canSupportMarkupKind(MarkupKind.MARKDOWN),
 					completionRequest.isCompletionSnippetsSupported(), (context, model) -> {
-						if (context instanceof IQuteSnippetContext) {
-							return (((IQuteSnippetContext) context).isMatch(completionRequest, model));
+						if (context instanceof AbstractQuteSnippetContext) {
+							return (((AbstractQuteSnippetContext) context).isMatch(completionRequest, model));
 						}
 						return false;
 					}, (suffix) -> {

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/snippets/AbstractQuteSnippetContext.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/snippets/AbstractQuteSnippetContext.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.snippets;
+
+import com.redhat.qute.ls.commons.snippets.AbstractSnippetContext;
+import com.redhat.qute.services.completions.CompletionRequest;
+
+/**
+ * Abstract Qute snippet context.
+ *
+ * @param <T> the value type waited by the snippet context.
+ */
+public abstract class AbstractQuteSnippetContext extends AbstractSnippetContext<CompletionRequest>
+		implements IQuteSnippetContext {
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/snippets/QuteSnippetContext.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/snippets/QuteSnippetContext.java
@@ -18,7 +18,7 @@ import com.redhat.qute.parser.template.NodeKind;
 import com.redhat.qute.parser.template.Section;
 import com.redhat.qute.services.completions.CompletionRequest;
 
-public abstract class QuteSnippetContext implements IQuteSnippetContext {
+public abstract class QuteSnippetContext extends AbstractQuteSnippetContext {
 
 	public static final QuteSnippetContext IN_TEXT = new QuteSnippetContext() {
 

--- a/qute.ls/com.redhat.qute.ls/src/main/resources/com/redhat/qute/services/snippets/qute-nested-snippets.json
+++ b/qute.ls/com.redhat.qute.ls/src/main/resources/com/redhat/qute/services/snippets/qute-nested-snippets.json
@@ -1,12 +1,44 @@
 {
-    "#else": {
+    "#case": {
+        "prefix": "case",
+        "body": [
+            "{#case ${1:case}}$0"
+        ],
+        "description": "Case section",
+        "context": {
+            "parent": "switch"
+        }
+    },
+    "#if-else": {
         "prefix": "else",
         "body": [
             "{#else}$0"
         ],
-        "description": "Else section",
+        "description": "Else section for if section",
         "context": {
             "parent": "if"
+        }
+    },
+    "#for-else": {
+        "prefix": "else",
+        "body": [
+            "{#else}$0"
+        ],
+        "description": "Else section for loop section",
+        "context": {
+            "parent": "for",
+            "unique": true
+        }
+    },
+    "#each-else": {
+        "prefix": "else",
+        "body": [
+            "{#else}$0"
+        ],
+        "description": "Else section for loop section",
+        "context": {
+            "parent": "each",
+            "unique": true
         }
     },
     "#elseif": {
@@ -17,6 +49,16 @@
         "description": "Else If section",
         "context": {
             "parent": "if"
+        }
+    },
+    "#is": {
+        "prefix": "is",
+        "body": [
+            "{#is ${1:case}}$0"
+        ],
+        "description": "Is section",
+        "context": {
+            "parent": "when"
         }
     }
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteSnippetCompletionInEachSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteSnippetCompletionInEachSectionTest.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.completions;
+
+import static com.redhat.qute.QuteAssert.SECTION_SNIPPET_SIZE;
+import static com.redhat.qute.QuteAssert.c;
+import static com.redhat.qute.QuteAssert.r;
+import static com.redhat.qute.QuteAssert.testCompletionFor;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for Qute snippet completion in #for section.
+ *
+ */
+public class QuteSnippetCompletionInEachSectionTest {
+
+	@Test
+	public void forSection() throws Exception {
+		String template = "|";
+		testCompletionFor(template, //
+				true, // snippet support
+				c("each", //
+						"{#each ${1:items}}" + System.lineSeparator() + //
+								"\t{it.${2:name}}$0" + System.lineSeparator() + //
+								"{/each}",
+						r(0, 0, 0, 0)));
+	}
+
+	@Test
+	public void snippetCompletionInNestedEach() throws Exception {
+		String template = "{#each items}\n" + //
+				"\t{it.name}\n" + //
+				"|\n" + //
+				"{/each}";
+		testCompletionFor(template, //
+				true, // snippet support
+				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 1, /* #else */ //
+				c("else", "{#else}$0", r(2, 0, 2, 0)));
+	}
+
+	@Test
+	public void sectionStartSnippetCompletionInNestedEach() throws Exception {
+		String template = "{#each items}\n" + //
+				"\t{it.name}\n" + //
+				"{#|}\n" + //
+				"{/each}";
+		testCompletionFor(template, //
+				true, // snippet support
+				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 1, /* #else */ //
+				c("else", "{#else}$0", r(2, 0, 2, 3)));
+	}
+
+	@Test
+	public void elseSnippetCompletionInNestedEach() throws Exception {
+		String template = "{#each items}\n" + //
+				"\t{it.name}\n" + //
+				"{#el|}\n" + //
+				"{/each}";
+		testCompletionFor(template, //
+				true, // snippet support
+				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 1, /* #else */ //
+				c("else", "{#else}$0", r(2, 0, 2, 5)));
+	}
+
+	@Test
+	public void snippetCompletionInNestedEachWithElse() throws Exception {
+		String template = "{#each items}\n" + //
+				"\t{it.name}\n" + //
+				"{#else}\n" + //
+				"|\n" + //
+				"{/each}";
+		testCompletionFor(template, true, SECTION_SNIPPET_SIZE);
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteSnippetCompletionInForSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteSnippetCompletionInForSectionTest.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.completions;
+
+import static com.redhat.qute.QuteAssert.SECTION_SNIPPET_SIZE;
+import static com.redhat.qute.QuteAssert.c;
+import static com.redhat.qute.QuteAssert.r;
+import static com.redhat.qute.QuteAssert.testCompletionFor;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for Qute snippet completion in #for section.
+ *
+ */
+public class QuteSnippetCompletionInForSectionTest {
+
+	@Test
+	public void forSection() throws Exception {
+		String template = "|";
+		testCompletionFor(template, //
+				true, // snippet support
+				c("for", //
+						"{#for ${1:item} in ${2:items}}" + System.lineSeparator() + //
+								"\t{${1:item}.${3:name}}$0" + System.lineSeparator() + //
+								"{/for}", //
+						r(0, 0, 0, 0)));
+	}
+
+	@Test
+	public void snippetCompletionInNestedFor() throws Exception {
+		String template = "{#for item in items}\n" + //
+				"|\n" + //
+				"{/for}";
+		testCompletionFor(template, //
+				true, // snippet support
+				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 1, /* #else */ //
+				c("else", "{#else}$0", r(1, 0, 1, 0)));
+	}
+
+	@Test
+	public void sectionStartSnippetCompletionInNestedFor() throws Exception {
+		String template = "{#for item in items}\n" + //
+				"{#|}\n" + //
+				"{/for}";
+		testCompletionFor(template, //
+				true, // snippet support
+				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 1, /* #else */ //
+				c("else", "{#else}$0", r(1, 0, 1, 3)));
+	}
+
+	@Test
+	public void elseSnippetCompletionInNestedFor() throws Exception {
+		String template = "{#for item in items}\n" + //
+				"{#el|}\n" + //
+				"{/for}";
+		testCompletionFor(template, //
+				true, // snippet support
+				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 1, /* #else */ //
+				c("else", "{#else}$0", r(1, 0, 1, 5)));
+	}
+
+	@Test
+	public void snippetCompletionInNestedForWithElse() throws Exception {
+		String template = "{#for item in items}\n" + //
+				"{#else}\n" + //
+				"|\n" + //
+				"{/for}";
+		testCompletionFor(template, true, SECTION_SNIPPET_SIZE);
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteSnippetCompletionInIfSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteSnippetCompletionInIfSectionTest.java
@@ -79,14 +79,28 @@ public class QuteSnippetCompletionInIfSectionTest {
 	}
 
 	@Test
-	public void elseSnippetCompletionInNestedIf() throws Exception {
+	public void snippetCompletionInNestedIfWithElseIf() throws Exception {
 		String template = "{#if condition}\n" + //
-				"{#el|}\n" + //
+				"{#else if condition}\n" + //
+				"|\n" + //
 				"{/if}";
 		testCompletionFor(template, //
 				true, // snippet support
 				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 2, /* #else #else if */ //
-				c("else", "{#else}$0", r(1, 0, 1, 5)), //
-				c("elseif", "{#else if ${1:condition}}$0", r(1, 0, 1, 5)));
+				c("else", "{#else}$0", r(2, 0, 2, 0)), //
+				c("elseif", "{#else if ${1:condition}}$0", r(2, 0, 2, 0)));
+	}
+
+	@Test
+	public void snippetCompletionInNestedIfWithElse() throws Exception {
+		String template = "{#if condition}\n" + //
+				"{#else}\n" + //
+				"|\n" + //
+				"{/if}";
+		testCompletionFor(template, //
+				true, // snippet support
+				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 2, /* #else #else if */ //
+				c("else", "{#else}$0", r(2, 0, 2, 0)), //
+				c("elseif", "{#else if ${1:condition}}$0", r(2, 0, 2, 0)));
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteSnippetCompletionInSwitchSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteSnippetCompletionInSwitchSectionTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.completions;
+
+import static com.redhat.qute.QuteAssert.SECTION_SNIPPET_SIZE;
+import static com.redhat.qute.QuteAssert.c;
+import static com.redhat.qute.QuteAssert.r;
+import static com.redhat.qute.QuteAssert.testCompletionFor;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for Qute snippet completion in #switch section.
+ *
+ */
+public class QuteSnippetCompletionInSwitchSectionTest {
+
+	@Test
+	public void switchSection() throws Exception {
+		String template = "|";
+		testCompletionFor(template, //
+				true, // snippet support
+				c("switch", //
+						"{#switch ${1:value}}" + System.lineSeparator() + //
+								"\t{#case ${2:case}}$0" + System.lineSeparator() + //
+								"{/switch}", //
+						r(0, 0, 0, 0)));
+	}
+
+	@Test
+	public void snippetCompletionInNestedSwitch() throws Exception {
+		String template = "{#switch value}\n" + //
+				"\t|\n" + //
+				"{/switch}";
+		testCompletionFor(template, //
+				true, // snippet support
+				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 1, /* #case */ //
+				c("case", "{#case ${1:case}}$0", r(1, 1, 1, 1)));
+	}
+
+	@Test
+	public void caseSnippetCompletionInNestedSwitch() throws Exception {
+		String template = "{#switch value}\n" + //
+				"\t{#ca|}\n" + //
+				"{/switch}";
+		testCompletionFor(template, //
+				true, // snippet support
+				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 1, /* #case */ //
+				c("case", "{#case ${1:case}}$0", r(1, 1, 1, 6)));
+	}
+
+	@Test
+	public void caseSnippetCompletionInNestedSwitchWithCase() throws Exception {
+		String template = "{#switch value}\n" + //
+				"\t{#case case}\n" + //
+				"\t|\n" + //
+				"{/switch}";
+		testCompletionFor(template, //
+				true, // snippet support
+				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 1, /* #case */ //
+				c("case", "{#case ${1:case}}$0", r(2, 1, 2, 1)));
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteSnippetCompletionInWhenSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteSnippetCompletionInWhenSectionTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.completions;
+
+import static com.redhat.qute.QuteAssert.SECTION_SNIPPET_SIZE;
+import static com.redhat.qute.QuteAssert.c;
+import static com.redhat.qute.QuteAssert.r;
+import static com.redhat.qute.QuteAssert.testCompletionFor;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for Qute snippet completion in #when section.
+ *
+ */
+public class QuteSnippetCompletionInWhenSectionTest {
+
+	@Test
+	public void switchSection() throws Exception {
+		String template = "|";
+		testCompletionFor(template, //
+				true, // snippet support
+				c("when", //
+						"{#when ${1:value}}" + System.lineSeparator() + //
+								"\t{#is ${2:case}}$0" + System.lineSeparator() + //
+								"{/when}",
+						r(0, 0, 0, 0)));
+	}
+
+	@Test
+	public void snippetCompletionInNestedWhen() throws Exception {
+		String template = "{#when value}\n" + //
+				"\t|\n" + //
+				"{/when}";
+		testCompletionFor(template, //
+				true, // snippet support
+				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 1, /* #is */ //
+				c("is", "{#is ${1:case}}$0", r(1, 1, 1, 1)));
+	}
+
+	@Test
+	public void isSnippetCompletionInNestedWhen() throws Exception {
+		String template = "{#when value}\n" + //
+				"\t{#i|}\n" + //
+				"{/when}";
+		testCompletionFor(template, //
+				true, // snippet support
+				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 1, /* #is */ //
+				c("is", "{#is ${1:case}}$0", r(1, 1, 1, 5)));
+	}
+
+	@Test
+	public void isSnippetCompletionInNestedWhenWithIs() throws Exception {
+		String template = "{#when value}\n" + //
+				"\t{#is case}\n" + //
+				"\t|\n" + //
+				"{/when}";
+		testCompletionFor(template, //
+				true, // snippet support
+				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 1, /* #is */ //
+				c("is", "{#is ${1:case}}$0", r(2, 1, 2, 1)));
+	}
+}


### PR DESCRIPTION
Improved completion when nested in Qute `for`, `each`, `switch` and `when` sections.

Fixes #497 

Signed-off-by: Alexander Chen <alchen@redhat.com>