### PR TITLE
Fix NPE with data model template

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/QuteProjectRegistry.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/QuteProjectRegistry.java
@@ -302,7 +302,7 @@ public class QuteProjectRegistry implements QuteProjectInfoProvider, QuteDataMod
 			return template.getProjectFuture() //
 					.thenCompose(project -> {
 						if (project == null) {
-							return null;
+							return EXTENDED_TEMPLATE_DATAMODEL_NULL_FUTURE;
 						}
 						return getDataModelTemplate(template, project.getUri());
 					});


### PR DESCRIPTION
If you create a Qute template outside a Java project, you can see that codelens failed with some NPE.

This PR should fix that.