### PR TITLE
Remove unnecessary Gson dependency in pom files.

### DIFF
--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/pom.xml
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/pom.xml
@@ -42,12 +42,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
-	<dependencies>
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.8.5</version>
-		</dependency>
-	</dependencies>
 </project>

--- a/qute.jdt/com.redhat.qute.jdt/pom.xml
+++ b/qute.jdt/com.redhat.qute.jdt/pom.xml
@@ -13,11 +13,4 @@
 	<name>Qute JDT LS Extension</name>
 	<description>Qute JDT LS Extension </description>
 
-	<dependencies>
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.8.5</version>
-		</dependency>
-	</dependencies>
 </project>


### PR DESCRIPTION
- com.google.gson will come from the o.e.jdt.ls.tp target so there is no
  need to specify it as a dependency in the pom

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>