### PR TITLE
CodeAction to create field, getter, or template extension for a missing property that's referenced in a template

### DIFF
--- a/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-quickstart/src/main/java/org/acme/qute/Item.java
+++ b/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-quickstart/src/main/java/org/acme/qute/Item.java
@@ -8,6 +8,10 @@ public class Item {
 
 	public final BigDecimal price;
 
+	private final int identifier = 0, version = 1;
+
+	private double volume;
+
 	public Item(BigDecimal price, String name) {
 		this.price = price;
 		this.name = name;
@@ -20,7 +24,7 @@ public class Item {
 	public String varArgsMethod(int index, String... elements) {
 		return null;
 	}
-	
+
 	public static BigDecimal staticMethod(Item item) {
 		return item.price.multiply(new BigDecimal("0.9"));
 	}

--- a/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-quickstart/src/main/java/org/acme/qute/MyTemplateExtensions.java
+++ b/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-quickstart/src/main/java/org/acme/qute/MyTemplateExtensions.java
@@ -1,0 +1,8 @@
+package org.acme.qute;
+
+import io.quarkus.qute.TemplateExtension;
+
+@TemplateExtension
+public class MyTemplateExtensions {
+
+}

--- a/qute.jdt/com.redhat.qute.jdt.test/src/main/java/com/redhat/qute/jdt/template/TemplateGenerateMissingJavaMemberTest.java
+++ b/qute.jdt/com.redhat.qute.jdt.test/src/main/java/com/redhat/qute/jdt/template/TemplateGenerateMissingJavaMemberTest.java
@@ -1,0 +1,261 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.jdt.template;
+
+import static com.redhat.qute.jdt.QuteProjectTest.getJDTUtils;
+import static com.redhat.qute.jdt.QuteProjectTest.loadMavenProject;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.CreateFile;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.ResourceOperation;
+import org.eclipse.lsp4j.ResourceOperationKind;
+import org.eclipse.lsp4j.TextDocumentEdit;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.eclipse.lsp4j.WorkspaceClientCapabilities;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.WorkspaceEditCapabilities;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.redhat.qute.commons.GenerateMissingJavaMemberParams;
+import com.redhat.qute.jdt.QuteProjectTest.QuteMavenProjectName;
+import com.redhat.qute.jdt.QuteSupportForTemplate;
+
+/**
+ * Integration tests for QuteSupportForTemplateGenerateMissingJavaMember
+ * 
+ * Invokes the code in JDT to generate the WorkspaceEditd for the CodeActions
+ * directly instead of going through the Qute language server.
+ * 
+ * @author datho7561
+ */
+public class TemplateGenerateMissingJavaMemberTest {
+
+	@BeforeClass
+	public static void setupLS() {
+		JavaLanguageServerPlugin.getPreferencesManager().initialize();
+		ClientCapabilities clientCapabilities = new ClientCapabilities();
+		WorkspaceClientCapabilities workspaceClientCapabilities = new WorkspaceClientCapabilities();
+		WorkspaceEditCapabilities wEdit = new WorkspaceEditCapabilities();
+		wEdit.setResourceOperations(Arrays.asList(ResourceOperationKind.Create, ResourceOperationKind.Delete,
+				ResourceOperationKind.Rename));
+		workspaceClientCapabilities.setWorkspaceEdit(wEdit);
+		clientCapabilities.setWorkspace(workspaceClientCapabilities);
+		JavaLanguageServerPlugin.getPreferencesManager().updateClientPrefences(clientCapabilities, new HashMap<>());
+	}
+
+	@Test
+	public void generateField() throws Exception {
+
+		IJavaProject project = loadMavenProject(QuteMavenProjectName.qute_quickstart);
+		GenerateMissingJavaMemberParams params = new GenerateMissingJavaMemberParams(
+				GenerateMissingJavaMemberParams.MemberType.Field, "asdf", "org.acme.qute.Item",
+				QuteMavenProjectName.qute_quickstart);
+		WorkspaceEdit actual = QuteSupportForTemplate.getInstance().generateMissingJavaMember(params, getJDTUtils(),
+				new NullProgressMonitor());
+		WorkspaceEdit expected = we(Either.forLeft(tde(project, "src/main/java/org/acme/qute/Item.java",
+				te(6, 1, 6, 1, "public String asdf;\r\n\r\n\t"))));
+		assertWorkspaceEdit(expected, actual);
+
+	}
+
+	@Test
+	public void updateVisibilityOfFieldSimple() throws Exception {
+
+		IJavaProject project = loadMavenProject(QuteMavenProjectName.qute_quickstart);
+		GenerateMissingJavaMemberParams params = new GenerateMissingJavaMemberParams(
+				GenerateMissingJavaMemberParams.MemberType.Field, "volume", "org.acme.qute.Item",
+				QuteMavenProjectName.qute_quickstart);
+		WorkspaceEdit actual = QuteSupportForTemplate.getInstance().generateMissingJavaMember(params, getJDTUtils(),
+				new NullProgressMonitor());
+		WorkspaceEdit expected = we(
+				Either.forLeft(tde(project, "src/main/java/org/acme/qute/Item.java", te(12, 1, 12, 8, "public"))));
+		assertWorkspaceEdit(expected, actual);
+
+	}
+
+	@Test
+	public void updateVisibilityOfFieldComplex() throws Exception {
+
+		IJavaProject project = loadMavenProject(QuteMavenProjectName.qute_quickstart);
+		GenerateMissingJavaMemberParams params = new GenerateMissingJavaMemberParams(
+				GenerateMissingJavaMemberParams.MemberType.Field, "identifier", "org.acme.qute.Item",
+				QuteMavenProjectName.qute_quickstart);
+		WorkspaceEdit actual = QuteSupportForTemplate.getInstance().generateMissingJavaMember(params, getJDTUtils(),
+				new NullProgressMonitor());
+		WorkspaceEdit expected = we(Either.forLeft(tde(project, "src/main/java/org/acme/qute/Item.java",
+				te(6, 1, 10, 35, //
+						"public int identifier = 0;\r\n" //
+								+ "\r\n" //
+								+ "\tpublic final String name;\r\n" //
+								+ "\r\n" //
+								+ "\tpublic final BigDecimal price;\r\n" //
+								+ "\r\n" //
+								+ "\tprivate final int "))));
+		assertWorkspaceEdit(expected, actual);
+
+	}
+
+	@Test
+	public void generateGetterWithNoMatchingField() throws Exception {
+
+		IJavaProject project = loadMavenProject(QuteMavenProjectName.qute_quickstart);
+		GenerateMissingJavaMemberParams params = new GenerateMissingJavaMemberParams(
+				GenerateMissingJavaMemberParams.MemberType.Getter, "asdf", "org.acme.qute.Item",
+				QuteMavenProjectName.qute_quickstart);
+		WorkspaceEdit actual = QuteSupportForTemplate.getInstance().generateMissingJavaMember(params, getJDTUtils(),
+				new NullProgressMonitor());
+		WorkspaceEdit expected = we(Either.forLeft(tde(project, "src/main/java/org/acme/qute/Item.java",
+				te(6, 1, 6, 1, "public String getAsdf() {\r\n\t\treturn null;\r\n\t}\r\n\r\n\t"))));
+		assertWorkspaceEdit(expected, actual);
+
+	}
+
+	@Test
+	public void generateGetterWithMatchingField() throws Exception {
+
+		IJavaProject project = loadMavenProject(QuteMavenProjectName.qute_quickstart);
+		GenerateMissingJavaMemberParams params = new GenerateMissingJavaMemberParams(
+				GenerateMissingJavaMemberParams.MemberType.Getter, "identifier", "org.acme.qute.Item",
+				QuteMavenProjectName.qute_quickstart);
+		WorkspaceEdit actual = QuteSupportForTemplate.getInstance().generateMissingJavaMember(params, getJDTUtils(),
+				new NullProgressMonitor());
+		WorkspaceEdit expected = we(Either.forLeft(tde(project, "src/main/java/org/acme/qute/Item.java",
+				te(6, 1, 10, 18, //
+						"public int getIdentifier() {\r\n" //
+								+ "\t\treturn this.identifier;\r\n" //
+								+ "\t}\r\n\r\n" //
+								+ "\tpublic final String name;\r\n\r\n" //
+								+ "\tpublic final BigDecimal price;\r\n" //
+								+ "\r\n" //
+								+ "\tprivate final int"))));
+		assertWorkspaceEdit(expected, actual);
+
+	}
+
+	@Test
+	public void generateTemplateExtensionInNewClass() throws Exception {
+
+		String sep = System.lineSeparator();
+
+		IJavaProject project = loadMavenProject(QuteMavenProjectName.qute_quickstart);
+		GenerateMissingJavaMemberParams params = new GenerateMissingJavaMemberParams(
+				GenerateMissingJavaMemberParams.MemberType.CreateTemplateExtension, "asdf", "org.acme.qute.Item",
+				QuteMavenProjectName.qute_quickstart);
+		WorkspaceEdit actual = QuteSupportForTemplate.getInstance().generateMissingJavaMember(params, getJDTUtils(),
+				new NullProgressMonitor());
+		WorkspaceEdit expected = we(Either.forRight(createOp(project, "src/main/java/TemplateExtensions.java")),
+				Either.forLeft(tde(project, "src/main/java/TemplateExtensions.java", te(0, 0, 0, 0, //
+						sep //
+								+ "/**" + sep //
+								+ " * " + sep //
+								+ " */" + sep //
+								+ sep //
+								+ "@io.quarkus.qute.TemplateExtension" + sep //
+								+ "public class TemplateExtensions {" + sep //
+								+ "\tpublic static String asdf(org.acme.qute.Item item) {" + sep //
+								+ "\t\treturn null;" + sep //
+								+ "\t}" + sep //
+								+ "}" + sep))));
+		assertWorkspaceEdit(expected, actual);
+	}
+
+	@Test
+	public void generateTemplateExtensionInExistingClass() throws Exception {
+
+		IJavaProject project = loadMavenProject(QuteMavenProjectName.qute_quickstart);
+		GenerateMissingJavaMemberParams params = new GenerateMissingJavaMemberParams(
+				GenerateMissingJavaMemberParams.MemberType.AppendTemplateExtension, "asdf", "org.acme.qute.Item",
+				QuteMavenProjectName.qute_quickstart);
+		WorkspaceEdit actual = QuteSupportForTemplate.getInstance().generateMissingJavaMember(params, getJDTUtils(),
+				new NullProgressMonitor());
+		WorkspaceEdit expected = we(Either.forLeft(tde(project, "src/main/java/org/acme/qute/MyTemplateExtensions.java",
+				te(5, 35, 5, 35, //
+						"\n\n\tpublic static String asdf(org.acme.qute.Item item) {\n" //
+								+ "\t\treturn null;\n" //
+								+ "\t}"))));
+		assertWorkspaceEdit(expected, actual);
+	}
+
+	// ------------------- WorkspaceEdit assert
+
+	public static void assertWorkspaceEdit(WorkspaceEdit expected, WorkspaceEdit actual) {
+		if (expected == null) {
+			Assert.assertNull(actual);
+			return;
+		} else {
+			Assert.assertNotNull(actual);
+		}
+		Assert.assertEquals(expected.getDocumentChanges().size(), actual.getDocumentChanges().size());
+		for (int i = 0; i < expected.getDocumentChanges().size(); i++) {
+			Assert.assertEquals(expected.getDocumentChanges().get(i), actual.getDocumentChanges().get(i));
+		}
+	}
+
+	public static WorkspaceEdit we(Either<TextDocumentEdit, ResourceOperation>... documentChanges) {
+		return new WorkspaceEdit(Arrays.asList(documentChanges));
+	}
+
+	// ------------------- edits constants
+
+	private static Pattern FILE_PREFIX_PATTERN = Pattern.compile("file:/(?!//)");
+
+	// ------------------- ResourceOperation assert
+
+	private static ResourceOperation createOp(IJavaProject project, String projectFile) throws CoreException {
+		String brokenLocationUri = project.getUnderlyingResource().getLocationURI().toString();
+		Matcher m = FILE_PREFIX_PATTERN.matcher(brokenLocationUri);
+		String fixedLocationUri = m.replaceFirst("file:///");
+		return new CreateFile(fixedLocationUri + "/" + projectFile);
+	}
+
+	// ------------------- TextDocumentEdit assert
+
+	public static TextDocumentEdit tde(IJavaProject project, String projectFile, TextEdit... te) throws CoreException {
+		String brokenLocationUri = project.getUnderlyingResource().getLocationURI().toString();
+		Matcher m = FILE_PREFIX_PATTERN.matcher(brokenLocationUri);
+		String fixedLocationUri = m.replaceFirst("file:///");
+		return tde(fixedLocationUri + "/" + projectFile, 0, te);
+	}
+
+	public static TextDocumentEdit tde(String uri, int version, TextEdit... te) {
+		VersionedTextDocumentIdentifier versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier(uri,
+				version);
+		return new TextDocumentEdit(versionedTextDocumentIdentifier, Arrays.asList(te));
+	}
+
+	// ------------------- TextEdit assert
+
+	public static TextEdit te(int startLine, int startCharacter, int endLine, int endCharacter, String newText) {
+		TextEdit textEdit = new TextEdit();
+		textEdit.setNewText(newText);
+		textEdit.setRange(r(startLine, startCharacter, endLine, endCharacter));
+		return textEdit;
+	}
+
+	// ------------------- range utils
+	public static Range r(int startLine, int startCharacter, int endLine, int endCharacter) {
+		return new Range(new Position(startLine, startCharacter), new Position(endLine, endCharacter));
+	}
+}

--- a/qute.jdt/com.redhat.qute.jdt/META-INF/MANIFEST.MF
+++ b/qute.jdt/com.redhat.qute.jdt/META-INF/MANIFEST.MF
@@ -8,8 +8,11 @@ Bundle-Version: 0.12.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.ls.core;resolution:=optional,
  org.eclipse.jdt.core,
+ org.eclipse.text,
+ org.eclipse.ltk.core.refactoring,
  org.eclipse.core.resources,
  org.eclipse.lsp4j,
+ org.eclipse.lsp4j.jsonrpc,
  org.apache.commons.lang3,
  org.eclipse.jdt.core.manipulation,
  org.eclipse.xtext.xbase.lib
@@ -27,4 +30,3 @@ Export-Package: com.redhat.qute.commons,
  com.redhat.qute.jdt.template.datamodel,
  com.redhat.qute.jdt.utils
 Bundle-Activator: com.redhat.qute.jdt.QutePlugin
-

--- a/qute.jdt/com.redhat.qute.jdt/plugin.xml
+++ b/qute.jdt/com.redhat.qute.jdt/plugin.xml
@@ -8,29 +8,30 @@
 
    <!-- Delegate command handler for Qute template -->
    <extension point="org.eclipse.jdt.ls.core.delegateCommandHandler">
-      <delegateCommandHandler class="com.redhat.qute.jdt.internal.ls.QuteSupportForTemplateDelegateCommandHandler">      
+      <delegateCommandHandler class="com.redhat.qute.jdt.internal.ls.QuteSupportForTemplateDelegateCommandHandler">
             <command id="qute/template/project"/>
             <command id="qute/template/projectDataModel"/>
-            <command id="qute/template/userTags"/>            
+            <command id="qute/template/userTags"/>
             <command id="qute/template/javaTypes"/>
             <command id="qute/template/resolvedJavaType"/>
             <command id="qute/template/javaDefinition"/>
+            <command id="qute/template/generateMissingJavaMember"/>
        </delegateCommandHandler>
    </extension>
 
    <!-- Delegate command handler for Java files-->
    <extension point="org.eclipse.jdt.ls.core.delegateCommandHandler">
-      <delegateCommandHandler class="com.redhat.qute.jdt.internal.ls.QuteSupportForJavaDelegateCommandHandler">      
+      <delegateCommandHandler class="com.redhat.qute.jdt.internal.ls.QuteSupportForJavaDelegateCommandHandler">
             <command id="qute/java/codeLens"/>
             <command id="qute/java/diagnostics"/>
             <command id="qute/java/documentLink"/>
        </delegateCommandHandler>
    </extension>
-   
+
    <!-- Data model providers for Qute core -->
    <extension point="com.redhat.qute.jdt.dataModelProviders">
    	  <provider class="com.redhat.qute.jdt.internal.template.datamodel.CheckedTemplateSupport" />
-      <provider class="com.redhat.qute.jdt.internal.template.datamodel.TemplateExtensionAnnotationSupport" />            
+      <provider class="com.redhat.qute.jdt.internal.template.datamodel.TemplateExtensionAnnotationSupport" />
       <provider class="com.redhat.qute.jdt.internal.template.datamodel.TemplateFieldSupport" />
       <provider class="com.redhat.qute.jdt.internal.template.datamodel.TemplateDataAnnotationSupport" />
       <provider class="com.redhat.qute.jdt.internal.template.datamodel.TemplateEnumAnnotationSupport" />

--- a/qute.jdt/com.redhat.qute.jdt/pom.xml
+++ b/qute.jdt/com.redhat.qute.jdt/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<parent>
 		<artifactId>parent-qute</artifactId>
 		<groupId>com.redhat.microprofile</groupId>
@@ -11,6 +9,6 @@
 	<artifactId>com.redhat.qute.jdt</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	<name>Qute JDT LS Extension</name>
-	<description>Qute JDT LS Extension </description>
+	<description>Qute JDT LS Extension</description>
 
 </project>

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/GenerateMissingJavaMemberParams.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/GenerateMissingJavaMemberParams.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.commons;
+
+/**
+ * Parameters required for generating a field, getter, or template extension in
+ * a Java type.
+ *
+ * @author datho7561
+ */
+public class GenerateMissingJavaMemberParams {
+
+	public enum MemberType {
+
+		Field(1), Getter(2), AppendTemplateExtension(3), CreateTemplateExtension(4);
+
+		private final int value;
+
+		MemberType(int value) {
+			this.value = value;
+		}
+
+		public int getValue() {
+			return this.value;
+		}
+
+		public static MemberType forValue(int value) {
+			MemberType[] allValues = MemberType.values();
+			if (value < 1 || value > allValues.length)
+				throw new IllegalArgumentException("Illegal enum value: " + value);
+			return allValues[value - 1];
+		}
+
+	}
+
+	private MemberType memberType;
+	private String missingProperty;
+	private String javaType;
+	private String projectUri;
+
+	public GenerateMissingJavaMemberParams() {
+		this(null, null, null, null);
+	}
+
+	/**
+	 * Returns the parameters for generate a missing java member that is referenced
+	 * in a template but doesn't exist.
+	 * 
+	 * @param memberType      the type of member to generate
+	 * @param missingProperty the name of the java member that's missing
+	 * @param javaType        the java type to generate the missing member in
+	 * @param projectUri      the uri of the project
+	 */
+	public GenerateMissingJavaMemberParams(MemberType memberType, String missingProperty, String javaType,
+			String projectUri) {
+		this.memberType = memberType;
+		this.missingProperty = missingProperty;
+		this.javaType = javaType;
+		this.projectUri = projectUri;
+	}
+
+	public MemberType getMemberType() {
+		return this.memberType;
+	}
+
+	public void setMemberType(MemberType memberType) {
+		this.memberType = memberType;
+	}
+
+	public String getMissingProperty() {
+		return this.missingProperty;
+	}
+
+	public void setMissingProperty(String missingProperty) {
+		this.missingProperty = missingProperty;
+	}
+
+	public String getJavaType() {
+		return this.javaType;
+	}
+
+	public void setJavaType(String javaType) {
+		this.javaType = javaType;
+	}
+
+	public String getProjectUri() {
+		return this.projectUri;
+	}
+
+	public void setProjectUri(String projectUri) {
+		this.projectUri = projectUri;
+	}
+
+}

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/template/QuteSupportForTemplateGenerateMissingJavaMemberHandler.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/template/QuteSupportForTemplateGenerateMissingJavaMemberHandler.java
@@ -1,0 +1,683 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.jdt.internal.template;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.Flags;
+import org.eclipse.jdt.core.IAnnotatable;
+import org.eclipse.jdt.core.IAnnotation;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.ChildListPropertyDescriptor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.FieldAccess;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.Modifier.ModifierKeyword;
+import org.eclipse.jdt.core.dom.ReturnStatement;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
+import org.eclipse.jdt.core.manipulation.CodeGeneration;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+import org.eclipse.jdt.core.search.IJavaSearchScope;
+import org.eclipse.jdt.core.search.SearchEngine;
+import org.eclipse.jdt.core.search.SearchMatch;
+import org.eclipse.jdt.core.search.SearchParticipant;
+import org.eclipse.jdt.core.search.SearchPattern;
+import org.eclipse.jdt.core.search.SearchRequestor;
+import org.eclipse.jdt.internal.core.JavaModelManager;
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
+import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
+import org.eclipse.jdt.internal.corext.dom.ASTNodes;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.lsp4j.CreateFile;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.ResourceOperation;
+import org.eclipse.lsp4j.TextDocumentEdit;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+import com.redhat.qute.commons.GenerateMissingJavaMemberParams;
+import com.redhat.qute.jdt.internal.QuteJavaConstants;
+import com.redhat.qute.jdt.utils.IJDTUtils;
+import com.redhat.qute.jdt.utils.TextEditConverter;
+
+/**
+ * Resolves workspace edits for generating missing java members.
+ *
+ * @author datho7561
+ */
+public class QuteSupportForTemplateGenerateMissingJavaMemberHandler {
+
+	private static final Logger LOGGER = Logger
+			.getLogger(QuteSupportForTemplateGenerateMissingJavaMemberHandler.class.getName());
+
+	private static final Pattern BROKEN_FILE_PROTOCOL = Pattern.compile("file:/(?!//)");
+
+	private static final Range PREPEND_RANGE = new Range(new Position(0, 0), new Position(0, 0));
+
+	private QuteSupportForTemplateGenerateMissingJavaMemberHandler() {
+
+	}
+
+	/**
+	 * Returns the WorkspaceEdit needed to generate the requested member, or null if
+	 * it cannot be computed.
+	 *
+	 * @param params  the parameters needed to construct the workspace edit
+	 * @param utils   the jdt utils
+	 * @param monitor the progress monitor
+	 * @return the WorkspaceEdit needed to generate the requested member, or null if
+	 *         it cannot be computed
+	 */
+	public static WorkspaceEdit handleGenerateMissingJavaMember(GenerateMissingJavaMemberParams params, IJDTUtils utils,
+			IProgressMonitor monitor) {
+		switch (params.getMemberType()) {
+		case Field:
+			return handleMissingField(params, utils, monitor);
+		case Getter:
+			return handleCreateMissingGetterCodeAction(params, utils, monitor);
+		case AppendTemplateExtension:
+			return handleCreateMissingTemplateExtension(params, utils, monitor);
+		case CreateTemplateExtension:
+			return createNewTemplateExtensionsFile(params, utils, monitor);
+		default:
+			return null;
+		}
+	}
+
+	private static WorkspaceEdit handleMissingField(GenerateMissingJavaMemberParams params, IJDTUtils utils,
+			IProgressMonitor monitor) {
+		IJavaProject project = getJavaProjectFromProjectUri(params.getProjectUri());
+		IType javaType;
+		try {
+			javaType = project.findType(params.getJavaType());
+		} catch (JavaModelException e) {
+			return null;
+		}
+
+		IField currentlyField = javaType.getField(params.getMissingProperty());
+		if (currentlyField != null && currentlyField.exists()) {
+			return handleUpdatePermissionsOfExistingField(params, utils, project, javaType, monitor);
+		} else {
+			return handleCreateMissingField(params, utils, project, javaType, monitor);
+		}
+
+	}
+
+	private static WorkspaceEdit handleCreateMissingField(GenerateMissingJavaMemberParams params, IJDTUtils utils,
+			IJavaProject project, IType javaType, IProgressMonitor monitor) {
+		CompilationUnit cu = createQuickFixAST(javaType);
+		if (cu == null) {
+			return null;
+		}
+		ASTNode newTypeDecl = cu.findDeclaringNode("L" + params.getJavaType().replace('.', '/') + ";");
+		if (newTypeDecl == null) {
+			return null;
+		}
+		AST ast = newTypeDecl.getAST();
+		var rewrite = ASTRewrite.create(ast);
+
+		VariableDeclarationFragment fragment = ast.newVariableDeclarationFragment();
+		fragment.setName(ast.newSimpleName(params.getMissingProperty()));
+
+		Modifier modifier = ast.newModifier(ModifierKeyword.PUBLIC_KEYWORD);
+
+		FieldDeclaration decl = ast.newFieldDeclaration(fragment);
+		decl.setType(ast.newSimpleType(ast.newSimpleName("String")));
+		decl.modifiers().add(modifier);
+
+		ChildListPropertyDescriptor property = ASTNodes.getBodyDeclarationsProperty(newTypeDecl);
+		ListRewrite listRewrite = rewrite.getListRewrite(newTypeDecl, property);
+
+		listRewrite.insertAt(decl, 0, null);
+		org.eclipse.text.edits.TextEdit jdtTextEdit;
+		try {
+			jdtTextEdit = rewrite.rewriteAST();
+		} catch (JavaModelException e) {
+			return null;
+		}
+		TextDocumentEdit textDocumentEdit = new TextEditConverter((ICompilationUnit) javaType.getTypeRoot(),
+				jdtTextEdit, utils).convertToTextDocumentEdit(0);
+		return new WorkspaceEdit(Arrays.asList(Either.forLeft(textDocumentEdit)));
+	}
+
+	private static WorkspaceEdit handleUpdatePermissionsOfExistingField(GenerateMissingJavaMemberParams params,
+			IJDTUtils utils, IJavaProject project, IType javaType, IProgressMonitor monitor) {
+		CompilationUnit cu = createQuickFixAST(javaType);
+		if (cu == null) {
+			return null;
+		}
+		ASTNode newTypeDecl = cu.findDeclaringNode("L" + params.getJavaType().replace('.', '/') + ";");
+		if (newTypeDecl == null) {
+			return null;
+		}
+		AST ast = newTypeDecl.getAST();
+		var rewrite = ASTRewrite.create(ast);
+
+		FieldDeclFinder fieldDeclFinder = new FieldDeclFinder(params.getMissingProperty());
+		newTypeDecl.accept(fieldDeclFinder);
+		if (fieldDeclFinder.getFieldDeclaration() == null) {
+			return null;
+		}
+		FieldDeclaration oldFieldDeclaration = fieldDeclFinder.getFieldDeclaration();
+
+		// This is needed to prevent an exception, since the language client might send
+		// a new CodeAction request before the user saves the modifications to the Java
+		// class from accepting the previous CodeAction
+		boolean alreadyPublic = oldFieldDeclaration.modifiers().stream().anyMatch((mod) -> {
+			if (!(mod instanceof Modifier)) {
+				return false;
+			}
+			Modifier asMod = (Modifier) mod;
+			return asMod.getKeyword() == ModifierKeyword.PUBLIC_KEYWORD;
+		});
+		if (alreadyPublic) {
+			return null;
+		}
+
+		if (fieldDeclFinder.hasMultiDecl()) {
+			// eg. worst (most complex) case
+			// ```java
+			// private String prefix = "aaa", suffix = "bbb";
+			// ```
+			// in order to make `prefix` public,
+			// instead of changing the `private` modifier to `public`,
+			// we want to remove `prefix` from the list,
+			// then create a new, separate field declaration that has `public`.
+			// We also need to copy over the declaration of the value
+			VariableDeclarationFragment fragment = (VariableDeclarationFragment) rewrite
+					.createMoveTarget(fieldDeclFinder.getOldBadFragment());
+			rewrite.remove(fieldDeclFinder.getOldBadFragment(), null);
+
+			Modifier modifier = ast.newModifier(ModifierKeyword.PUBLIC_KEYWORD);
+
+			FieldDeclaration decl = ast.newFieldDeclaration(fragment);
+			// Preserve the type of the field we are making public
+			decl.setType(getCloneOfType(oldFieldDeclaration, ast, rewrite));
+			decl.modifiers().add(modifier);
+
+			ChildListPropertyDescriptor property = ASTNodes.getBodyDeclarationsProperty(newTypeDecl);
+			ListRewrite listRewrite = rewrite.getListRewrite(newTypeDecl, property);
+
+			listRewrite.insertAt(decl, 0, null);
+		} else {
+			Modifier oldModifier = null;
+			for (Object modifierUncast : oldFieldDeclaration.modifiers()) {
+				if (modifierUncast instanceof Modifier) {
+					Modifier modifier = (Modifier) modifierUncast;
+					if (modifier.isPrivate() || modifier.isProtected()) {
+						oldModifier = modifier;
+						break;
+					}
+				}
+			}
+			Modifier newModifier = ast.newModifier(Modifier.ModifierKeyword.PUBLIC_KEYWORD);
+			rewrite.replace(oldModifier, newModifier, null);
+		}
+
+		org.eclipse.text.edits.TextEdit jdtTextEdit;
+		try {
+			jdtTextEdit = rewrite.rewriteAST();
+		} catch (JavaModelException e) {
+			return null;
+		}
+		TextDocumentEdit textDocumentEdit = new TextEditConverter((ICompilationUnit) javaType.getTypeRoot(),
+				jdtTextEdit, utils).convertToTextDocumentEdit(0);
+		return new WorkspaceEdit(Arrays.asList(Either.forLeft(textDocumentEdit)));
+	}
+
+	private static WorkspaceEdit handleCreateMissingGetterCodeAction(GenerateMissingJavaMemberParams params,
+			IJDTUtils utils, IProgressMonitor monitor) {
+		IJavaProject project = getJavaProjectFromProjectUri(params.getProjectUri());
+		IType javaType;
+		try {
+			javaType = project.findType(params.getJavaType());
+		} catch (JavaModelException e) {
+			return null;
+		}
+		CompilationUnit cu = createQuickFixAST(javaType);
+		if (cu == null) {
+			return null;
+		}
+		ASTNode newTypeDecl = cu.findDeclaringNode("L" + params.getJavaType().replace('.', '/') + ";");
+		if (newTypeDecl == null) {
+			return null;
+		}
+		AST ast = newTypeDecl.getAST();
+		var rewrite = ASTRewrite.create(ast);
+
+		MethodDeclaration methodDeclaration = ast.newMethodDeclaration();
+		String methodName = "get" + getCapitalized(params.getMissingProperty());
+		methodDeclaration.setName(ast.newSimpleName(methodName));
+		methodDeclaration.modifiers().add(ast.newModifier(ModifierKeyword.PUBLIC_KEYWORD));
+
+		Block block = ast.newBlock();
+		ReturnStatement returnStatement = ast.newReturnStatement();
+		IField field = javaType.getField(params.getMissingProperty());
+		if (field != null && field.exists()) {
+			FieldDeclFinder declFinder = new FieldDeclFinder(params.getMissingProperty());
+			newTypeDecl.accept(declFinder);
+			FieldDeclaration fieldDeclaration = declFinder.getFieldDeclaration();
+			FieldAccess fieldAccess = ast.newFieldAccess();
+			fieldAccess.setName(ast.newSimpleName(params.getMissingProperty()));
+			fieldAccess.setExpression(ast.newThisExpression());
+			returnStatement.setExpression(fieldAccess);
+			methodDeclaration.setReturnType2(getCloneOfType(fieldDeclaration, ast, rewrite));
+		} else {
+			Expression expression = ast.newNullLiteral();
+			returnStatement.setExpression(expression);
+			methodDeclaration.setReturnType2(ast.newSimpleType(ast.newSimpleName("String")));
+		}
+		block.statements().add(returnStatement);
+		methodDeclaration.setBody(block);
+
+		ChildListPropertyDescriptor property = ASTNodes.getBodyDeclarationsProperty(newTypeDecl);
+		ListRewrite listRewrite = rewrite.getListRewrite(newTypeDecl, property);
+
+		listRewrite.insertAt(methodDeclaration, 0, null);
+		org.eclipse.text.edits.TextEdit jdtTextEdit;
+		try {
+			jdtTextEdit = rewrite.rewriteAST();
+		} catch (JavaModelException e) {
+			return null;
+		}
+		TextDocumentEdit textDocumentEdit = new TextEditConverter((ICompilationUnit) javaType.getTypeRoot(),
+				jdtTextEdit, utils).convertToTextDocumentEdit(0);
+		return new WorkspaceEdit(Arrays.asList(Either.forLeft(textDocumentEdit)));
+	}
+
+	// TODO: caching scheme
+	private static WorkspaceEdit handleCreateMissingTemplateExtension(GenerateMissingJavaMemberParams params,
+			IJDTUtils utils, IProgressMonitor monitor) {
+
+		IJavaProject project = getJavaProjectFromProjectUri(params.getProjectUri());
+		SearchPattern searchPattern = createTemplateExtensionSearchPattern();
+		SearchEngine searchEngine = new SearchEngine();
+		IJavaSearchScope searchScope = null;
+		try {
+			searchScope = createSearchContext(project);
+		} catch (JavaModelException e) {
+			LOGGER.log(Level.SEVERE, "Error while collecting @TemplateExtension references", e);
+		}
+		if (searchScope == null) {
+			return null;
+		}
+
+		List<Object> matches = new ArrayList<>();
+
+		try {
+			searchEngine.search(searchPattern, new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() },
+					searchScope, new SearchRequestor() {
+						@Override
+						public void acceptSearchMatch(SearchMatch match) throws CoreException {
+							// We collect only references from java code and not from JavaDoc
+
+							// --> In this case @Named will be collected :
+							// @Named
+							// private String foo;
+
+							// --> In this case @Named will not be collected :
+							// /* Demonstrate {@link Named} */
+							// private String foo;
+
+							// Also, ignore annotations on methods, eg:
+							// @TemplateExtension
+							// public static String (Foo foo) {
+							// return foo.value * 5;
+							// }
+							// This syntax is supported, but discouraged,
+							// according to https://quarkus.io/guides/qute#template-extension-methods
+
+							if (!match.isInsideDocComment()
+									&& ((IJavaElement) match.getElement()).getElementType() == IJavaElement.TYPE) {
+								matches.add(match.getElement());
+							}
+						}
+					}, monitor);
+		} catch (CoreException _e) {
+		}
+
+		if (matches.size() == 0) {
+			return createNewTemplateExtensionFile(params, utils, project, monitor);
+		} else {
+			Object match = matches.get(0);
+			IType type = null;
+			if (match instanceof IAnnotatable) {
+				IAnnotatable annotatable = (IAnnotatable) match;
+				type = (IType) annotatable.getAnnotation(QuteJavaConstants.TEMPLATE_EXTENSION_ANNOTATION)
+						.getAncestor(IJavaElement.TYPE);
+			} else if (match instanceof IAnnotation) {
+				IAnnotation annotation = (IAnnotation) match;
+				type = (IType) annotation.getAncestor(IJavaElement.TYPE);
+			}
+			if (type == null) {
+				LOGGER.severe(
+						"Could not locate the underlying type for the @TemplateExtension annotation that was located by the SearchEngine");
+				return null;
+			}
+			return addTemplateExtensionToFile(params, utils, project, type, monitor);
+		}
+	}
+
+	private static WorkspaceEdit createNewTemplateExtensionsFile(GenerateMissingJavaMemberParams params,
+			IJDTUtils utils, IProgressMonitor monitor) {
+		IJavaProject project = getJavaProjectFromProjectUri(params.getProjectUri());
+		return createNewTemplateExtensionFile(params, utils, project, monitor);
+	}
+
+	private static WorkspaceEdit addTemplateExtensionToFile(GenerateMissingJavaMemberParams params, IJDTUtils utils,
+			IJavaProject project, IType templateExtensionType, IProgressMonitor monitor) {
+		CompilationUnit cu = createQuickFixAST(templateExtensionType);
+		ASTNode newTypeDecl = cu.findDeclaringNode(templateExtensionType.getKey());
+		if (newTypeDecl == null) {
+			return null;
+		}
+		AST ast = newTypeDecl.getAST();
+		var rewrite = ASTRewrite.create(ast);
+
+		MethodDeclaration methodDeclaration = ast.newMethodDeclaration();
+		String methodName = params.getMissingProperty();
+		methodDeclaration.setName(ast.newSimpleName(methodName));
+		methodDeclaration.modifiers().add(ast.newModifier(ModifierKeyword.PUBLIC_KEYWORD));
+		methodDeclaration.modifiers().add(ast.newModifier(ModifierKeyword.STATIC_KEYWORD));
+		SingleVariableDeclaration singleVariableDeclaration = ast.newSingleVariableDeclaration();
+		singleVariableDeclaration.setType(ast.newSimpleType(ast.newName(params.getJavaType())));
+		singleVariableDeclaration.setName(ast.newSimpleName(getParamNameFromFullyQualifiedType(params.getJavaType())));
+		methodDeclaration.parameters().add(singleVariableDeclaration);
+
+		Block block = ast.newBlock();
+		ReturnStatement returnStatement = ast.newReturnStatement();
+		Expression expression = ast.newNullLiteral();
+		returnStatement.setExpression(expression);
+		methodDeclaration.setReturnType2(ast.newSimpleType(ast.newSimpleName("String")));
+		block.statements().add(returnStatement);
+		methodDeclaration.setBody(block);
+
+		ChildListPropertyDescriptor property = ASTNodes.getBodyDeclarationsProperty(newTypeDecl);
+		ListRewrite listRewrite = rewrite.getListRewrite(newTypeDecl, property);
+
+		listRewrite.insertAt(methodDeclaration, 0, null);
+		org.eclipse.text.edits.TextEdit jdtTextEdit;
+		try {
+			jdtTextEdit = rewrite.rewriteAST();
+		} catch (JavaModelException e) {
+			return null;
+		}
+		TextDocumentEdit textDocumentEdit = new TextEditConverter(
+				(ICompilationUnit) templateExtensionType.getTypeRoot(), jdtTextEdit, utils)
+				.convertToTextDocumentEdit(0);
+		return new WorkspaceEdit(Arrays.asList(Either.forLeft(textDocumentEdit)));
+	}
+
+	private static WorkspaceEdit createNewTemplateExtensionFile(GenerateMissingJavaMemberParams params, IJDTUtils utils,
+			IJavaProject project, IProgressMonitor monitor) {
+
+		IPackageFragment destPackage = null;
+		try {
+			// TODO: longest substring match of package of original class
+			// OR: figure out the "correct" one from the groupId?
+			IPackageFragmentRoot fragmentRoot = project.getPackageFragmentRoots()[0];
+			destPackage = fragmentRoot.getPackageFragment("");
+		} catch (JavaModelException e) {
+		}
+		// TODO: just use the default package I guess?
+		if (destPackage == null) {
+			return null;
+		}
+
+		String baseName = "TemplateExtensions";
+		String name = baseName;
+		ICompilationUnit cu = destPackage.getCompilationUnit(baseName + ".java");
+		int i = 0;
+		while (cu.exists()) {
+			name = baseName + i;
+			cu = destPackage.getCompilationUnit(name + ".java");
+		}
+
+		ResourceOperation createFileOperation = new CreateFile(
+				fixBrokenUri(cu.getResource().getRawLocationURI().toString()));
+		TextDocumentEdit addContentEdit;
+		try {
+			addContentEdit = createNewTemplateExtensionsContent(cu, name, params.getMissingProperty(),
+					params.getJavaType(), fixBrokenUri(cu.getResource().getRawLocationURI().toString()));
+		} catch (CoreException e) {
+			throw new RuntimeException("Failure while constructing new Java file content", e);
+		}
+
+		WorkspaceEdit makeTemplateExtensions = new WorkspaceEdit();
+		makeTemplateExtensions.setDocumentChanges(
+				Arrays.asList(Either.forRight(createFileOperation), Either.forLeft(addContentEdit)));
+		return makeTemplateExtensions;
+
+	}
+
+	private static TextDocumentEdit createNewTemplateExtensionsContent(ICompilationUnit cu, String typeName,
+			String methodName, String methodParamFullyQualifiedType, String uri) throws CoreException {
+		String lineDelimiter = StubUtility.getLineDelimiterUsed(cu.getJavaProject());
+		String typeStub = constructTypeStub(cu, typeName, Flags.AccPublic, methodName, methodParamFullyQualifiedType,
+				lineDelimiter);
+		String cuContent = constructCUContent(cu, typeStub, lineDelimiter);
+		TextDocumentEdit tde = new TextDocumentEdit();
+		tde.setTextDocument(new VersionedTextDocumentIdentifier(uri, 0));
+		tde.setEdits(Arrays.asList(new TextEdit(PREPEND_RANGE, cuContent)));
+		return tde;
+	}
+
+	/*
+	 * Copied & modified from JDT-LS
+	 */
+	private static String constructTypeStub(ICompilationUnit parentCU, String name, int modifiers, String methodName,
+			String methodParamFullyQualifiedType, String lineDelimiter) {
+		StringBuilder buf = new StringBuilder();
+
+		buf.append("@");
+		buf.append(QuteJavaConstants.TEMPLATE_EXTENSION_ANNOTATION);
+		buf.append(lineDelimiter);
+
+		buf.append(Flags.toString(modifiers));
+		if (modifiers != 0) {
+			buf.append(' ');
+		}
+
+		buf.append("class ");
+		buf.append(name);
+		buf.append(" {").append(lineDelimiter); //$NON-NLS-1$
+		buf.append(constructMethodStub(parentCU, methodName, methodParamFullyQualifiedType, lineDelimiter));
+		buf.append('}').append(lineDelimiter);
+		return buf.toString();
+	}
+
+	private static String constructMethodStub(ICompilationUnit compilationUnit, String methodName,
+			String methodParamFullyQualifiedType, String lineDelimiter) {
+		StringBuilder buf = new StringBuilder("\tpublic static String ");
+		buf.append(methodName).append("(").append(methodParamFullyQualifiedType);
+		buf.append(" ");
+		buf.append(getParamNameFromFullyQualifiedType(methodParamFullyQualifiedType));
+		buf.append(") {").append(lineDelimiter);
+		buf.append("\t\treturn null;").append(lineDelimiter);
+		buf.append("\t}").append(lineDelimiter);
+		return buf.toString();
+	}
+
+	/**
+	 * Copied from JDT-LS
+	 */
+	private static String constructCUContent(ICompilationUnit cu, String typeContent, String lineDelimiter)
+			throws CoreException {
+		String fileComment = CodeGeneration.getFileComment(cu, lineDelimiter);
+		String typeComment = CodeGeneration.getTypeComment(cu, cu.getElementName(), lineDelimiter);
+		IPackageFragment pack = (IPackageFragment) cu.getParent();
+		String content = CodeGeneration.getCompilationUnitContent(cu, fileComment, typeComment, typeContent,
+				lineDelimiter);
+		if (content != null) {
+			ASTParser parser = ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+			parser.setProject(cu.getJavaProject());
+			parser.setSource(content.toCharArray());
+			CompilationUnit unit = (CompilationUnit) parser.createAST(null);
+			if ((pack.isDefaultPackage() || unit.getPackage() != null) && !unit.types().isEmpty()) {
+				return content;
+			}
+		}
+		StringBuilder buf = new StringBuilder();
+		if (!pack.isDefaultPackage()) {
+			buf.append("package ").append(pack.getElementName()).append(';'); //$NON-NLS-1$
+		}
+		buf.append(lineDelimiter).append(lineDelimiter);
+		buf.append(typeContent);
+		return buf.toString();
+	}
+
+	private static CompilationUnit createQuickFixAST(IType javaType) {
+		if (javaType.isBinary()) {
+			return null;
+		}
+		return ASTResolving.createQuickFixAST((ICompilationUnit)javaType.getCompilationUnit(), null);
+	}
+
+	private static IJavaSearchScope createSearchContext(IJavaProject project) throws JavaModelException {
+		int searchScope = IJavaSearchScope.SOURCES;
+		return SearchEngine.createJavaSearchScope(true, new IJavaElement[] { project }, searchScope);
+	}
+
+	private static SearchPattern createTemplateExtensionSearchPattern() {
+		return SearchPattern.createPattern(QuteJavaConstants.TEMPLATE_EXTENSION_ANNOTATION,
+				IJavaSearchConstants.ANNOTATION_TYPE, IJavaSearchConstants.ANNOTATION_TYPE_REFERENCE,
+				SearchPattern.R_EXACT_MATCH);
+	}
+
+	private static IJavaProject getJavaProjectFromProjectUri(String projectName) {
+		if (projectName == null) {
+			return null;
+		}
+		IJavaProject javaProject = JavaModelManager.getJavaModelManager().getJavaModel().getJavaProject(projectName);
+		return javaProject.exists() ? javaProject : null;
+	}
+
+	/**
+	 * Returns the given camelCaseName with the first letter capitalized.
+	 *
+	 * @param camelCaseName the camelCaseVariableName to capitalize
+	 * @return the given camelCaseName with the first letter capitalized
+	 */
+	private static String getCapitalized(String camelCaseName) {
+		return camelCaseName.substring(0, 1).toUpperCase() + camelCaseName.substring(1);
+	}
+
+	/**
+	 * Gets the type of the field declaration, then recreates it on the given ast.
+	 *
+	 * @param toClone the field declaration to clone the type of
+	 * @param ast     the ast on which to create the clone of the type
+	 * @return the cloned type
+	 */
+	private static Type getCloneOfType(FieldDeclaration toClone, AST ast, ASTRewrite rewrite) {
+		return (Type) rewrite.createCopyTarget(toClone.getType());
+	}
+
+	private static String getParamNameFromFullyQualifiedType(String fullyQualifiedType) {
+		int lastDot = fullyQualifiedType.lastIndexOf(".");
+		return fullyQualifiedType.substring(lastDot + 1, lastDot + 2).toLowerCase()
+				+ fullyQualifiedType.substring(lastDot + 2);
+	}
+
+	private static String fixBrokenUri(String uri) {
+		Matcher m = BROKEN_FILE_PROTOCOL.matcher(uri);
+		return m.replaceFirst("file:///");
+	}
+
+	/**
+	 * An ASTVisitor that visits a type declaration and finds the field declaration
+	 * for the given field name
+	 */
+	static class FieldDeclFinder extends ASTVisitor {
+
+		private boolean hasEnteredRootType = false;
+
+		private FieldDeclaration fieldDeclaration = null;
+		private boolean multiDecl = false;
+		private VariableDeclarationFragment oldBadFragment = null;
+		private final String privatedProperty;
+
+		public FieldDeclFinder(String privatedProperty) {
+			this.privatedProperty = privatedProperty;
+		}
+
+		@Override
+		public boolean visit(FieldDeclaration fieldDeclaration) {
+			if (this.fieldDeclaration != null) {
+				return false;
+			}
+			Collection<VariableDeclarationFragment> fragments = (Collection<VariableDeclarationFragment>) fieldDeclaration
+					.getStructuralProperty(FieldDeclaration.FRAGMENTS_PROPERTY);
+			for (VariableDeclarationFragment fragment : fragments) {
+				if (fragment.getName().getFullyQualifiedName().equals(this.privatedProperty)) {
+					this.fieldDeclaration = fieldDeclaration;
+					this.multiDecl = fragments.size() > 1;
+					this.oldBadFragment = fragment;
+					return false;
+				}
+			}
+			return false;
+		}
+
+		@Override
+		public boolean visit(TypeDeclaration typeDeclaration) {
+			if (hasEnteredRootType) {
+				return false;
+			}
+			hasEnteredRootType = true;
+			return true;
+		}
+
+		public FieldDeclaration getFieldDeclaration() {
+			return this.fieldDeclaration;
+		}
+
+		public boolean hasMultiDecl() {
+			return this.multiDecl;
+		}
+
+		public VariableDeclarationFragment getOldBadFragment() {
+			return this.oldBadFragment;
+		}
+	}
+
+}

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/utils/TextEditConverter.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/utils/TextEditConverter.java
@@ -1,0 +1,294 @@
+/*******************************************************************************
+ * Copyright (c) 2016-2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.qute.jdt.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.core.util.SimpleDocument;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+import org.eclipse.lsp4j.TextDocumentEdit;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.eclipse.text.edits.CopySourceEdit;
+import org.eclipse.text.edits.CopyTargetEdit;
+import org.eclipse.text.edits.DeleteEdit;
+import org.eclipse.text.edits.ISourceModifier;
+import org.eclipse.text.edits.InsertEdit;
+import org.eclipse.text.edits.MalformedTreeException;
+import org.eclipse.text.edits.MoveSourceEdit;
+import org.eclipse.text.edits.MoveTargetEdit;
+import org.eclipse.text.edits.MultiTextEdit;
+import org.eclipse.text.edits.ReplaceEdit;
+import org.eclipse.text.edits.TextEdit;
+import org.eclipse.text.edits.TextEditVisitor;
+
+/**
+ * Converts an {@link org.eclipse.text.edits.TextEdit} to
+ * {@link org.eclipse.lsp4j.TextEdit}
+ *
+ * @author Gorkem Ercan
+ *
+ */
+public class TextEditConverter extends TextEditVisitor {
+
+	private static final Logger LOGGER = Logger.getLogger(TextEditConverter.class.getName());
+
+	private final TextEdit source;
+	protected ICompilationUnit compilationUnit;
+	protected List<org.eclipse.lsp4j.TextEdit> converted;
+	private final IJDTUtils utils;
+
+	public TextEditConverter(ICompilationUnit unit, TextEdit edit, IJDTUtils utils) {
+		this.utils = utils;
+		this.source = edit;
+		this.converted = new ArrayList<>();
+		if (unit == null) {
+			throw new IllegalArgumentException("Compilation unit can not be null");
+		}
+		this.compilationUnit = unit;
+	}
+
+	public List<org.eclipse.lsp4j.TextEdit> convert() {
+		if (this.source != null) {
+			this.source.accept(this);
+		}
+		return converted;
+	}
+
+	public TextDocumentEdit convertToTextDocumentEdit(int version) {
+		String uri = utils.toUri(compilationUnit);
+		VersionedTextDocumentIdentifier identifier = new VersionedTextDocumentIdentifier(version);
+		identifier.setUri(uri);
+		return new TextDocumentEdit(identifier, this.convert());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.text.edits.TextEditVisitor#visit(org.eclipse.text.edits.
+	 * InsertEdit)
+	 */
+	@Override
+	public boolean visit(InsertEdit edit) {
+		try {
+			org.eclipse.lsp4j.TextEdit te = new org.eclipse.lsp4j.TextEdit();
+			te.setNewText(edit.getText());
+			te.setRange(utils.toRange(compilationUnit, edit.getOffset(), edit.getLength()));
+			converted.add(te);
+		} catch (JavaModelException e) {
+			LOGGER.log(Level.SEVERE, "Error converting TextEdits", e);
+		}
+		return super.visit(edit);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.text.edits.TextEditVisitor#visit(org.eclipse.text.edits.
+	 * CopySourceEdit)
+	 */
+	@Override
+	public boolean visit(CopySourceEdit edit) {
+		try {
+			if (edit.getTargetEdit() != null) {
+				org.eclipse.lsp4j.TextEdit te = new org.eclipse.lsp4j.TextEdit();
+				te.setRange(utils.toRange(compilationUnit, edit.getOffset(), edit.getLength()));
+				Document doc = new Document(compilationUnit.getSource());
+				edit.apply(doc, TextEdit.UPDATE_REGIONS);
+				String content = doc.get(edit.getOffset(), edit.getLength());
+				if (edit.getSourceModifier() != null) {
+					content = applySourceModifier(content, edit.getSourceModifier());
+				}
+				te.setNewText(content);
+				converted.add(te);
+			}
+			return false;
+		} catch (JavaModelException | MalformedTreeException | BadLocationException e) {
+			LOGGER.log(Level.SEVERE, "Error converting TextEdits", e);
+		}
+		return super.visit(edit);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.text.edits.TextEditVisitor#visit(org.eclipse.text.edits.
+	 * DeleteEdit)
+	 */
+	@Override
+	public boolean visit(DeleteEdit edit) {
+		try {
+			org.eclipse.lsp4j.TextEdit te = new org.eclipse.lsp4j.TextEdit();
+			te.setNewText("");
+			te.setRange(utils.toRange(compilationUnit, edit.getOffset(), edit.getLength()));
+			converted.add(te);
+		} catch (JavaModelException e) {
+			LOGGER.log(Level.SEVERE, "Error converting TextEdits", e);
+		}
+		return super.visit(edit);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.text.edits.TextEditVisitor#visit(org.eclipse.text.edits.
+	 * MultiTextEdit)
+	 */
+	@Override
+	public boolean visit(MultiTextEdit edit) {
+		try {
+			org.eclipse.lsp4j.TextEdit te = new org.eclipse.lsp4j.TextEdit();
+			te.setRange(utils.toRange(compilationUnit, edit.getOffset(), edit.getLength()));
+			Document doc = new Document(compilationUnit.getSource());
+			edit.apply(doc, TextEdit.UPDATE_REGIONS);
+			String content = doc.get(edit.getOffset(), edit.getLength());
+			te.setNewText(content);
+			converted.add(te);
+			return false;
+		} catch (JavaModelException | MalformedTreeException | BadLocationException e) {
+			LOGGER.log(Level.SEVERE, "Error converting TextEdits", e);
+		}
+		return false;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.text.edits.TextEditVisitor#visit(org.eclipse.text.edits.
+	 * ReplaceEdit)
+	 */
+	@Override
+	public boolean visit(ReplaceEdit edit) {
+		try {
+			org.eclipse.lsp4j.TextEdit te = new org.eclipse.lsp4j.TextEdit();
+			te.setNewText(edit.getText());
+			te.setRange(utils.toRange(compilationUnit, edit.getOffset(), edit.getLength()));
+			converted.add(te);
+		} catch (JavaModelException e) {
+			LOGGER.log(Level.SEVERE, "Error converting TextEdits", e);
+		}
+		return super.visit(edit);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see org.eclipse.text.edits.TextEditVisitor#visit(org.eclipse.text.edits.
+	 * CopyTargetEdit)
+	 */
+	@Override
+	public boolean visit(CopyTargetEdit edit) {
+		try {
+			if (edit.getSourceEdit() != null) {
+				org.eclipse.lsp4j.TextEdit te = new org.eclipse.lsp4j.TextEdit();
+				te.setRange(utils.toRange(compilationUnit, edit.getOffset(), edit.getLength()));
+
+				Document doc = new Document(compilationUnit.getSource());
+				edit.apply(doc, TextEdit.UPDATE_REGIONS);
+				String content = doc.get(edit.getSourceEdit().getOffset(), edit.getSourceEdit().getLength());
+
+				if (edit.getSourceEdit().getSourceModifier() != null) {
+					content = applySourceModifier(content, edit.getSourceEdit().getSourceModifier());
+				}
+
+				te.setNewText(content);
+				converted.add(te);
+			}
+			return false; // do not visit children
+		} catch (MalformedTreeException | BadLocationException | CoreException e) {
+			LOGGER.log(Level.SEVERE, "Error converting TextEdits", e);
+		}
+		return super.visit(edit);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see org.eclipse.text.edits.TextEditVisitor#visit(org.eclipse.text.edits.
+	 * MoveSourceEdit)
+	 */
+	@Override
+	public boolean visit(MoveSourceEdit edit) {
+		try {
+			// If MoveSourcedEdit & MoveTargetEdit are the same level, should delete the
+			// original contenxt.
+			// See issue#https://github.com/redhat-developer/vscode-java/issues/253
+			if (edit.getParent() != null && edit.getTargetEdit() != null
+					&& edit.getParent().equals(edit.getTargetEdit().getParent())) {
+				org.eclipse.lsp4j.TextEdit te = new org.eclipse.lsp4j.TextEdit();
+				te.setNewText("");
+				te.setRange(utils.toRange(compilationUnit, edit.getOffset(), edit.getLength()));
+				converted.add(te);
+				return false;
+			}
+		} catch (JavaModelException e) {
+			LOGGER.log(Level.SEVERE, "Error converting TextEdits", e);
+		}
+		return super.visit(edit);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see org.eclipse.text.edits.TextEditVisitor#visit(org.eclipse.text.edits.
+	 * MoveTargetEdit)
+	 */
+	@Override
+	public boolean visit(MoveTargetEdit edit) {
+		try {
+			if (edit.getSourceEdit() != null) {
+				org.eclipse.lsp4j.TextEdit te = new org.eclipse.lsp4j.TextEdit();
+				te.setRange(utils.toRange(compilationUnit, edit.getOffset(), edit.getLength()));
+
+				Document doc = new Document(compilationUnit.getSource());
+				edit.apply(doc, TextEdit.UPDATE_REGIONS);
+				String content = doc.get(edit.getSourceEdit().getOffset(), edit.getSourceEdit().getLength());
+				if (edit.getSourceEdit().getSourceModifier() != null) {
+					content = applySourceModifier(content, edit.getSourceEdit().getSourceModifier());
+				}
+				te.setNewText(content);
+				converted.add(te);
+				return false; // do not visit children
+			}
+		} catch (MalformedTreeException | BadLocationException | CoreException e) {
+			LOGGER.log(Level.SEVERE, "Error converting TextEdits", e);
+		}
+		return super.visit(edit);
+	}
+
+	private String applySourceModifier(String content, ISourceModifier modifier) {
+		if (StringUtils.isBlank(content) || modifier == null) {
+			return content;
+		}
+
+		SimpleDocument subDocument = new SimpleDocument(content);
+		TextEdit newEdit = new MultiTextEdit(0, subDocument.getLength());
+		ReplaceEdit[] replaces = modifier.getModifications(content);
+		for (ReplaceEdit replace : replaces) {
+			newEdit.addChild(replace);
+		}
+		try {
+			newEdit.apply(subDocument, TextEdit.NONE);
+		} catch (BadLocationException e) {
+			LOGGER.log(Level.SEVERE, "Error applying edit to document", e);
+		}
+		return subDocument.get();
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/GenerateMissingJavaMemberParams.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/GenerateMissingJavaMemberParams.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.commons;
+
+/**
+ * Parameters required for generating a field, getter, or template extension in
+ * a Java type.
+ *
+ * @author datho7561
+ */
+public class GenerateMissingJavaMemberParams {
+
+	public enum MemberType {
+
+		Field(1), Getter(2), AppendTemplateExtension(3), CreateTemplateExtension(4);
+
+		private final int value;
+
+		MemberType(int value) {
+			this.value = value;
+		}
+
+		public int getValue() {
+			return this.value;
+		}
+
+		public static MemberType forValue(int value) {
+			MemberType[] allValues = MemberType.values();
+			if (value < 1 || value > allValues.length)
+				throw new IllegalArgumentException("Illegal enum value: " + value);
+			return allValues[value - 1];
+		}
+
+	}
+
+	private MemberType memberType;
+	private String missingProperty;
+	private String javaType;
+	private String projectUri;
+
+	public GenerateMissingJavaMemberParams() {
+		this(null, null, null, null);
+	}
+
+	/**
+	 * Returns the parameters for generate a missing java member that is referenced
+	 * in a template but doesn't exist.
+	 * 
+	 * @param memberType      the type of member to generate
+	 * @param missingProperty the name of the java member that's missing
+	 * @param javaType        the java type to generate the missing member in
+	 * @param projectUri      the uri of the project
+	 */
+	public GenerateMissingJavaMemberParams(MemberType memberType, String missingProperty, String javaType,
+			String projectUri) {
+		this.memberType = memberType;
+		this.missingProperty = missingProperty;
+		this.javaType = javaType;
+		this.projectUri = projectUri;
+	}
+
+	public MemberType getMemberType() {
+		return this.memberType;
+	}
+
+	public void setMemberType(MemberType memberType) {
+		this.memberType = memberType;
+	}
+
+	public String getMissingProperty() {
+		return this.missingProperty;
+	}
+
+	public void setMissingProperty(String missingProperty) {
+		this.missingProperty = missingProperty;
+	}
+
+	public String getJavaType() {
+		return this.javaType;
+	}
+
+	public void setJavaType(String javaType) {
+		this.javaType = javaType;
+	}
+
+	public String getProjectUri() {
+		return this.projectUri;
+	}
+
+	public void setProjectUri(String projectUri) {
+		this.projectUri = projectUri;
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/QuteLanguageServer.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/QuteLanguageServer.java
@@ -53,6 +53,7 @@ import com.redhat.qute.ls.api.QuteLanguageClientAPI;
 import com.redhat.qute.ls.api.QuteLanguageServerAPI;
 import com.redhat.qute.ls.api.QuteProjectInfoProvider;
 import com.redhat.qute.ls.api.QuteResolvedJavaTypeProvider;
+import com.redhat.qute.ls.api.QuteTemplateGenerateMissingJavaMember;
 import com.redhat.qute.ls.api.QuteUserTagProvider;
 import com.redhat.qute.ls.commons.ParentProcessWatcher.ProcessLanguageServer;
 import com.redhat.qute.ls.commons.client.ExtendedClientCapabilities;
@@ -74,7 +75,7 @@ import com.redhat.qute.settings.capabilities.ServerCapabilitiesInitializer;
  */
 public class QuteLanguageServer implements LanguageServer, ProcessLanguageServer, QuteLanguageServerAPI,
 		QuteProjectInfoProvider, QuteJavaTypesProvider, QuteResolvedJavaTypeProvider, QuteJavaDefinitionProvider,
-		QuteDataModelProjectProvider, QuteUserTagProvider {
+		QuteDataModelProjectProvider, QuteUserTagProvider, QuteTemplateGenerateMissingJavaMember {
 
 	private static final Logger LOGGER = Logger.getLogger(QuteLanguageServer.class.getName());
 

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/api/QuteLanguageClientAPI.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/api/QuteLanguageClientAPI.java
@@ -15,12 +15,13 @@ import org.eclipse.lsp4j.services.LanguageClient;
 
 /**
  * Qute language client API.
- * 
+ *
  * @author Angelo ZERR
  *
  */
-public interface QuteLanguageClientAPI extends LanguageClient, QuteJavaTypesProvider, QuteResolvedJavaTypeProvider,
-		QuteJavaDefinitionProvider, QuteProjectInfoProvider, QuteDataModelProjectProvider, QuteUserTagProvider,
-		QuteJavaCodeLensProvider, QuteJavaDiagnosticsProvider, QuteJavaDocumentLinkProvider {
+public interface QuteLanguageClientAPI
+		extends LanguageClient, QuteJavaTypesProvider, QuteResolvedJavaTypeProvider, QuteJavaDefinitionProvider,
+		QuteProjectInfoProvider, QuteDataModelProjectProvider, QuteUserTagProvider, QuteJavaCodeLensProvider,
+		QuteJavaDiagnosticsProvider, QuteJavaDocumentLinkProvider, QuteTemplateGenerateMissingJavaMember {
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/api/QuteTemplateGenerateMissingJavaMember.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/api/QuteTemplateGenerateMissingJavaMember.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.ls.api;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+
+import com.redhat.qute.commons.GenerateMissingJavaMemberParams;
+
+/**
+ * Request additional information from the associated java language server in
+ * order to resolve the workspace edit to create a field, getter, or template
+ * extension for a given type.
+ *
+ * @author datho7561
+ */
+public interface QuteTemplateGenerateMissingJavaMember {
+	@JsonRequest("qute/template/generateMissingJavaMember")
+	default CompletableFuture<WorkspaceEdit> generateMissingJavaMember(GenerateMissingJavaMemberParams params) {
+		return CompletableFuture.completedFuture(null);
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/CodeActionFactory.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/CodeActionFactory.java
@@ -204,6 +204,23 @@ public class CodeActionFactory {
 		return codeAction;
 	}
 
+	/**
+	 * Makes a CodeAction and attaches the associated data.
+	 *
+	 * No edits/workspace edits/commands are specified for the CodeAction
+	 *
+	 * @param title       The displayed name of the CodeAction
+	 * @param data        The data to attach to the CodeAction
+	 * @param diagnostics The diagnostic list that this CodeAction will fix
+	 * @return the new CodeAction
+	 */
+	public static CodeAction createCodeActionWithData(String title, Object data, List<Diagnostic> diagnostics) {
+		CodeAction codeAction = new CodeAction(title);
+		codeAction.setData(data);
+		codeAction.setKind(CodeActionKind.QuickFix);
+		return codeAction;
+	}
+
 	public static boolean isDiagnosticCode(Either<String, Integer> diagnosticCode, String code) {
 		if (diagnosticCode == null || diagnosticCode.isRight()) {
 			return false;

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/template/TemplateFileTextDocumentService.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/template/TemplateFileTextDocumentService.java
@@ -59,6 +59,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import com.redhat.qute.commons.datamodel.JavaDataModelChangeEvent;
 import com.redhat.qute.ls.AbstractTextDocumentService;
 import com.redhat.qute.ls.QuteLanguageServer;
+import com.redhat.qute.ls.api.QuteLanguageClientAPI;
 import com.redhat.qute.ls.commons.ModelTextDocument;
 import com.redhat.qute.ls.commons.ValidatorDelayer;
 import com.redhat.qute.parser.template.Template;
@@ -76,6 +77,7 @@ public class TemplateFileTextDocumentService extends AbstractTextDocumentService
 
 	private final QuteTextDocuments documents;
 	private ValidatorDelayer<ModelTextDocument<Template>> validatorDelayer;
+	private final QuteLanguageServer languageServer;
 
 	public TemplateFileTextDocumentService(QuteLanguageServer quteLanguageServer, SharedSettings sharedSettings) {
 		super(quteLanguageServer, sharedSettings);
@@ -85,6 +87,7 @@ public class TemplateFileTextDocumentService extends AbstractTextDocumentService
 		this.validatorDelayer = new ValidatorDelayer<ModelTextDocument<Template>>((template) -> {
 			validate((QuteTextDocument) template);
 		});
+		this.languageServer = quteLanguageServer;
 	}
 
 	@Override
@@ -155,7 +158,7 @@ public class TemplateFileTextDocumentService extends AbstractTextDocumentService
 					// Cancel checker is not passed to doCodeActions, since code actions don't yet
 					// need to interact with JDT/editor
 					return getQuteLanguageService()
-							.doCodeActions(template, params.getContext(), params.getRange(), sharedSettings) //
+							.doCodeActions(template, params.getContext(), getLanguageClient(), params.getRange(), sharedSettings) //
 							.thenApply(codeActions -> {
 								cancelChecker.checkCanceled();
 								return codeActions.stream() //
@@ -401,6 +404,10 @@ public class TemplateFileTextDocumentService extends AbstractTextDocumentService
 		documents.all().stream().forEach(document -> {
 			triggerValidationFor((QuteTextDocument) document, true);
 		});
+	}
+
+	private QuteLanguageClientAPI getLanguageClient() {
+		return languageServer.getLanguageClient();
 	}
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/Parameter.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/Parameter.java
@@ -92,7 +92,7 @@ public class Parameter extends Node implements JavaTypeInfoProvider {
 
 	/**
 	 * Returns the parameter name.
-	 * 
+	 *
 	 * @return the parameter name.
 	 */
 	public String getName() {
@@ -216,12 +216,12 @@ public class Parameter extends Node implements JavaTypeInfoProvider {
 	/**
 	 * Returns true if the last part of the expression parameter is optional (ends
 	 * with ??) and false otherwise.
-	 * 
+	 *
 	 * <p>
 	 * {#let bar=foo??}
 	 * {#if foo??}
 	 * </p>
-	 * 
+	 *
 	 * @return true if the last part of the expression parameter is optional (ends
 	 *         with ??) and false otherwise.
 	 */

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteDiagnostics.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteDiagnostics.java
@@ -32,6 +32,8 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import com.redhat.qute.commons.InvalidMethodReason;
 import com.redhat.qute.commons.JavaElementKind;
 import com.redhat.qute.commons.JavaMemberInfo;
@@ -65,6 +67,7 @@ import com.redhat.qute.project.datamodel.JavaDataModelCache;
 import com.redhat.qute.project.indexing.QuteIndex;
 import com.redhat.qute.project.tags.UserTag;
 import com.redhat.qute.services.diagnostics.DiagnosticDataFactory;
+import com.redhat.qute.services.diagnostics.UnknownPropertyData;
 import com.redhat.qute.services.diagnostics.QuteDiagnosticsForSyntax;
 import com.redhat.qute.services.diagnostics.QuteErrorCode;
 import com.redhat.qute.services.nativemode.JavaTypeAccessibiltyRule;
@@ -284,7 +287,7 @@ class QuteDiagnostics {
 
 	/**
 	 * Validate parameter declaration.
-	 * 
+	 *
 	 * @param parameter                the parameter declaration.
 	 * @param template                 the owner Qute template.
 	 * @param projectUri               the project Uri.
@@ -701,8 +704,11 @@ class QuteDiagnostics {
 			// ex : {@org.acme.Item item}
 			// "{item.XXXX}
 			Range range = QutePositionUtility.createRange(part);
+			String signature = baseType.getSignature();
+			String property = part.getPartName();
 			Diagnostic diagnostic = createDiagnostic(range, DiagnosticSeverity.Error, QuteErrorCode.UnknownProperty,
-					part.getPartName(), baseType.getSignature());
+					property, signature);
+			diagnostic.setData(new UnknownPropertyData(signature, property));
 			diagnostics.add(diagnostic);
 			return null;
 		} else if (canValidateMemberInNativeMode(filter, javaMember)) {

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteLanguageService.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteLanguageService.java
@@ -34,6 +34,7 @@ import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
+import com.redhat.qute.ls.api.QuteTemplateGenerateMissingJavaMember;
 import com.redhat.qute.ls.commons.snippets.Snippet;
 import com.redhat.qute.ls.commons.snippets.SnippetRegistry;
 import com.redhat.qute.ls.commons.snippets.SnippetRegistryProvider;
@@ -91,12 +92,13 @@ public class QuteLanguageService implements SnippetRegistryProvider<Snippet> {
 	 *
 	 * @param template       the Qute template.
 	 * @param context        the Code Action context.
+	 * @param resolver       the generate missing java member resolver
 	 * @param sharedSettings the Qute shared settings.
 	 * @return the CodeAction(s) to be added to the Qute template.
 	 */
-	public CompletableFuture<List<CodeAction>> doCodeActions(Template template, CodeActionContext context, Range range,
-			SharedSettings sharedSettings) {
-		return codeActions.doCodeActions(template, context, range, sharedSettings);
+	public CompletableFuture<List<CodeAction>> doCodeActions(Template template, CodeActionContext context,
+			QuteTemplateGenerateMissingJavaMember resolver, Range range, SharedSettings sharedSettings) {
+		return codeActions.doCodeActions(template, context, range, resolver, sharedSettings);
 	}
 
 	/**

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/diagnostics/DiagnosticDataFactory.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/diagnostics/DiagnosticDataFactory.java
@@ -21,10 +21,12 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.Range;
 
 import com.google.gson.JsonObject;
+import com.redhat.qute.parser.template.Template;
+import com.redhat.qute.utils.JSONUtility;
 
 /**
  * Diagnostic factory.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -41,6 +43,20 @@ public class DiagnosticDataFactory {
 		JsonObject data = new JsonObject();
 		data.addProperty(DIAGNOSTIC_DATA_TAG, tagName);
 		return data;
+	}
+
+
+	public static UnknownPropertyData getMissingMemberData(Diagnostic diagnostic) {
+		if (diagnostic.getData() == null) {
+			// TODO: the client may not support diagnostic data; resolve the needed
+			// information some other way, such as with the Java cache
+			return null;
+		}
+		return JSONUtility.toModel(diagnostic.getData(), UnknownPropertyData.class);
+	}
+
+	public static UnknownPropertyData getMissingMemberData(JsonObject obj) {
+		return JSONUtility.toModel(obj, UnknownPropertyData.class);
 	}
 
 	public static Diagnostic createDiagnostic(Range range, DiagnosticSeverity severity, IQuteErrorCode errorCode,

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/diagnostics/UnknownPropertyData.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/diagnostics/UnknownPropertyData.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.diagnostics;
+
+/**
+ * Represents the data needed to create a "create missing member" CodeAction
+ *
+ * @author datho7561
+ */
+public class UnknownPropertyData {
+
+	private String signature;
+	private String property;
+
+	public UnknownPropertyData(String signature, String property) {
+		this.signature = signature;
+		this.property = property;
+	}
+
+	public String getSignature() {
+		return this.signature;
+	}
+
+	public String getProperty() {
+		return this.property;
+	}
+
+	@Override
+	public UnknownPropertyData clone() {
+		return new UnknownPropertyData(signature, property);
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (other == null || !(other instanceof UnknownPropertyData)) {
+			return false;
+		}
+		UnknownPropertyData otherCast = (UnknownPropertyData) other;
+		return (this.property.equals(otherCast.property))
+				&& (this.signature.equals(otherCast.signature));
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
@@ -65,6 +65,7 @@ import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import com.redhat.qute.commons.ProjectInfo;
+import com.redhat.qute.ls.api.QuteTemplateGenerateMissingJavaMember;
 import com.redhat.qute.ls.commons.BadLocationException;
 import com.redhat.qute.ls.commons.TextDocument;
 import com.redhat.qute.ls.commons.client.CommandCapabilities;
@@ -375,6 +376,13 @@ public class QuteAssert {
 	}
 
 	public static Diagnostic d(int startLine, int startCharacter, int endLine, int endCharacter, IQuteErrorCode code,
+			String message, Object data, DiagnosticSeverity severity) {
+		Diagnostic diagnostic = d(startLine, startCharacter, endLine, endCharacter, code, message, QUTE_SOURCE, severity);
+		diagnostic.setData(data);
+		return diagnostic;
+	}
+
+	public static Diagnostic d(int startLine, int startCharacter, int endLine, int endCharacter, IQuteErrorCode code,
 			String message, String source, DiagnosticSeverity severity) {
 		// Diagnostic on 1 line
 		return new Diagnostic(r(startLine, startCharacter, endLine, endCharacter), message, severity, source,
@@ -666,7 +674,9 @@ public class QuteAssert {
 		Template template = createTemplate(value, fileUri, projectUri, templateBaseDir, projectRegistry);
 		QuteLanguageService languageService = new QuteLanguageService(new JavaDataModelCache(projectRegistry));
 
-		List<CodeAction> actual = languageService.doCodeActions(template, context, range, settings).get();
+		List<CodeAction> actual = languageService.doCodeActions(template, context, new QuteTemplateGenerateMissingJavaMember() {
+			// do not attempt to resolve "generate missing java member" code actions in qute-ls unit tests
+		}, range, settings).get();
 		assertCodeActions(actual, expected);
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/arrays/ArrayLengthValueResolverTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/arrays/ArrayLengthValueResolverTest.java
@@ -21,6 +21,8 @@ import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.jupiter.api.Test;
 
+import com.redhat.qute.services.diagnostics.DiagnosticDataFactory;
+import com.redhat.qute.services.diagnostics.UnknownPropertyData;
 import com.redhat.qute.services.diagnostics.QuteErrorCode;
 
 /**
@@ -44,6 +46,7 @@ public class ArrayLengthValueResolverTest {
 		testDiagnosticsFor(template, //
 				d(1, 7, 1, 16, QuteErrorCode.UnknownProperty,
 						"`lengthXXX` cannot be resolved or is not a field of `org.acme.Item[]` Java type.",
+						new UnknownPropertyData("org.acme.Item[]", "lengthXXX"),
 						DiagnosticSeverity.Error));
 
 		template = "{@java.util.List<org.acme.Item> items}\r\n" + //
@@ -51,6 +54,7 @@ public class ArrayLengthValueResolverTest {
 		testDiagnosticsFor(template, //
 				d(1, 7, 1, 13, QuteErrorCode.UnknownProperty,
 						"`length` cannot be resolved or is not a field of `java.util.List<E>` Java type.",
+						new UnknownPropertyData("java.util.List<E>", "length"),
 						DiagnosticSeverity.Error));
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/arrays/ArraySizeValueResolverTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/arrays/ArraySizeValueResolverTest.java
@@ -21,6 +21,7 @@ import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.jupiter.api.Test;
 
+import com.redhat.qute.services.diagnostics.UnknownPropertyData;
 import com.redhat.qute.services.diagnostics.QuteErrorCode;
 
 /**
@@ -44,6 +45,7 @@ public class ArraySizeValueResolverTest {
 		testDiagnosticsFor(template, //
 				d(1, 7, 1, 14, QuteErrorCode.UnknownProperty,
 						"`sizeXXX` cannot be resolved or is not a field of `org.acme.Item[]` Java type.",
+						new UnknownPropertyData("org.acme.Item[]", "sizeXXX"),
 						DiagnosticSeverity.Error));
 
 		template = "{@java.util.List<org.acme.Item> items}\r\n" + //

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/arrays/ArrayTakeLastValueResolverTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/arrays/ArrayTakeLastValueResolverTest.java
@@ -21,6 +21,7 @@ import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.jupiter.api.Test;
 
+import com.redhat.qute.services.diagnostics.UnknownPropertyData;
 import com.redhat.qute.services.diagnostics.QuteErrorCode;
 
 /**
@@ -38,16 +39,17 @@ public class ArrayTakeLastValueResolverTest {
 		String template = "{@org.acme.Item[] items}\r\n" + //
 				"{items.takeLast(0)}";
 		testDiagnosticsFor(template);
-		
+
 		template = "{@org.acme.Item[] items}\r\n" + //
 				"{items.takeLast(0).length}";
 		testDiagnosticsFor(template);
-		
+
 		template = "{@org.acme.Item[] items}\r\n" + //
 				"{items.takeLast(0).lengthXXX}";
 		testDiagnosticsFor(template, //
 				d(1, 19, 1, 28, QuteErrorCode.UnknownProperty,
 						"`lengthXXX` cannot be resolved or is not a field of `org.acme.Item[]` Java type.",
+						new UnknownPropertyData("org.acme.Item[]", "lengthXXX"),
 						DiagnosticSeverity.Error));
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/arrays/ArrayTakeValueResolverTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/arrays/ArrayTakeValueResolverTest.java
@@ -21,6 +21,7 @@ import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.jupiter.api.Test;
 
+import com.redhat.qute.services.diagnostics.UnknownPropertyData;
 import com.redhat.qute.services.diagnostics.QuteErrorCode;
 
 /**
@@ -38,16 +39,17 @@ public class ArrayTakeValueResolverTest {
 		String template = "{@org.acme.Item[] items}\r\n" + //
 				"{items.take(0)}";
 		testDiagnosticsFor(template);
-		
+
 		template = "{@org.acme.Item[] items}\r\n" + //
 				"{items.take(0).length}";
 		testDiagnosticsFor(template);
-		
+
 		template = "{@org.acme.Item[] items}\r\n" + //
 				"{items.take(0).lengthXXX}";
 		testDiagnosticsFor(template, //
 				d(1, 15, 1, 24, QuteErrorCode.UnknownProperty,
 						"`lengthXXX` cannot be resolved or is not a field of `org.acme.Item[]` Java type.",
+						new UnknownPropertyData("org.acme.Item[]", "lengthXXX"),
 						DiagnosticSeverity.Error));
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionTest.java
@@ -228,6 +228,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testDiagnosticsFor(template, //
 				d(1, 6, 1, 10, QuteErrorCode.UnknownProperty,
 						"`XXXX` cannot be resolved or is not a field of `org.acme.Item` Java type.",
+						new UnknownPropertyData("org.acme.Item", "XXXX"),
 						DiagnosticSeverity.Error));
 
 		template = "{@org.acme.Item item}\r\n" + //
@@ -235,6 +236,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testDiagnosticsFor(template, //
 				d(1, 6, 1, 10, QuteErrorCode.UnknownProperty,
 						"`XXXX` cannot be resolved or is not a field of `org.acme.Item` Java type.",
+						new UnknownPropertyData("org.acme.Item", "XXXX"),
 						DiagnosticSeverity.Error));
 
 		template = "{@org.acme.Item item}\r\n" + //
@@ -242,6 +244,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testDiagnosticsFor(template, //
 				d(1, 11, 1, 15, QuteErrorCode.UnknownProperty,
 						"`YYYY` cannot be resolved or is not a field of `java.lang.String` Java type.",
+						new UnknownPropertyData("java.lang.String", "YYYY"),
 						DiagnosticSeverity.Error));
 	}
 
@@ -336,6 +339,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testDiagnosticsFor(template, //
 				d(1, 7, 1, 14, QuteErrorCode.UnknownProperty,
 						"`sizeXXX` cannot be resolved or is not a field of `java.util.List<E>` Java type.",
+						new UnknownPropertyData("java.util.List<E>", "sizeXXX"),
 						DiagnosticSeverity.Error));
 
 		template = "{@java.util.List<org.acme.Item> items}\r\n" + //
@@ -351,7 +355,9 @@ public class QuteDiagnosticsInExpressionTest {
 		String template = "{@java.util.List<org.acme.Item> items}\r\n" + //
 				"{items.size.XXX}";
 		testDiagnosticsFor(template, d(1, 12, 1, 15, QuteErrorCode.UnknownProperty,
-				"`XXX` cannot be resolved or is not a field of `int` Java type.", DiagnosticSeverity.Error));
+				"`XXX` cannot be resolved or is not a field of `int` Java type.",
+				new UnknownPropertyData("int", "XXX"),
+				DiagnosticSeverity.Error));
 	}
 
 	@Test
@@ -450,36 +456,36 @@ public class QuteDiagnosticsInExpressionTest {
 		String template = "{@org.acme.Item item}\r\n" + //
 				"		{item.pretty()}";
 		testDiagnosticsFor(template);
-		
+
 		template = "{@org.acme.Item item}\r\n" + //
 				"		{item.pretty('a')}";
 		testDiagnosticsFor(template);
-		
+
 		template = "{@org.acme.Item item}\r\n" + //
 				"		{item.pretty('a','b')}";
 		testDiagnosticsFor(template);
-		
+
 		template = "{@org.acme.Item item}\r\n" + //
 				"		{item.pretty(0)}";
 		testDiagnosticsFor(template, //
 				d(1, 8, 1, 14, QuteErrorCode.InvalidMethodParameter,
 						"The method `pretty(String...)` in the type `ItemResource` is not applicable for the arguments `(Integer)`.",
 						DiagnosticSeverity.Error));
-		
+
 		template = "{@org.acme.Item item}\r\n" + //
 				"		{item.pretty(0,'a')}";
 		testDiagnosticsFor(template, //
 				d(1, 8, 1, 14, QuteErrorCode.InvalidMethodParameter,
 						"The method `pretty(String...)` in the type `ItemResource` is not applicable for the arguments `(Integer, String)`.",
 						DiagnosticSeverity.Error));
-		
+
 		template = "{@org.acme.Item item}\r\n" + //
 				"		{item.pretty('a',0)}";
 		testDiagnosticsFor(template, //
 				d(1, 8, 1, 14, QuteErrorCode.InvalidMethodParameter,
 						"The method `pretty(String...)` in the type `ItemResource` is not applicable for the arguments `(String, Integer)`.",
 						DiagnosticSeverity.Error));
-		
+
 		template = "{@org.acme.Item item}\r\n" + //
 				"		{item.pretty('a',0,'b')}";
 		testDiagnosticsFor(template, //
@@ -487,7 +493,7 @@ public class QuteDiagnosticsInExpressionTest {
 						"The method `pretty(String...)` in the type `ItemResource` is not applicable for the arguments `(String, Integer, String)`.",
 						DiagnosticSeverity.Error));
 	}
-	
+
 	@Test
 	public void listGeneric() throws Exception {
 		String template = "{@java.util.List<org.acme.Item> items}\r\n" + //
@@ -684,6 +690,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testDiagnosticsFor(template, //
 				d(1, 8, 1, 12, QuteErrorCode.UnknownProperty,
 						"`XXXX` cannot be resolved or is not a field of `org.acme.Item` Java type.",
+						new UnknownPropertyData("org.acme.Item", "XXXX"),
 						DiagnosticSeverity.Error));
 	}
 
@@ -721,6 +728,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testDiagnosticsFor(template, //
 				d(0, 8, 0, 12, QuteErrorCode.UnknownProperty,
 						"`XXXX` cannot be resolved or is not a field of `java.lang.String` Java type.",
+						new UnknownPropertyData("java.lang.String", "XXXX"),
 						DiagnosticSeverity.Error));
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithEachSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithEachSectionTest.java
@@ -54,7 +54,7 @@ public class QuteDiagnosticsInExpressionWithEachSectionTest {
 	}
 
 	@Test
-	public void unkwownProperty() throws Exception {
+	public void unknownProperty() throws Exception {
 		String template = "{@java.util.List<org.acme.Item> items}\r\n" + //
 				" \r\n" + //
 				"{#each items}\r\n" + //
@@ -63,6 +63,7 @@ public class QuteDiagnosticsInExpressionWithEachSectionTest {
 		testDiagnosticsFor(template, //
 				d(3, 5, 3, 12, QuteErrorCode.UnknownProperty,
 						"`nameXXX` cannot be resolved or is not a field of `org.acme.Item` Java type.",
+						new UnknownPropertyData("org.acme.Item", "nameXXX"),
 						DiagnosticSeverity.Error));
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithForSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithForSectionTest.java
@@ -106,6 +106,7 @@ public class QuteDiagnosticsInExpressionWithForSectionTest {
 		testDiagnosticsFor(template, //
 				d(3, 7, 3, 14, QuteErrorCode.UnknownProperty,
 						"`nameXXX` cannot be resolved or is not a field of `org.acme.Item` Java type.",
+						new UnknownPropertyData("org.acme.Item", "nameXXX"),
 						DiagnosticSeverity.Error));
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithNamespaceTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithNamespaceTest.java
@@ -104,6 +104,7 @@ public class QuteDiagnosticsInExpressionWithNamespaceTest {
 		testDiagnosticsFor(template,
 				d(0, 13, 0, 17, QuteErrorCode.UnknownProperty,
 						"`XXXX` cannot be resolved or is not a field of `java.lang.String` Java type.",
+						new UnknownPropertyData("java.lang.String", "XXXX"),
 						DiagnosticSeverity.Error));
 
 		template = "{inject:bean.XXXX()}";


### PR DESCRIPTION
Generates Java code for a property referenced in a Qute template that doesn't exist yet.

It can generate:
  *  A new public field, or update the visibility of an existing field
  *  A new getter, properly returning the field bearing the corresponding name if it exists
  *  A new template extension in the detected template extensions class
  *  A new template extension in a newly generated template extensions class

Fixes #536