### PR TITLE
Added nested `else` completion support for `when` section

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/resources/com/redhat/qute/services/snippets/qute-nested-snippets.json
+++ b/qute.ls/com.redhat.qute.ls/src/main/resources/com/redhat/qute/services/snippets/qute-nested-snippets.json
@@ -41,6 +41,17 @@
             "unique": true
         }
     },
+    "#when-else": {
+        "prefix": "else",
+        "body": [
+            "{#else}$0"
+        ],
+        "description": "Else section for when section",
+        "context": {
+            "parent": "when",
+            "unique": true
+        }
+    },
     "#elseif": {
         "prefix": "elseif",
         "body": [

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteSnippetCompletionInWhenSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteSnippetCompletionInWhenSectionTest.java
@@ -43,8 +43,9 @@ public class QuteSnippetCompletionInWhenSectionTest {
 				"{/when}";
 		testCompletionFor(template, //
 				true, // snippet support
-				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 1, /* #is */ //
-				c("is", "{#is ${1:case}}$0", r(1, 1, 1, 1)));
+				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 2, /* #is, #else */ //
+				c("is", "{#is ${1:case}}$0", r(1, 1, 1, 1)), //
+				c("else", "{#else}$0", r(1, 1, 1, 1)));
 	}
 
 	@Test
@@ -54,19 +55,46 @@ public class QuteSnippetCompletionInWhenSectionTest {
 				"{/when}";
 		testCompletionFor(template, //
 				true, // snippet support
-				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 1, /* #is */ //
+				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 2, /* #is, #else */ //
 				c("is", "{#is ${1:case}}$0", r(1, 1, 1, 5)));
 	}
 
 	@Test
-	public void isSnippetCompletionInNestedWhenWithIs() throws Exception {
+	public void snippetCompletionInNestedWhenWithIs() throws Exception {
 		String template = "{#when value}\n" + //
 				"\t{#is case}\n" + //
 				"\t|\n" + //
 				"{/when}";
 		testCompletionFor(template, //
 				true, // snippet support
-				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 1, /* #is */ //
-				c("is", "{#is ${1:case}}$0", r(2, 1, 2, 1)));
+				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 2, /* #is, #else */ //
+				c("is", "{#is ${1:case}}$0", r(2, 1, 2, 1)), //
+				c("else", "{#else}$0", r(2, 1, 2, 1)));
+	}
+
+	@Test
+	public void elseSnippetCompletionInNestedWhenWithIs() throws Exception {
+		String template = "{#when value}\n" + //
+				"\t{#is case}\n" + //
+				"\t{#el|}\n" + //
+				"{/when}";
+		testCompletionFor(template, //
+				true, // snippet support
+				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 2, /* #is, #else */ //
+				c("is", "{#is ${1:case}}$0", r(2, 1, 2, 6)), //
+				c("else", "{#else}$0", r(2, 1, 2, 6)));
+	}
+
+	@Test
+	public void sectionStartSnippetCompletionInNestedWhen() throws Exception {
+		String template = "{#when value}\n" + //
+				"\t{#is case}\n" + //
+				"\t{#|}\n" + //
+				"{/when}";
+		testCompletionFor(template, //
+				true, // snippet support
+				SECTION_SNIPPET_SIZE /* #each, #if, ... */ + 2, /* #is, #else */ //
+				c("is", "{#is ${1:case}}$0", r(2, 1, 2, 4)), //
+				c("else", "{#else}$0", r(2, 1, 2, 4)));
 	}
 }


### PR DESCRIPTION
Added nested `else` completion support for `when` section.
![nested-else-when](https://user-images.githubusercontent.com/26389510/176749211-72b64c4a-378f-4403-b186-82d55ab77408.gif)

Part of #497 

Signed-off-by: Alexander Chen <alchen@redhat.com>