### PR TITLE
Improve TemplateScanner performance

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/condition/scanner/ConditionScanner.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/condition/scanner/ConditionScanner.java
@@ -15,7 +15,7 @@ import com.redhat.qute.parser.scanner.AbstractScanner;
 
 /**
  * Condition scanner.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -35,6 +35,8 @@ public class ConditionScanner extends AbstractScanner<TokenType, ScannerState> {
 	}
 
 	private int nbMethods;
+
+	private static final int[] QUOTE_OR_PAREN = new int[] {'(', ')', '\'', '"'};
 
 	@Override
 	protected TokenType internalScan() {
@@ -68,7 +70,7 @@ public class ConditionScanner extends AbstractScanner<TokenType, ScannerState> {
 				}
 				return finishToken(offset, TokenType.EndBracketCondition);
 			}
-			if (stream.advanceUntilChar('(', ')', '\'', '"')) {
+			if (stream.advanceUntilChar(QUOTE_OR_PAREN)) {
 				int c = stream.peekChar();
 				if (c == '"' || c == '\'') {
 					stream.advance(1);

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/expression/scanner/ExpressionScanner.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/expression/scanner/ExpressionScanner.java
@@ -11,9 +11,16 @@
 *******************************************************************************/
 package com.redhat.qute.parser.expression.scanner;
 
+import static com.redhat.qute.parser.template.scanner.TemplateScanner.QUOTE;
+import static com.redhat.qute.parser.template.scanner.TemplateScanner.QUOTE_C;
+
 import com.redhat.qute.parser.scanner.AbstractScanner;
 
 public class ExpressionScanner extends AbstractScanner<TokenType, ScannerState> {
+
+	private static final int[] QUOTE_OR_PAREN = new int[] { '(', ')', '"', '\'', };
+	private static final int[] SPACE_PERIOD_LBRACKET = new int[] {' ', '.', '['};
+	private static final int[] SPACE_PERIOD_LBRACKET_LPAREN_COLON = new int[] {' ', '.', '[', '(', ':'};
 
 	public static ExpressionScanner createScanner(String input, boolean canSupportInfixNotation) {
 		return createScanner(input, canSupportInfixNotation, 0, input.length());
@@ -107,7 +114,7 @@ public class ExpressionScanner extends AbstractScanner<TokenType, ScannerState> 
 				bracket++;
 				return finishToken(offset, TokenType.OpenBracket);
 			}
-			stream.advanceUntilChar('(', ')', '"', '\'');
+			stream.advanceUntilChar(QUOTE_OR_PAREN);
 			if (stream.peekChar() == '(') {
 				stream.advance(1);
 				bracket++;
@@ -132,7 +139,7 @@ public class ExpressionScanner extends AbstractScanner<TokenType, ScannerState> 
 		}
 
 		case WithinString: {
-			if (stream.advanceIfAnyOfChars('"', '\'')) {
+			if (stream.advanceIfAnyOfChars(QUOTE_C)) {
 				if (inMethod) {
 					state = ScannerState.WithinMethod;
 				} else {
@@ -140,7 +147,7 @@ public class ExpressionScanner extends AbstractScanner<TokenType, ScannerState> 
 				}
 				return finishToken(offset, TokenType.EndString);
 			}
-			stream.advanceUntilChar('"', '\'');
+			stream.advanceUntilChar(QUOTE);
 			return finishToken(offset, TokenType.String);
 		}
 
@@ -212,17 +219,17 @@ public class ExpressionScanner extends AbstractScanner<TokenType, ScannerState> 
 				stream.advanceUntilChar(c);
 			} else {
 				// foo or| bar
-				stream.advanceUntilAnyOfChars(' ', '.', '[');
+				stream.advanceUntilAnyOfChars(SPACE_PERIOD_LBRACKET);
 			}
 		}
 		// foo.or|
-		stream.advanceUntilAnyOfChars(' ', '.', '[', '(', ':');
+		stream.advanceUntilAnyOfChars(SPACE_PERIOD_LBRACKET_LPAREN_COLON);
 	}
 
 	/**
 	 * Returns true if the current expression scan an Infix Notation and false
 	 * otherwise.
-	 * 
+	 *
 	 * @return true if the current expression scan an Infix Notation and false
 	 *         otherwise.
 	 */

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/scanner/MultiLineStream.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/scanner/MultiLineStream.java
@@ -73,7 +73,7 @@ public class MultiLineStream {
 
 	/**
 	 * Peeks at next char at position + n. peekChar() == peekChar(0)
-	 * 
+	 *
 	 * @param n
 	 * @return
 	 */
@@ -87,7 +87,7 @@ public class MultiLineStream {
 
 	/**
 	 * Peeks at the char at position 'offset' of the whole document
-	 * 
+	 *
 	 * @param offset
 	 * @return
 	 */
@@ -106,7 +106,7 @@ public class MultiLineStream {
 		return false;
 	}
 
-	public boolean advanceIfChars(int... ch) {
+	public boolean advanceIfChars(int[] ch) {
 		int i;
 		if (this.position + ch.length > this.len) {
 			return false;
@@ -120,7 +120,7 @@ public class MultiLineStream {
 		return true;
 	}
 
-	public boolean advanceIfAnyOfChars(char... ch) {
+	public boolean advanceIfAnyOfChars(char[] ch) {
 		int i;
 		if (this.position + 1 > this.len) {
 			return false;
@@ -135,10 +135,10 @@ public class MultiLineStream {
 
 	/**
 	 * Advances stream.position no matter what until it hits ch or eof(this.len)
-	 * 
+	 *
 	 * @return boolean: was the char found
 	 */
-	public boolean advanceUntilChar(int... ch) {
+	public boolean advanceUntilChar(int[] ch) {
 		while (this.position < this.len) {
 			for (int c : ch) {
 				if (peekChar() == c) {
@@ -151,9 +151,24 @@ public class MultiLineStream {
 	}
 
 	/**
+	 * Advances stream.position no matter what until it hits ch or eof(this.len)
+	 *
+	 * @return boolean: was the char found
+	 */
+	public boolean advanceUntilChar(int ch) {
+		while (this.position < this.len) {
+			if (peekChar() == ch) {
+				return true;
+			}
+			this.advance(1);
+		}
+		return false;
+	}
+
+	/**
 	 * Will advance until any of the provided chars are encountered
 	 */
-	public boolean advanceUntilAnyOfChars(int... ch) {
+	public boolean advanceUntilAnyOfChars(int[] ch) {
 		while (this.position < this.len) {
 			for (int i = 0; i < ch.length; i++) {
 				if (peekChar() == ch[i]) {
@@ -166,7 +181,7 @@ public class MultiLineStream {
 		return false;
 	}
 
-	public boolean advanceUntilChars(int... ch) {
+	public boolean advanceUntilChars(int[] ch) {
 		while (this.position + ch.length <= this.len) {
 			int i = 0;
 			for (; i < ch.length && peekChar(i) == ch[i]; i++) {

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/scanner/TemplateScanner.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/scanner/TemplateScanner.java
@@ -18,11 +18,20 @@ import com.redhat.qute.parser.scanner.Scanner;
 
 /**
  * Qute Template scanner.
- * 
+ *
  * @author Angelo ZERR
  *
  */
 public class TemplateScanner extends AbstractScanner<TokenType, ScannerState> {
+
+	public static final int[] QUOTE = new int[] { '"', '\'', };
+	public static final char[] QUOTE_C = new char[] { '"', '\'', };
+	private static final int[] EXCLAMATION_RBRACKET = new int[] { '!', '}' };
+	private static final int[] RBRACKETS = new int[] { ']', '}' };
+	private static final int[] PIPE_RBRACKET = new int[] { '|', '}' };
+	private static final int[] CURLY_BRACKETS = new int[] { '}', '{', };
+	private static final int[] RCURLY_SLASH_QUOTE_SPACE = new int[] { '}', '/', '"', '\'', ' ' };
+	private static final int[] RCURLY_QUOTE = new int[] { '}', '"', '\'', };
 
 	private static final Predicate<Integer> TAG_NAME_PREDICATE = ch -> {
 		return Character.isLetter(ch);
@@ -55,213 +64,213 @@ public class TemplateScanner extends AbstractScanner<TokenType, ScannerState> {
 		String errorMessage = null;
 		switch (state) {
 
-		case WithinContent: {
-			if (stream.advanceIfChar('{')) {
-				// A valid identifier must start with a digit, alphabet, underscore, comment
-				// delimiter, cdata start delimiter or a tag command (e.g. # for sections)
-				// see
-				// https://github.com/quarkusio/quarkus/blob/7164bfa115d9096a3ba0b2929c98f89ac01c2dce/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java#L332
-				if (stream.advanceIfChar('!')) {
-					// Comment -> {! This is a comment !}
-					state = ScannerState.WithinComment;
-					return finishToken(offset, TokenType.StartComment);
-				} else if (stream.advanceIfChar('|')) {
-					// Unparsed Character Data -> {| <script>if(true){alert('Qute is
-					// cute!')};</script> |}
-					state = ScannerState.WithinCDATA;
-					return finishToken(offset, TokenType.CDATATagOpen);
-				} else if (stream.advanceIfChar('[')) {
-					// Unparsed Character Data (old syntax) -> {[ <script>if(true){alert('Qute is
-					// cute!')};</script> ]}
-					state = ScannerState.WithinCDATAOld;
-					return finishToken(offset, TokenType.CDATAOldTagOpen);
-				} else if (stream.advanceIfChar('#')) {
-					// Section (start) tag -> {#if
-					state = ScannerState.AfterOpeningStartTag;
-					return finishToken(offset, TokenType.StartTagOpen);
-				} else if (stream.advanceIfChar('/')) {
-					if (stream.advanceIfChar('}')) {
-						// Section (end) tag with name optional syntax -> {/}
-						state = ScannerState.WithinContent;
-						return finishToken(offset, TokenType.EndTagSelfClose);
-					}
-					// Section (end) tag -> {/if}
-					state = ScannerState.AfterOpeningEndTag;
-					return finishToken(offset, TokenType.EndTagOpen);
-				} else if (stream.advanceIfChar('@')) {
-					// Parameter declaration -> {@org.acme.Foo foo}
-					state = ScannerState.WithinParameterDeclaration;
-					return finishToken(offset, TokenType.StartParameterDeclaration);
-				} else {
-					int ch = stream.peekChar();
-					if (isValidIdentifierStart(ch)) {
-						// Expression
-						state = ScannerState.WithinExpression;
-						return finishToken(offset, TokenType.StartExpression);
+			case WithinContent: {
+				if (stream.advanceIfChar('{')) {
+					// A valid identifier must start with a digit, alphabet, underscore, comment
+					// delimiter, cdata start delimiter or a tag command (e.g. # for sections)
+					// see
+					// https://github.com/quarkusio/quarkus/blob/7164bfa115d9096a3ba0b2929c98f89ac01c2dce/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java#L332
+					if (stream.advanceIfChar('!')) {
+						// Comment -> {! This is a comment !}
+						state = ScannerState.WithinComment;
+						return finishToken(offset, TokenType.StartComment);
+					} else if (stream.advanceIfChar('|')) {
+						// Unparsed Character Data -> {| <script>if(true){alert('Qute is
+						// cute!')};</script> |}
+						state = ScannerState.WithinCDATA;
+						return finishToken(offset, TokenType.CDATATagOpen);
+					} else if (stream.advanceIfChar('[')) {
+						// Unparsed Character Data (old syntax) -> {[ <script>if(true){alert('Qute is
+						// cute!')};</script> ]}
+						state = ScannerState.WithinCDATAOld;
+						return finishToken(offset, TokenType.CDATAOldTagOpen);
+					} else if (stream.advanceIfChar('#')) {
+						// Section (start) tag -> {#if
+						state = ScannerState.AfterOpeningStartTag;
+						return finishToken(offset, TokenType.StartTagOpen);
+					} else if (stream.advanceIfChar('/')) {
+						if (stream.advanceIfChar('}')) {
+							// Section (end) tag with name optional syntax -> {/}
+							state = ScannerState.WithinContent;
+							return finishToken(offset, TokenType.EndTagSelfClose);
+						}
+						// Section (end) tag -> {/if}
+						state = ScannerState.AfterOpeningEndTag;
+						return finishToken(offset, TokenType.EndTagOpen);
+					} else if (stream.advanceIfChar('@')) {
+						// Parameter declaration -> {@org.acme.Foo foo}
+						state = ScannerState.WithinParameterDeclaration;
+						return finishToken(offset, TokenType.StartParameterDeclaration);
 					} else {
-						// Text node, increment position if needed
-						if (!stream.eos()) {
-							stream.advance(1);
+						int ch = stream.peekChar();
+						if (isValidIdentifierStart(ch)) {
+							// Expression
+							state = ScannerState.WithinExpression;
+							return finishToken(offset, TokenType.StartExpression);
+						} else {
+							// Text node, increment position if needed
+							if (!stream.eos()) {
+								stream.advance(1);
+							}
 						}
 					}
 				}
-			}
-			stream.advanceUntilChar('{');
-			return finishToken(offset, TokenType.Content);
-		}
-
-		case WithinComment: {
-			if (stream.advanceIfChars('!', '}')) {
-				state = ScannerState.WithinContent;
-				return finishToken(offset, TokenType.EndComment);
-			}
-			stream.advanceUntilChars('!', '}');
-			return finishToken(offset, TokenType.Comment);
-		}
-
-		case WithinCDATA: {
-			if (stream.advanceIfChars('|', '}')) {
-				state = ScannerState.WithinContent;
-				return finishToken(offset, TokenType.CDATATagClose);
-			}
-			stream.advanceUntilChars('|', '}');
-			return finishToken(offset, TokenType.CDATAContent);
-		}
-
-		case WithinCDATAOld: {
-			if (stream.advanceIfChars(']', '}')) {
-				state = ScannerState.WithinContent;
-				return finishToken(offset, TokenType.CDATAOldTagClose);
-			}
-			stream.advanceUntilChars(']', '}');
-			return finishToken(offset, TokenType.CDATAContent);
-		}
-
-		case WithinParameterDeclaration: {
-			if (stream.skipWhitespace()) {
-				return finishToken(offset, TokenType.Whitespace);
-			}
-			
-			stream.advanceUntilChar('}', '{');
-			if (stream.advanceIfChar('}')) {
-				state = ScannerState.WithinContent;
-				return finishToken(offset, TokenType.EndParameterDeclaration);
-			}
-			if (stream.peekChar() == '{') {
-				state = ScannerState.WithinContent;
-				return internalScan();
-			}
-			return finishToken(offset, TokenType.ParameterDeclaration);
-		}
-
-		case WithinExpression: {
-			if (stream.skipWhitespace()) {
-				return finishToken(offset, TokenType.Whitespace);
+				stream.advanceUntilChar('{');
+				return finishToken(offset, TokenType.Content);
 			}
 
-			if (stream.advanceIfChar('}')) {
-				state = ScannerState.WithinContent;
-				return finishToken(offset, TokenType.EndExpression);
-			}
-			stream.advanceUntilChar('}', '"', '\'');
-			if (stream.peekChar() == '"' || stream.peekChar() == '\'') {
-				stream.advance(1);
-				state = ScannerState.WithinString;
-				return finishToken(stream.pos() - 1, TokenType.StartString);
-			}
-			return internalScan(); // (offset, TokenType.Expression);
-		}
-
-		case WithinString: {
-			if (stream.advanceIfAnyOfChars('"', '\'')) {
-				state = ScannerState.WithinExpression;
-				return finishToken(offset, TokenType.EndString);
-			}
-			stream.advanceUntilChar('"', '\'');
-			return finishToken(offset, TokenType.String);
-		}
-
-		case AfterOpeningStartTag: {
-			if (hasNextTagName()) {
-				state = ScannerState.WithinTag;
-				return finishToken(offset, TokenType.StartTag);
-			}
-			if (stream.skipWhitespace()) { // white space is not valid here
-				return finishToken(offset, TokenType.Whitespace, "Tag name must directly follow the open bracket.");
-			}
-			state = ScannerState.WithinTag;
-			if (stream.advanceUntilCharOrNewTag('}')) {
-				if (stream.peekChar() == '{') {
+			case WithinComment: {
+				if (stream.advanceIfChars(EXCLAMATION_RBRACKET)) {
 					state = ScannerState.WithinContent;
+					return finishToken(offset, TokenType.EndComment);
 				}
-				return internalScan();
+				stream.advanceUntilChars(EXCLAMATION_RBRACKET);
+				return finishToken(offset, TokenType.Comment);
 			}
-			return finishToken(offset, TokenType.Unknown);
-		}
 
-		case AfterOpeningEndTag:
-			if (hasNextTagName()) {
-				state = ScannerState.WithinEndTag;
-				return finishToken(offset, TokenType.EndTag);
-			}
-			if (stream.skipWhitespace()) { // white space is not valid here
-				return finishToken(offset, TokenType.Whitespace, "Tag name must directly follow the open bracket.");
-			}
-			state = ScannerState.WithinEndTag;
-			if (stream.advanceUntilCharOrNewTag('}')) {
-				if (stream.peekChar() == '{') {
+			case WithinCDATA: {
+				if (stream.advanceIfChars(PIPE_RBRACKET)) {
 					state = ScannerState.WithinContent;
+					return finishToken(offset, TokenType.CDATATagClose);
 				}
-				return internalScan();
-			}
-			return finishToken(offset, TokenType.Unknown);
-
-		case WithinEndTag:
-			if (stream.skipWhitespace()) { // white space is valid here
-				return finishToken(offset, TokenType.Whitespace);
-			}
-			if (stream.advanceIfChar('}')) {
-				state = ScannerState.WithinContent;
-				return finishToken(offset, TokenType.EndTagClose);
-			}
-			if (stream.advanceUntilChar('{')) {
-				state = ScannerState.WithinContent;
-				return internalScan();
-			}
-			return finishToken(offset, TokenType.Whitespace);
-
-		case WithinTag: {
-			if (stream.skipWhitespace()) {
-				return finishToken(offset, TokenType.Whitespace);
+				stream.advanceUntilChars(PIPE_RBRACKET);
+				return finishToken(offset, TokenType.CDATAContent);
 			}
 
-			if (stream.advanceIfChar('/')) {
-				state = ScannerState.WithinTag;
+			case WithinCDATAOld: {
+				if (stream.advanceIfChars(RBRACKETS)) {
+					state = ScannerState.WithinContent;
+					return finishToken(offset, TokenType.CDATAOldTagClose);
+				}
+				stream.advanceUntilChars(RBRACKETS);
+				return finishToken(offset, TokenType.CDATAContent);
+			}
+
+			case WithinParameterDeclaration: {
+				if (stream.skipWhitespace()) {
+					return finishToken(offset, TokenType.Whitespace);
+				}
+
+				stream.advanceUntilChar(CURLY_BRACKETS);
 				if (stream.advanceIfChar('}')) {
 					state = ScannerState.WithinContent;
-					return finishToken(offset, TokenType.StartTagSelfClose);
+					return finishToken(offset, TokenType.EndParameterDeclaration);
+				}
+				if (stream.peekChar() == '{') {
+					state = ScannerState.WithinContent;
+					return internalScan();
+				}
+				return finishToken(offset, TokenType.ParameterDeclaration);
+			}
+
+			case WithinExpression: {
+				if (stream.skipWhitespace()) {
+					return finishToken(offset, TokenType.Whitespace);
+				}
+
+				if (stream.advanceIfChar('}')) {
+					state = ScannerState.WithinContent;
+					return finishToken(offset, TokenType.EndExpression);
+				}
+				stream.advanceUntilChar(RCURLY_QUOTE);
+				if (stream.peekChar() == '"' || stream.peekChar() == '\'') {
+					stream.advance(1);
+					state = ScannerState.WithinString;
+					return finishToken(stream.pos() - 1, TokenType.StartString);
+				}
+				return internalScan(); // (offset, TokenType.Expression);
+			}
+
+			case WithinString: {
+				if (stream.advanceIfAnyOfChars(QUOTE_C)) {
+					state = ScannerState.WithinExpression;
+					return finishToken(offset, TokenType.EndString);
+				}
+				stream.advanceUntilChar(QUOTE);
+				return finishToken(offset, TokenType.String);
+			}
+
+			case AfterOpeningStartTag: {
+				if (hasNextTagName()) {
+					state = ScannerState.WithinTag;
+					return finishToken(offset, TokenType.StartTag);
+				}
+				if (stream.skipWhitespace()) { // white space is not valid here
+					return finishToken(offset, TokenType.Whitespace, "Tag name must directly follow the open bracket.");
+				}
+				state = ScannerState.WithinTag;
+				if (stream.advanceUntilCharOrNewTag('}')) {
+					if (stream.peekChar() == '{') {
+						state = ScannerState.WithinContent;
+					}
+					return internalScan();
 				}
 				return finishToken(offset, TokenType.Unknown);
 			}
-			if (stream.advanceIfChar('}')) {
-				state = ScannerState.WithinContent;
-				return finishToken(offset, TokenType.StartTagClose);
-			}
 
-			stream.advanceUntilChar('}', '/', '"', '\'', ' ');
-			int c = stream.peekChar();
-			if (c == '"' || c == '\'') {
-				stream.advance(1);
-				stream.advanceUntilChar(c);
-				if (stream.peekChar() == c) {
-					stream.advance(1);
+			case AfterOpeningEndTag:
+				if (hasNextTagName()) {
+					state = ScannerState.WithinEndTag;
+					return finishToken(offset, TokenType.EndTag);
 				}
+				if (stream.skipWhitespace()) { // white space is not valid here
+					return finishToken(offset, TokenType.Whitespace, "Tag name must directly follow the open bracket.");
+				}
+				state = ScannerState.WithinEndTag;
+				if (stream.advanceUntilCharOrNewTag('}')) {
+					if (stream.peekChar() == '{') {
+						state = ScannerState.WithinContent;
+					}
+					return internalScan();
+				}
+				return finishToken(offset, TokenType.Unknown);
+
+			case WithinEndTag:
+				if (stream.skipWhitespace()) { // white space is valid here
+					return finishToken(offset, TokenType.Whitespace);
+				}
+				if (stream.advanceIfChar('}')) {
+					state = ScannerState.WithinContent;
+					return finishToken(offset, TokenType.EndTagClose);
+				}
+				if (stream.advanceUntilChar('{')) {
+					state = ScannerState.WithinContent;
+					return internalScan();
+				}
+				return finishToken(offset, TokenType.Whitespace);
+
+			case WithinTag: {
+				if (stream.skipWhitespace()) {
+					return finishToken(offset, TokenType.Whitespace);
+				}
+
+				if (stream.advanceIfChar('/')) {
+					state = ScannerState.WithinTag;
+					if (stream.advanceIfChar('}')) {
+						state = ScannerState.WithinContent;
+						return finishToken(offset, TokenType.StartTagSelfClose);
+					}
+					return finishToken(offset, TokenType.Unknown);
+				}
+				if (stream.advanceIfChar('}')) {
+					state = ScannerState.WithinContent;
+					return finishToken(offset, TokenType.StartTagClose);
+				}
+
+				stream.advanceUntilChar(RCURLY_SLASH_QUOTE_SPACE);
+				int c = stream.peekChar();
+				if (c == '"' || c == '\'') {
+					stream.advance(1);
+					stream.advanceUntilChar(c);
+					if (stream.peekChar() == c) {
+						stream.advance(1);
+					}
+				}
+
+				return finishToken(offset, TokenType.ParameterTag);
 			}
 
-			return finishToken(offset, TokenType.ParameterTag);
-		}
-
-		default:
+			default:
 		}
 		stream.advance(1);
 		return


### PR DESCRIPTION
Use preinitialized arrays in order to improve the scanner performance.

Addresses #654

Signed-off-by: David Thompson <davthomp@redhat.com>
