### PR TITLE
Do not give CodeActions for stale diagnostics

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/ValidatorDelayer.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/ValidatorDelayer.java
@@ -83,4 +83,16 @@ public class ValidatorDelayer<T extends TextDocument> {
             }
         }
     }
+
+    /**
+	 * Returns true if the document has a revalidation pending and false otherwise.
+	 *
+	 * @param uri the uri of the document to check
+	 * @return true if the document has a revalidation pending and false otherwise
+	 */
+	public boolean isRevalidating(String uri) {
+		synchronized (pendingValidationRequests) {
+			return pendingValidationRequests.containsKey(uri);
+		}
+	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/template/TemplateFileTextDocumentService.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/template/TemplateFileTextDocumentService.java
@@ -153,6 +153,9 @@ public class TemplateFileTextDocumentService extends AbstractTextDocumentService
 
 	@Override
 	public CompletableFuture<List<Either<Command, CodeAction>>> codeAction(CodeActionParams params) {
+		if (validatorDelayer.isRevalidating(params.getTextDocument().getUri())) {
+			return CompletableFuture.completedFuture((List<Either<Command, CodeAction>>) Collections.EMPTY_LIST);
+		}
 		return getTemplateCompose(params.getTextDocument(),
 				(template, cancelChecker) -> {
 					// Cancel checker is not passed to doCodeActions, since code actions don't yet


### PR DESCRIPTION
Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

See https://github.com/eclipse/lsp4mp/pull/273 . It turns out we have the same issue in Qute templates. As @angelozerr mentions, if you have a template like :

```
{#for item in items}
{/for}
```

and change `items` quickly, it can occur.

```
[Error - 2:59:06 p.m.] Request textDocument/codeAction failed.
  Message: Internal error.
  Code: -32603 
java.util.concurrent.CompletionException: java.lang.ClassCastException: class com.redhat.qute.parser.template.sections.ForSection cannot be cast to class com.redhat.qute.parser.expression.ObjectPart (com.redhat.qute.parser.template.sections.ForSection and com.redhat.qute.parser.expression.ObjectPart are in unnamed module of loader 'app')
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture$UniCompose.tryFire(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
Caused by: java.lang.ClassCastException: class com.redhat.qute.parser.template.sections.ForSection cannot be cast to class com.redhat.qute.parser.expression.ObjectPart (com.redhat.qute.parser.template.sections.ForSection and com.redhat.qute.parser.expression.ObjectPart are in unnamed module of loader 'app')
	at com.redhat.qute.services.codeactions.QuteCodeActionForUndefinedObject.doCodeActions(QuteCodeActionForUndefinedObject.java:77)
	at com.redhat.qute.services.QuteCodeActions.doCodeActions(QuteCodeActions.java:98)
	at com.redhat.qute.services.QuteLanguageService.doCodeActions(QuteLanguageService.java:101)
	at com.redhat.qute.ls.template.TemplateFileTextDocumentService.lambda$codeAction$9(TemplateFileTextDocumentService.java:161)
	at com.redhat.qute.ls.commons.ModelTextDocuments.lambda$computeModelAsyncCompose$1(ModelTextDocuments.java:144)
	... 7 more
```
