### PR TITLE
Don't show "add field/getter" CodeActions in Qute for binary types

### DIFF
--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/GenerateMissingJavaMemberParams.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/GenerateMissingJavaMemberParams.java
@@ -9,6 +9,8 @@
 *******************************************************************************/
 package com.redhat.qute.commons;
 
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
 /**
  * Parameters required for generating a field, getter, or template extension in
  * a Java type.
@@ -96,6 +98,29 @@ public class GenerateMissingJavaMemberParams {
 
 	public void setProjectUri(String projectUri) {
 		this.projectUri = projectUri;
+	}
+
+	@Override
+	public String toString() {
+		ToStringBuilder builder = new ToStringBuilder(this);
+		builder.add("memberType", memberType);
+		builder.add("missingProperty", missingProperty);
+		builder.add("javaType", javaType);
+		builder.add("projectUri", projectUri);
+		return builder.toString();
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (other == null || !(other instanceof GenerateMissingJavaMemberParams)) {
+			return false;
+		}
+		GenerateMissingJavaMemberParams that = (GenerateMissingJavaMemberParams) other;
+		return (this.memberType == that.memberType) //
+				&& ((this.missingProperty == null && that.missingProperty == null)
+						|| this.missingProperty.equals(that.missingProperty)) //
+				&& ((this.javaType == null && that.javaType == null) || this.javaType.equals(that.javaType)) //
+				&& ((this.projectUri == null && that.projectUri == null) || this.projectUri.equals(that.projectUri));
 	}
 
 }

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/ResolvedJavaTypeInfo.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/ResolvedJavaTypeInfo.java
@@ -43,6 +43,8 @@ public class ResolvedJavaTypeInfo extends JavaTypeInfo {
 
 	private Boolean isIterable;
 
+	private Boolean source;
+
 	private RegisterForReflectionAnnotation registerForReflectionAnnotation;
 
 	private List<TemplateDataAnnotation> templateDataAnnotations;
@@ -152,6 +154,26 @@ public class ResolvedJavaTypeInfo extends JavaTypeInfo {
 	}
 
 	/**
+	 * Returns true if this Java type is in a user modifiable source file, and false
+	 * otherwise.
+	 * 
+	 * @return true if this Java type is in a user modifiable source file, and false
+	 *         otherwise
+	 */
+	public boolean isSource() {
+		return source != null && source.booleanValue();
+	}
+
+	/**
+	 * Set if this type comes from a source file.
+	 * 
+	 * @param source true if the type comes from a source file, false otherwise
+	 */
+	public void setSource(Boolean source) {
+		this.source = source;
+	}
+
+	/**
 	 * Returns true if the Java type is an integer and false otherwise.
 	 * 
 	 * @return true if the Java type is an integer and false otherwise.
@@ -234,6 +256,7 @@ public class ResolvedJavaTypeInfo extends JavaTypeInfo {
 		ToStringBuilder b = new ToStringBuilder(this);
 		b.add("name", this.getName());
 		b.add("signature", this.getSignature());
+		b.add("source", this.isSource() ? "SOURCE" : "BINARY");
 		b.add("iterableOf", this.getIterableOf());
 		b.add("iterableType", this.getIterableType());
 		b.add("templateDataAnnotations", this.getTemplateDataAnnotations());

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/QuteSupportForTemplate.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/QuteSupportForTemplate.java
@@ -359,6 +359,9 @@ public class QuteSupportForTemplate {
 		}
 
 		ITypeResolver typeResolver = createTypeResolver(type);
+		
+		// Find if the type is a source or binary file
+		boolean isTypeSource = !type.isBinary();
 
 		// 1) Collect fields
 		List<JavaFieldInfo> fieldsInfo = new ArrayList<>();
@@ -430,6 +433,7 @@ public class QuteSupportForTemplate {
 
 		ResolvedJavaTypeInfo resolvedType = new ResolvedJavaTypeInfo();
 		String typeSignature = AbstractTypeResolver.resolveJavaTypeSignature(type);
+		resolvedType.setSource(isTypeSource);
 		resolvedType.setSignature(typeSignature);
 		resolvedType.setFields(fieldsInfo);
 		resolvedType.setMethods(methodsInfo);

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/ls/QuteSupportForTemplateDelegateCommandHandler.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/ls/QuteSupportForTemplateDelegateCommandHandler.java
@@ -217,12 +217,12 @@ public class QuteSupportForTemplateDelegateCommandHandler extends AbstractQuteDe
 	private static ResolvedJavaTypeInfo getResolvedJavaType(List<Object> arguments, String commandId,
 			IProgressMonitor monitor) throws JavaModelException, CoreException {
 		// Create java file information parameter
-		QuteResolvedJavaTypeParams params = createQuteResolvedJavaTyeParams(arguments, commandId);
+		QuteResolvedJavaTypeParams params = createQuteResolvedJavaTypeParams(arguments, commandId);
 		// Return file information from the parameter
 		return QuteSupportForTemplate.getInstance().getResolvedJavaType(params, JDTUtilsLSImpl.getInstance(), monitor);
 	}
 
-	private static QuteResolvedJavaTypeParams createQuteResolvedJavaTyeParams(List<Object> arguments,
+	private static QuteResolvedJavaTypeParams createQuteResolvedJavaTypeParams(List<Object> arguments,
 			String commandId) {
 		Map<String, Object> obj = getFirst(arguments);
 		if (obj == null) {

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/GenerateMissingJavaMemberParams.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/GenerateMissingJavaMemberParams.java
@@ -9,6 +9,8 @@
 *******************************************************************************/
 package com.redhat.qute.commons;
 
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
 /**
  * Parameters required for generating a field, getter, or template extension in
  * a Java type.
@@ -96,6 +98,29 @@ public class GenerateMissingJavaMemberParams {
 
 	public void setProjectUri(String projectUri) {
 		this.projectUri = projectUri;
+	}
+
+	@Override
+	public String toString() {
+		ToStringBuilder builder = new ToStringBuilder(this);
+		builder.add("memberType", memberType);
+		builder.add("missingProperty", missingProperty);
+		builder.add("javaType", javaType);
+		builder.add("projectUri", projectUri);
+		return builder.toString();
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (other == null || !(other instanceof GenerateMissingJavaMemberParams)) {
+			return false;
+		}
+		GenerateMissingJavaMemberParams that = (GenerateMissingJavaMemberParams) other;
+		return (this.memberType == that.memberType) //
+				&& ((this.missingProperty == null && that.missingProperty == null)
+						|| this.missingProperty.equals(that.missingProperty)) //
+				&& ((this.javaType == null && that.javaType == null) || this.javaType.equals(that.javaType)) //
+				&& ((this.projectUri == null && that.projectUri == null) || this.projectUri.equals(that.projectUri));
 	}
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/ResolvedJavaTypeInfo.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/ResolvedJavaTypeInfo.java
@@ -43,6 +43,8 @@ public class ResolvedJavaTypeInfo extends JavaTypeInfo {
 
 	private Boolean isIterable;
 
+	private Boolean source;
+
 	private RegisterForReflectionAnnotation registerForReflectionAnnotation;
 
 	private List<TemplateDataAnnotation> templateDataAnnotations;
@@ -152,6 +154,26 @@ public class ResolvedJavaTypeInfo extends JavaTypeInfo {
 	}
 
 	/**
+	 * Returns true if this Java type is in a user modifiable source file, and false
+	 * otherwise.
+	 * 
+	 * @return true if this Java type is in a user modifiable source file, and false
+	 *         otherwise
+	 */
+	public boolean isSource() {
+		return source != null && source.booleanValue();
+	}
+
+	/**
+	 * Set if this type comes from a source file.
+	 * 
+	 * @param source true if the type comes from a source file, false otherwise
+	 */
+	public void setSource(Boolean source) {
+		this.source = source;
+	}
+
+	/**
 	 * Returns true if the Java type is an integer and false otherwise.
 	 * 
 	 * @return true if the Java type is an integer and false otherwise.
@@ -234,6 +256,7 @@ public class ResolvedJavaTypeInfo extends JavaTypeInfo {
 		ToStringBuilder b = new ToStringBuilder(this);
 		b.add("name", this.getName());
 		b.add("signature", this.getSignature());
+		b.add("source", this.isSource() ? "SOURCE" : "BINARY");
 		b.add("iterableOf", this.getIterableOf());
 		b.add("iterableType", this.getIterableType());
 		b.add("templateDataAnnotations", this.getTemplateDataAnnotations());

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/CodeActionFactory.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/CodeActionFactory.java
@@ -218,6 +218,7 @@ public class CodeActionFactory {
 		CodeAction codeAction = new CodeAction(title);
 		codeAction.setData(data);
 		codeAction.setKind(CodeActionKind.QuickFix);
+		codeAction.setDiagnostics(diagnostics);
 		return codeAction;
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteCodeActions.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteCodeActions.java
@@ -435,48 +435,47 @@ class QuteCodeActions {
 
 		String projectUri = template.getProjectUri();
 
-		GenerateMissingJavaMemberParams publicFieldParams = new GenerateMissingJavaMemberParams(MemberType.Field,
-				missingProperty, resolvedType, projectUri);
-		GenerateMissingJavaMemberParams getterParams = new GenerateMissingJavaMemberParams(MemberType.Getter,
-				missingProperty, resolvedType, projectUri);
+		if (unknownPropertyData.isSource()) {
+			GenerateMissingJavaMemberParams publicFieldParams = new GenerateMissingJavaMemberParams(MemberType.Field,
+					missingProperty, resolvedType, projectUri);
+			GenerateMissingJavaMemberParams getterParams = new GenerateMissingJavaMemberParams(MemberType.Getter,
+					missingProperty, resolvedType, projectUri);
+			CodeAction createPublicField = createCodeActionWithData(
+					String.format(CREATE_PUBLIC_FIELD, missingProperty, resolvedType), publicFieldParams,
+					Collections.singletonList(diagnostic));
+			CodeAction createGetter = createCodeActionWithData(
+					String.format(CREATE_GETTER, propertyCapitalized, resolvedType), getterParams,
+					Collections.singletonList(diagnostic));
+			codeActions.add(createPublicField);
+			codeActions.add(createGetter);
+			registrations.add(resolver.generateMissingJavaMember(publicFieldParams) //
+					.thenAccept((workspaceEdit) -> {
+						if (workspaceEdit == null) {
+							return;
+						}
+						createPublicField.setEdit(workspaceEdit);
+					}));
+
+			registrations.add(resolver.generateMissingJavaMember(getterParams) //
+					.thenAccept((workspaceEdit) -> {
+						if (workspaceEdit == null) {
+							return;
+						}
+						createGetter.setEdit(workspaceEdit);
+					}));
+		}
 		GenerateMissingJavaMemberParams appendToTemplateExtensionsParams = new GenerateMissingJavaMemberParams(
 				MemberType.AppendTemplateExtension, missingProperty, resolvedType, projectUri);
 		GenerateMissingJavaMemberParams createTemplateExtensionsParams = new GenerateMissingJavaMemberParams(
 				MemberType.CreateTemplateExtension, missingProperty, resolvedType, projectUri);
-
-		CodeAction createPublicField = createCodeActionWithData(
-				String.format(CREATE_PUBLIC_FIELD, missingProperty, resolvedType), publicFieldParams,
-				Collections.singletonList(diagnostic));
-		CodeAction createGetter = createCodeActionWithData(
-				String.format(CREATE_GETTER, propertyCapitalized, resolvedType), getterParams,
-				Collections.singletonList(diagnostic));
 		CodeAction appendToTemplateExtensions = createCodeActionWithData(
 				String.format(APPEND_TO_TEMPLATE_EXTENSIONS, missingProperty), appendToTemplateExtensionsParams,
 				Collections.singletonList(diagnostic));
 		CodeAction createTemplateExtensions = createCodeActionWithData(
 				String.format(CREATE_TEMPLATE_EXTENSIONS, missingProperty), createTemplateExtensionsParams,
 				Collections.singletonList(diagnostic));
-		codeActions.add(createPublicField);
-		codeActions.add(createGetter);
 		codeActions.add(appendToTemplateExtensions);
 		codeActions.add(createTemplateExtensions);
-
-		registrations.add(resolver.generateMissingJavaMember(publicFieldParams) //
-				.thenAccept((workspaceEdit) -> {
-					if (workspaceEdit == null) {
-						return;
-					}
-					createPublicField.setEdit(workspaceEdit);
-				}));
-
-		registrations.add(resolver.generateMissingJavaMember(getterParams) //
-				.thenAccept((workspaceEdit) -> {
-					if (workspaceEdit == null) {
-						return;
-					}
-					createGetter.setEdit(workspaceEdit);
-				}));
-
 		registrations.add(resolver.generateMissingJavaMember(appendToTemplateExtensionsParams) //
 				.thenAccept((workspaceEdit) -> {
 					if (workspaceEdit == null) {
@@ -492,6 +491,7 @@ class QuteCodeActions {
 					}
 					createTemplateExtensions.setEdit(workspaceEdit);
 				}));
+
 
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteDiagnostics.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteDiagnostics.java
@@ -708,7 +708,7 @@ class QuteDiagnostics {
 			String property = part.getPartName();
 			Diagnostic diagnostic = createDiagnostic(range, DiagnosticSeverity.Error, QuteErrorCode.UnknownProperty,
 					property, signature);
-			diagnostic.setData(new UnknownPropertyData(signature, property));
+			diagnostic.setData(new UnknownPropertyData(signature, property, baseType.isSource()));
 			diagnostics.add(diagnostic);
 			return null;
 		} else if (canValidateMemberInNativeMode(filter, javaMember)) {

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/diagnostics/UnknownPropertyData.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/diagnostics/UnknownPropertyData.java
@@ -9,6 +9,8 @@
 *******************************************************************************/
 package com.redhat.qute.services.diagnostics;
 
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
 /**
  * Represents the data needed to create a "create missing member" CodeAction
  *
@@ -18,10 +20,12 @@ public class UnknownPropertyData {
 
 	private String signature;
 	private String property;
+	private Boolean source;
 
-	public UnknownPropertyData(String signature, String property) {
+	public UnknownPropertyData(String signature, String property, Boolean source) {
 		this.signature = signature;
 		this.property = property;
+		this.source = source;
 	}
 
 	public String getSignature() {
@@ -32,9 +36,13 @@ public class UnknownPropertyData {
 		return this.property;
 	}
 
+	public Boolean isSource() {
+		return source != null && this.source.booleanValue();
+	}
+
 	@Override
 	public UnknownPropertyData clone() {
-		return new UnknownPropertyData(signature, property);
+		return new UnknownPropertyData(signature, property, source);
 	}
 
 	@Override
@@ -43,8 +51,20 @@ public class UnknownPropertyData {
 			return false;
 		}
 		UnknownPropertyData otherCast = (UnknownPropertyData) other;
-		return (this.property.equals(otherCast.property))
-				&& (this.signature.equals(otherCast.signature));
+		return ((this.property == null && otherCast.property == null) || (this.property.equals(otherCast.property)))
+				&& ((this.signature == null && otherCast.signature == null)
+						|| (this.signature.equals(otherCast.signature)))
+				&& ((this.source == null && otherCast.source == null)
+						|| (this.source.booleanValue() == otherCast.source.booleanValue()));
+	}
+
+	@Override
+	public String toString() {
+		ToStringBuilder builder = new ToStringBuilder(this);
+		builder.add("signature", signature);
+		builder.add("property", property);
+		builder.add("source", source);
+		return builder.toString();
 	}
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/MockQuteProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/MockQuteProject.java
@@ -106,15 +106,16 @@ public abstract class MockQuteProject extends QuteProject {
 		return typeInfo;
 	}
 
-	protected static ResolvedJavaTypeInfo createResolvedJavaTypeInfo(String typeName, List<ResolvedJavaTypeInfo> cache,
+	protected static ResolvedJavaTypeInfo createResolvedJavaTypeInfo(String typeName, List<ResolvedJavaTypeInfo> cache, boolean isSource,
 			ResolvedJavaTypeInfo... extended) {
-		return createResolvedJavaTypeInfo(typeName, null, null, cache, extended);
+		return createResolvedJavaTypeInfo(typeName, null, null, cache, isSource, extended);
 	}
 
 	protected static ResolvedJavaTypeInfo createResolvedJavaTypeInfo(String signature, String iterableType,
-			String iterableOf, List<ResolvedJavaTypeInfo> cache, ResolvedJavaTypeInfo... extended) {
+			String iterableOf, List<ResolvedJavaTypeInfo> cache, boolean isSource, ResolvedJavaTypeInfo... extended) {
 		ResolvedJavaTypeInfo resolvedType = new ResolvedJavaTypeInfo();
 		resolvedType.setKind(JavaTypeKind.Class);
+		resolvedType.setSource(isSource);
 		resolvedType.setSignature(signature);
 		resolvedType.setIterableType(iterableType);
 		resolvedType.setIterableOf(iterableOf);

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/QuteQuickStartProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/QuteQuickStartProject.java
@@ -53,11 +53,11 @@ public class QuteQuickStartProject extends MockQuteProject {
 	protected List<ResolvedJavaTypeInfo> createResolvedTypes() {
 		List<ResolvedJavaTypeInfo> cache = new ArrayList<>();
 
-		createResolvedJavaTypeInfo("org.acme", cache).setKind(JavaTypeKind.Package);
+		createResolvedJavaTypeInfo("org.acme", cache, true).setKind(JavaTypeKind.Package);
 
-		createResolvedJavaTypeInfo("java.lang.Object", cache);
+		createResolvedJavaTypeInfo("java.lang.Object", cache, false);
 
-		ResolvedJavaTypeInfo string = createResolvedJavaTypeInfo("java.lang.String", cache);
+		ResolvedJavaTypeInfo string = createResolvedJavaTypeInfo("java.lang.String", cache, false);
 		registerField("UTF16 : byte", string);
 		registerMethod("isEmpty() : boolean", string);
 		registerMethod("codePointCount(beginIndex : int,endIndex : int) : int", string);
@@ -67,36 +67,36 @@ public class QuteQuickStartProject extends MockQuteProject {
 		registerMethod("getBytes(charsetName : java.lang.String) : byte[]", string);
 		registerMethod("getBytes() : byte[]", string);
 
-		createResolvedJavaTypeInfo("java.lang.Boolean", cache);
-		createResolvedJavaTypeInfo("java.lang.Integer", cache);
-		createResolvedJavaTypeInfo("java.lang.Double", cache);
-		createResolvedJavaTypeInfo("java.lang.Long", cache);
-		createResolvedJavaTypeInfo("java.lang.Float", cache);
-		createResolvedJavaTypeInfo("java.math.BigDecimal", cache);
+		createResolvedJavaTypeInfo("java.lang.Boolean", cache, false);
+		createResolvedJavaTypeInfo("java.lang.Integer", cache, false);
+		createResolvedJavaTypeInfo("java.lang.Double", cache, false);
+		createResolvedJavaTypeInfo("java.lang.Long", cache, false);
+		createResolvedJavaTypeInfo("java.lang.Float", cache, false);
+		createResolvedJavaTypeInfo("java.math.BigDecimal", cache, false);
 
-		ResolvedJavaTypeInfo bigInteger = createResolvedJavaTypeInfo("java.math.BigInteger", cache);
+		ResolvedJavaTypeInfo bigInteger = createResolvedJavaTypeInfo("java.math.BigInteger", cache, false);
 		registerMethod("divide(val : java.math.BigInteger) : java.math.BigInteger", bigInteger);
 
-		ResolvedJavaTypeInfo bean = createResolvedJavaTypeInfo("org.acme.Bean", cache);
+		ResolvedJavaTypeInfo bean = createResolvedJavaTypeInfo("org.acme.Bean", cache, true);
 		registerField("bean : java.lang.String", bean);
 
-		ResolvedJavaTypeInfo review = createResolvedJavaTypeInfo("org.acme.Review", cache);
+		ResolvedJavaTypeInfo review = createResolvedJavaTypeInfo("org.acme.Review", cache, true);
 		registerField("name : java.lang.String", review);
 		registerField("average : java.lang.Integer", review);
 		registerMethod("getReviews() : java.util.List<org.acme.Review>", review);
 
 		// Item <- BaseItem <- AbstractItem
-		ResolvedJavaTypeInfo abstractItem = createResolvedJavaTypeInfo("org.acme.AbstractItem", cache);
+		ResolvedJavaTypeInfo abstractItem = createResolvedJavaTypeInfo("org.acme.AbstractItem", cache, true);
 		registerField("abstractName : java.lang.String", abstractItem);
 		registerMethod("convert(item : org.acme.AbstractItem) : int", abstractItem);
 
-		ResolvedJavaTypeInfo baseItem = createResolvedJavaTypeInfo("org.acme.BaseItem", cache, abstractItem);
+		ResolvedJavaTypeInfo baseItem = createResolvedJavaTypeInfo("org.acme.BaseItem", cache, true, abstractItem);
 		registerField("base : java.lang.String", baseItem);
 		registerField("name : java.lang.String", baseItem);
 		registerMethod("getReviews() : java.util.List<org.acme.Review>", baseItem);
 
 		// org.acme.Item
-		ResolvedJavaTypeInfo item = createResolvedJavaTypeInfo("org.acme.Item", cache, baseItem);
+		ResolvedJavaTypeInfo item = createResolvedJavaTypeInfo("org.acme.Item", cache, true, baseItem);
 		registerField("name : java.lang.String", item); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", item);
 		registerField("review : org.acme.Review", item);
@@ -104,20 +104,20 @@ public class QuteQuickStartProject extends MockQuteProject {
 		registerMethod("getReview2() : org.acme.Review", item);
 		// Override BaseItem#getReviews()
 		registerMethod("getReviews() : java.util.List<org.acme.Review>", item);
-		createResolvedJavaTypeInfo("java.util.List<org.acme.Review>", "java.util.List", "org.acme.Review", cache);
+		createResolvedJavaTypeInfo("java.util.List<org.acme.Review>", "java.util.List", "org.acme.Review", cache, false, null);
 		registerField("derivedItems : java.util.List<org.acme.Item>", item);
 		registerField("derivedItemArray : org.acme.Item[]", item);
 		item.setInvalidMethod("staticMethod", InvalidMethodReason.Static); // public static BigDecimal
 																			// staticMethod(Item item)
 
-		createResolvedJavaTypeInfo("java.util.List<org.acme.Item>", "java.util.List", "org.acme.Item", cache);
-		createResolvedJavaTypeInfo("java.lang.Iterable<org.acme.Item>", "java.lang.Iterable", "org.acme.Item", cache);
-		createResolvedJavaTypeInfo("org.acme.Item[]", null, "org.acme.Item", cache);
+		createResolvedJavaTypeInfo("java.util.List<org.acme.Item>", "java.util.List", "org.acme.Item", cache, false);
+		createResolvedJavaTypeInfo("java.lang.Iterable<org.acme.Item>", "java.lang.Iterable", "org.acme.Item", cache, false);
+		createResolvedJavaTypeInfo("org.acme.Item[]", null, "org.acme.Item", cache, false);
 
 		// @TemplateData
 		// public class ItemWithTemplateData
 		ResolvedJavaTypeInfo itemWithTemplateData = createResolvedJavaTypeInfo("org.acme.ItemWithTemplateData", cache,
-				baseItem);
+				true, baseItem);
 		registerField("name : java.lang.String", itemWithTemplateData); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithTemplateData);
 		registerMethod("getReview2() : org.acme.Review", itemWithTemplateData);
@@ -128,7 +128,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @TemplateData(target = BigInteger.class)
 		// public class ItemWithTemplateDataWithTarget
 		ResolvedJavaTypeInfo itemWithTemplateDataWithTarget = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithTemplateDataWithTarget", cache, baseItem);
+				"org.acme.ItemWithTemplateDataWithTarget", cache, true, baseItem);
 		registerField("name : java.lang.String", itemWithTemplateDataWithTarget); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithTemplateDataWithTarget);
 		registerMethod("getReview2() : org.acme.Review", itemWithTemplateDataWithTarget);
@@ -141,7 +141,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @TemplateData(properties = true)
 		// public class ItemWithTemplateDataProperties
 		ResolvedJavaTypeInfo itemWithTemplateDataProperties = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithTemplateDataProperties", cache, baseItem);
+				"org.acme.ItemWithTemplateDataProperties", cache, true, baseItem);
 		registerField("name : java.lang.String", itemWithTemplateDataProperties); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithTemplateDataProperties);
 		registerMethod("getReview2() : org.acme.Review", itemWithTemplateDataProperties);
@@ -153,7 +153,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @TemplateData(ignoreSuperclasses = true)
 		// public class ItemWithTemplateDataIgnoreSubClasses
 		ResolvedJavaTypeInfo itemWithTemplateDataIgnoreSubClasses = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithTemplateDataIgnoreSubClasses", cache, baseItem);
+				"org.acme.ItemWithTemplateDataIgnoreSubClasses", cache, true, baseItem);
 		registerField("name : java.lang.String", itemWithTemplateDataIgnoreSubClasses); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithTemplateDataIgnoreSubClasses);
 		registerMethod("getReview2() : org.acme.Review", itemWithTemplateDataIgnoreSubClasses);
@@ -165,7 +165,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @RegisterForReflection
 		// public class ItemWithRegisterForReflection
 		ResolvedJavaTypeInfo itemWithRegisterForReflection = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithRegisterForReflection", cache, baseItem);
+				"org.acme.ItemWithRegisterForReflection", cache, true, baseItem);
 		registerField("name : java.lang.String", itemWithRegisterForReflection); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithRegisterForReflection);
 		registerMethod("getReview2() : org.acme.Review", itemWithRegisterForReflection);
@@ -175,7 +175,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @RegisterForReflection(fields = false)
 		// public class ItemWithRegisterForReflectionNoFields
 		ResolvedJavaTypeInfo itemWithRegisterForReflectionNoFields = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithRegisterForReflectionNoFields", cache, baseItem);
+				"org.acme.ItemWithRegisterForReflectionNoFields", cache, true, baseItem);
 		registerField("name : java.lang.String", itemWithRegisterForReflectionNoFields); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithRegisterForReflectionNoFields);
 		registerMethod("getReview2() : org.acme.Review", itemWithRegisterForReflectionNoFields);
@@ -186,7 +186,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @RegisterForReflection(methods = false)
 		// public class ItemWithRegisterForReflectionNoMethods
 		ResolvedJavaTypeInfo itemWithRegisterForReflectionNoMethods = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithRegisterForReflectionNoMethods", cache, baseItem);
+				"org.acme.ItemWithRegisterForReflectionNoMethods", cache, true, baseItem);
 		registerField("name : java.lang.String", itemWithRegisterForReflectionNoMethods); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithRegisterForReflectionNoMethods);
 		registerMethod("getReview2() : org.acme.Review", itemWithRegisterForReflectionNoMethods);
@@ -195,17 +195,17 @@ public class QuteQuickStartProject extends MockQuteProject {
 		itemWithRegisterForReflectionNoMethods.setRegisterForReflectionAnnotation(registerForReflectionAnnotation);
 
 		ResolvedJavaTypeInfo iterable = createResolvedJavaTypeInfo("java.lang.Iterable<T>", "java.lang.Iterable", "T",
-				cache);
+				cache, false);
 
-		ResolvedJavaTypeInfo list = createResolvedJavaTypeInfo("java.util.List<E>", "java.util.List", "E", cache);
+		ResolvedJavaTypeInfo list = createResolvedJavaTypeInfo("java.util.List<E>", "java.util.List", "E", cache, false);
 		list.setExtendedTypes(Arrays.asList("java.lang.Iterable"));
 		registerMethod("size() : int", list);
 		registerMethod("get(index : int) : E", list);
 
-		ResolvedJavaTypeInfo map = createResolvedJavaTypeInfo("java.util.Map", cache);
+		ResolvedJavaTypeInfo map = createResolvedJavaTypeInfo("java.util.Map", cache, false);
 
 		// RawString for raw and safe resolver tests
-		ResolvedJavaTypeInfo rawString = createResolvedJavaTypeInfo("io.quarkus.qute.RawString", cache);
+		ResolvedJavaTypeInfo rawString = createResolvedJavaTypeInfo("io.quarkus.qute.RawString", cache, false);
 		registerMethod("getValue() : java.lang.String", rawString);
 		registerMethod("toString() : java.lang.String", rawString);
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/arrays/ArrayLengthValueResolverTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/arrays/ArrayLengthValueResolverTest.java
@@ -46,7 +46,7 @@ public class ArrayLengthValueResolverTest {
 		testDiagnosticsFor(template, //
 				d(1, 7, 1, 16, QuteErrorCode.UnknownProperty,
 						"`lengthXXX` cannot be resolved or is not a field of `org.acme.Item[]` Java type.",
-						new UnknownPropertyData("org.acme.Item[]", "lengthXXX"),
+						new UnknownPropertyData("org.acme.Item[]", "lengthXXX", false),
 						DiagnosticSeverity.Error));
 
 		template = "{@java.util.List<org.acme.Item> items}\r\n" + //
@@ -54,7 +54,7 @@ public class ArrayLengthValueResolverTest {
 		testDiagnosticsFor(template, //
 				d(1, 7, 1, 13, QuteErrorCode.UnknownProperty,
 						"`length` cannot be resolved or is not a field of `java.util.List<E>` Java type.",
-						new UnknownPropertyData("java.util.List<E>", "length"),
+						new UnknownPropertyData("java.util.List<E>", "length", false),
 						DiagnosticSeverity.Error));
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/arrays/ArraySizeValueResolverTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/arrays/ArraySizeValueResolverTest.java
@@ -45,7 +45,7 @@ public class ArraySizeValueResolverTest {
 		testDiagnosticsFor(template, //
 				d(1, 7, 1, 14, QuteErrorCode.UnknownProperty,
 						"`sizeXXX` cannot be resolved or is not a field of `org.acme.Item[]` Java type.",
-						new UnknownPropertyData("org.acme.Item[]", "sizeXXX"),
+						new UnknownPropertyData("org.acme.Item[]", "sizeXXX", false),
 						DiagnosticSeverity.Error));
 
 		template = "{@java.util.List<org.acme.Item> items}\r\n" + //

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/arrays/ArrayTakeLastValueResolverTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/arrays/ArrayTakeLastValueResolverTest.java
@@ -49,7 +49,7 @@ public class ArrayTakeLastValueResolverTest {
 		testDiagnosticsFor(template, //
 				d(1, 19, 1, 28, QuteErrorCode.UnknownProperty,
 						"`lengthXXX` cannot be resolved or is not a field of `org.acme.Item[]` Java type.",
-						new UnknownPropertyData("org.acme.Item[]", "lengthXXX"),
+						new UnknownPropertyData("org.acme.Item[]", "lengthXXX", false),
 						DiagnosticSeverity.Error));
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/arrays/ArrayTakeValueResolverTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/arrays/ArrayTakeValueResolverTest.java
@@ -49,7 +49,7 @@ public class ArrayTakeValueResolverTest {
 		testDiagnosticsFor(template, //
 				d(1, 15, 1, 24, QuteErrorCode.UnknownProperty,
 						"`lengthXXX` cannot be resolved or is not a field of `org.acme.Item[]` Java type.",
-						new UnknownPropertyData("org.acme.Item[]", "lengthXXX"),
+						new UnknownPropertyData("org.acme.Item[]", "lengthXXX", false),
 						DiagnosticSeverity.Error));
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteGenerateMissingMemberCodeActionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteGenerateMissingMemberCodeActionTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.codeaction;
+
+import static com.redhat.qute.QuteAssert.d;
+import static com.redhat.qute.QuteAssert.testCodeActionsFor;
+import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
+
+import java.util.Arrays;
+
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.commons.GenerateMissingJavaMemberParams;
+import com.redhat.qute.commons.GenerateMissingJavaMemberParams.MemberType;
+import com.redhat.qute.services.diagnostics.QuteErrorCode;
+import com.redhat.qute.services.diagnostics.UnknownPropertyData;
+
+public class QuteGenerateMissingMemberCodeActionTest {
+
+	@Test
+	public void userGeneratedClass() throws Exception {
+		String template = "{@org.acme.Item item}\n" //
+				+"{item.asdf}\n";
+
+		Diagnostic d = d(1, 6, 1, 10, //
+				QuteErrorCode.UnknownProperty, //
+				"`asdf` cannot be resolved or is not a field of `org.acme.Item` Java type.", //
+				DiagnosticSeverity.Error);
+		d.setData(new UnknownPropertyData("org.acme.Item", "asdf", true));
+
+		testDiagnosticsFor(template, d);
+		testCodeActionsFor(template, d, //
+				ca(d, new GenerateMissingJavaMemberParams(MemberType.Field, "asdf", "org.acme.Item", "qute-quickstart")), //
+				ca(d, new GenerateMissingJavaMemberParams(MemberType.Getter, "asdf", "org.acme.Item", "qute-quickstart")), //
+				ca(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "asdf", "org.acme.Item", "qute-quickstart")), //
+				ca(d, new GenerateMissingJavaMemberParams(MemberType.CreateTemplateExtension, "asdf", "org.acme.Item", "qute-quickstart")));
+	}
+	
+	@Test
+	public void builtInClass() throws Exception {
+		String template = "{@java.lang.String item}\n" //
+				+"{item.asdf}\n";
+
+		Diagnostic d = d(1, 6, 1, 10, //
+				QuteErrorCode.UnknownProperty, //
+				"`asdf` cannot be resolved or is not a field of `java.lang.String` Java type.", //
+				DiagnosticSeverity.Error);
+		d.setData(new UnknownPropertyData("java.lang.String", "asdf", false));
+
+		testDiagnosticsFor(template, d);
+		testCodeActionsFor(template, d, //
+				ca(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "asdf", "java.lang.String", "qute-quickstart")), //
+				ca(d, new GenerateMissingJavaMemberParams(MemberType.CreateTemplateExtension, "asdf", "java.lang.String", "qute-quickstart")));
+	}
+	
+	private static CodeAction ca(Diagnostic d, Object data) {
+		CodeAction codeAction = new CodeAction("");
+		codeAction.setDiagnostics(Arrays.asList(d));
+		codeAction.setData(data);
+		return codeAction;
+	}
+	
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionTest.java
@@ -228,7 +228,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testDiagnosticsFor(template, //
 				d(1, 6, 1, 10, QuteErrorCode.UnknownProperty,
 						"`XXXX` cannot be resolved or is not a field of `org.acme.Item` Java type.",
-						new UnknownPropertyData("org.acme.Item", "XXXX"),
+						new UnknownPropertyData("org.acme.Item", "XXXX", true),
 						DiagnosticSeverity.Error));
 
 		template = "{@org.acme.Item item}\r\n" + //
@@ -236,7 +236,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testDiagnosticsFor(template, //
 				d(1, 6, 1, 10, QuteErrorCode.UnknownProperty,
 						"`XXXX` cannot be resolved or is not a field of `org.acme.Item` Java type.",
-						new UnknownPropertyData("org.acme.Item", "XXXX"),
+						new UnknownPropertyData("org.acme.Item", "XXXX", true),
 						DiagnosticSeverity.Error));
 
 		template = "{@org.acme.Item item}\r\n" + //
@@ -244,7 +244,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testDiagnosticsFor(template, //
 				d(1, 11, 1, 15, QuteErrorCode.UnknownProperty,
 						"`YYYY` cannot be resolved or is not a field of `java.lang.String` Java type.",
-						new UnknownPropertyData("java.lang.String", "YYYY"),
+						new UnknownPropertyData("java.lang.String", "YYYY", false),
 						DiagnosticSeverity.Error));
 	}
 
@@ -339,7 +339,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testDiagnosticsFor(template, //
 				d(1, 7, 1, 14, QuteErrorCode.UnknownProperty,
 						"`sizeXXX` cannot be resolved or is not a field of `java.util.List<E>` Java type.",
-						new UnknownPropertyData("java.util.List<E>", "sizeXXX"),
+						new UnknownPropertyData("java.util.List<E>", "sizeXXX", false),
 						DiagnosticSeverity.Error));
 
 		template = "{@java.util.List<org.acme.Item> items}\r\n" + //
@@ -356,7 +356,7 @@ public class QuteDiagnosticsInExpressionTest {
 				"{items.size.XXX}";
 		testDiagnosticsFor(template, d(1, 12, 1, 15, QuteErrorCode.UnknownProperty,
 				"`XXX` cannot be resolved or is not a field of `int` Java type.",
-				new UnknownPropertyData("int", "XXX"),
+				new UnknownPropertyData("int", "XXX", false),
 				DiagnosticSeverity.Error));
 	}
 
@@ -690,7 +690,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testDiagnosticsFor(template, //
 				d(1, 8, 1, 12, QuteErrorCode.UnknownProperty,
 						"`XXXX` cannot be resolved or is not a field of `org.acme.Item` Java type.",
-						new UnknownPropertyData("org.acme.Item", "XXXX"),
+						new UnknownPropertyData("org.acme.Item", "XXXX", true),
 						DiagnosticSeverity.Error));
 	}
 
@@ -728,7 +728,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testDiagnosticsFor(template, //
 				d(0, 8, 0, 12, QuteErrorCode.UnknownProperty,
 						"`XXXX` cannot be resolved or is not a field of `java.lang.String` Java type.",
-						new UnknownPropertyData("java.lang.String", "XXXX"),
+						new UnknownPropertyData("java.lang.String", "XXXX", false),
 						DiagnosticSeverity.Error));
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithEachSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithEachSectionTest.java
@@ -63,7 +63,7 @@ public class QuteDiagnosticsInExpressionWithEachSectionTest {
 		testDiagnosticsFor(template, //
 				d(3, 5, 3, 12, QuteErrorCode.UnknownProperty,
 						"`nameXXX` cannot be resolved or is not a field of `org.acme.Item` Java type.",
-						new UnknownPropertyData("org.acme.Item", "nameXXX"),
+						new UnknownPropertyData("org.acme.Item", "nameXXX", true),
 						DiagnosticSeverity.Error));
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithForSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithForSectionTest.java
@@ -108,7 +108,8 @@ public class QuteDiagnosticsInExpressionWithForSectionTest {
 		testDiagnosticsFor(template, //
 				d(3, 7, 3, 14, QuteErrorCode.UnknownProperty,
 						"`nameXXX` cannot be resolved or is not a field of `org.acme.Item` Java type.",
-						new UnknownPropertyData("org.acme.Item", "nameXXX"), DiagnosticSeverity.Error));
+						new UnknownPropertyData("org.acme.Item", "nameXXX", true),
+						DiagnosticSeverity.Error));
 	}
 
 	@Test

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithNamespaceTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithNamespaceTest.java
@@ -104,7 +104,7 @@ public class QuteDiagnosticsInExpressionWithNamespaceTest {
 		testDiagnosticsFor(template,
 				d(0, 13, 0, 17, QuteErrorCode.UnknownProperty,
 						"`XXXX` cannot be resolved or is not a field of `java.lang.String` Java type.",
-						new UnknownPropertyData("java.lang.String", "XXXX"),
+						new UnknownPropertyData("java.lang.String", "XXXX", false),
 						DiagnosticSeverity.Error));
 
 		template = "{inject:bean.XXXX()}";


### PR DESCRIPTION
When generating CodeActions for missing properties that are referenced in a Qute template, don't suggest adding a field or adding a getter when the type that is being referred to is a binary type (i.e. built-in class or class from an external library).

Similarly, don't suggest creating a template extension for a type whose source code is available.

Fixes #676

Signed-off-by: David Thompson <davthomp@redhat.com>