### PR TITLE
Generate one CodeAction for each template extensions class

### DIFF
--- a/qute.jdt/com.redhat.qute.jdt.test/src/main/java/com/redhat/qute/jdt/template/TemplateGenerateMissingJavaMemberTest.java
+++ b/qute.jdt/com.redhat.qute.jdt.test/src/main/java/com/redhat/qute/jdt/template/TemplateGenerateMissingJavaMemberTest.java
@@ -187,7 +187,7 @@ public class TemplateGenerateMissingJavaMemberTest {
 		IJavaProject project = loadMavenProject(QuteMavenProjectName.qute_quickstart);
 		GenerateMissingJavaMemberParams params = new GenerateMissingJavaMemberParams(
 				GenerateMissingJavaMemberParams.MemberType.AppendTemplateExtension, "asdf", "org.acme.qute.Item",
-				QuteMavenProjectName.qute_quickstart);
+				QuteMavenProjectName.qute_quickstart, "org.acme.qute.MyTemplateExtensions");
 		WorkspaceEdit actual = QuteSupportForTemplate.getInstance().generateMissingJavaMember(params, getJDTUtils(),
 				new NullProgressMonitor());
 		WorkspaceEdit expected = we(Either.forLeft(tde(project, "src/main/java/org/acme/qute/MyTemplateExtensions.java",

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/GenerateMissingJavaMemberParams.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/GenerateMissingJavaMemberParams.java
@@ -46,6 +46,7 @@ public class GenerateMissingJavaMemberParams {
 	private String missingProperty;
 	private String javaType;
 	private String projectUri;
+	private String templateClass;
 
 	public GenerateMissingJavaMemberParams() {
 		this(null, null, null, null);
@@ -59,13 +60,30 @@ public class GenerateMissingJavaMemberParams {
 	 * @param missingProperty the name of the java member that's missing
 	 * @param javaType        the java type to generate the missing member in
 	 * @param projectUri      the uri of the project
+	 * @param templateClass   the template class to generate the member in (when
+	 *                        {@code memberType == MemberType.AppendTemplateExtension})
 	 */
 	public GenerateMissingJavaMemberParams(MemberType memberType, String missingProperty, String javaType,
-			String projectUri) {
+			String projectUri, String templateClass) {
 		this.memberType = memberType;
 		this.missingProperty = missingProperty;
 		this.javaType = javaType;
 		this.projectUri = projectUri;
+		this.templateClass = templateClass;
+	}
+
+	/**
+	 * Returns the parameters for generate a missing java member that is referenced
+	 * in a template but doesn't exist.
+	 * 
+	 * @param memberType      the type of member to generate
+	 * @param missingProperty the name of the java member that's missing
+	 * @param javaType        the java type to generate the missing member in
+	 * @param projectUri      the uri of the project
+	 */
+	public GenerateMissingJavaMemberParams(MemberType memberType, String missingProperty, String javaType,
+			String projectUri) {
+		this(memberType, missingProperty, javaType, projectUri, null);
 	}
 
 	public MemberType getMemberType() {
@@ -100,6 +118,14 @@ public class GenerateMissingJavaMemberParams {
 		this.projectUri = projectUri;
 	}
 
+	public String getTemplateClass() {
+		return this.templateClass;
+	}
+
+	public void setTemplateClass(String templateClass) {
+		this.templateClass = templateClass;
+	}
+
 	@Override
 	public String toString() {
 		ToStringBuilder builder = new ToStringBuilder(this);
@@ -107,6 +133,7 @@ public class GenerateMissingJavaMemberParams {
 		builder.add("missingProperty", missingProperty);
 		builder.add("javaType", javaType);
 		builder.add("projectUri", projectUri);
+		builder.add("templateClass", templateClass);
 		return builder.toString();
 	}
 
@@ -120,7 +147,9 @@ public class GenerateMissingJavaMemberParams {
 				&& ((this.missingProperty == null && that.missingProperty == null)
 						|| this.missingProperty.equals(that.missingProperty)) //
 				&& ((this.javaType == null && that.javaType == null) || this.javaType.equals(that.javaType)) //
-				&& ((this.projectUri == null && that.projectUri == null) || this.projectUri.equals(that.projectUri));
+				&& ((this.projectUri == null && that.projectUri == null) || this.projectUri.equals(that.projectUri)) //
+				&& ((this.templateClass == null && that.templateClass == null)
+						|| this.templateClass.equals(that.templateClass));
 	}
 
 }

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/ResolvedJavaTypeInfo.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/ResolvedJavaTypeInfo.java
@@ -43,7 +43,7 @@ public class ResolvedJavaTypeInfo extends JavaTypeInfo {
 
 	private Boolean isIterable;
 
-	private Boolean source;
+	private Boolean binary;
 
 	private RegisterForReflectionAnnotation registerForReflectionAnnotation;
 
@@ -154,23 +154,23 @@ public class ResolvedJavaTypeInfo extends JavaTypeInfo {
 	}
 
 	/**
-	 * Returns true if this Java type is in a user modifiable source file, and false
+	 * Returns true if this Java type is in a binary file, and false
 	 * otherwise.
 	 * 
-	 * @return true if this Java type is in a user modifiable source file, and false
+	 * @return true if this Java type is in a binary file, and false
 	 *         otherwise
 	 */
-	public boolean isSource() {
-		return source != null && source.booleanValue();
+	public boolean isBinary() {
+		return binary != null && binary.booleanValue();
 	}
 
 	/**
-	 * Set if this type comes from a source file.
+	 * Set if this type comes from a binary file.
 	 * 
-	 * @param source true if the type comes from a source file, false otherwise
+	 * @param binary true if the type comes from a binary file, false otherwise
 	 */
-	public void setSource(Boolean source) {
-		this.source = source;
+	public void setBinary(Boolean binary) {
+		this.binary = binary;
 	}
 
 	/**
@@ -256,7 +256,7 @@ public class ResolvedJavaTypeInfo extends JavaTypeInfo {
 		ToStringBuilder b = new ToStringBuilder(this);
 		b.add("name", this.getName());
 		b.add("signature", this.getSignature());
-		b.add("source", this.isSource() ? "SOURCE" : "BINARY");
+		b.add("binary", this.isBinary() ? "BINARY" : "SOURCE");
 		b.add("iterableOf", this.getIterableOf());
 		b.add("iterableType", this.getIterableType());
 		b.add("templateDataAnnotations", this.getTemplateDataAnnotations());

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/datamodel/resolvers/ValueResolverInfo.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/datamodel/resolvers/ValueResolverInfo.java
@@ -32,6 +32,10 @@ public class ValueResolverInfo {
 	private String signature;
 
 	private String sourceType;
+	
+	private Boolean binary;
+	
+	private ValueResolverKind kind;
 
 	private Boolean globalVariable;
 
@@ -113,6 +117,42 @@ public class ValueResolverInfo {
 	 */
 	public void setSourceType(String sourceType) {
 		this.sourceType = sourceType;
+	}
+	
+	/**
+	 * Returns true if the source type is a source file and false otherwise.
+	 * 
+	 * @return true if the source type is a source file and false otherwise
+	 */
+	public boolean isBinary() {
+		return binary != null && binary.booleanValue();
+	}
+	
+	/**
+	 * Sets if the source type is a binary file.
+	 * 
+	 * @param binary true if the source type is a binary file and false otherwise
+	 */
+	public void setBinary(boolean binary) {
+		this.binary = binary;
+	}
+	
+	/**
+	 * Returns the kind of the value resolver.
+	 * 
+	 * @return the kind of the value resolver
+	 */
+	public ValueResolverKind getKind() {
+		return this.kind;
+	}
+	
+	/**
+	 * Sets the kind of the value resolver.
+	 * 
+	 * @param kind the kind of the value resolver
+	 */
+	public void setKind(ValueResolverKind kind) {
+		this.kind = kind;
 	}
 
 	/**

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/datamodel/resolvers/ValueResolverKind.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/datamodel/resolvers/ValueResolverKind.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.commons.datamodel.resolvers;
+
+/**
+ * Represents the kind of a value resolver.
+ * 
+ * @author datho7561
+ */
+public enum ValueResolverKind {
+	TemplateData(0), //
+	TemplateEnum(1), //
+	TemplateExtensionOnMethod(2), //
+	TemplateExtensionOnClass(3), //
+	TemplateGlobal(4), //
+	InjectedBean(5);
+
+	private final int value;
+
+	ValueResolverKind(int value) {
+		this.value = value;
+	}
+
+	public int getValue() {
+		return value;
+	}
+
+	public static ValueResolverKind forValue(int value) {
+		ValueResolverKind[] allValues = ValueResolverKind.values();
+		if (value < 1 || value > allValues.length)
+			throw new IllegalArgumentException("Illegal enum value: " + value);
+		return allValues[value - 1];
+	}
+
+	public String toString() {
+		return this.name();
+	}
+
+}

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/QuteSupportForTemplate.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/QuteSupportForTemplate.java
@@ -359,9 +359,6 @@ public class QuteSupportForTemplate {
 		}
 
 		ITypeResolver typeResolver = createTypeResolver(type);
-		
-		// Find if the type is a source or binary file
-		boolean isTypeSource = !type.isBinary();
 
 		// 1) Collect fields
 		List<JavaFieldInfo> fieldsInfo = new ArrayList<>();
@@ -433,7 +430,7 @@ public class QuteSupportForTemplate {
 
 		ResolvedJavaTypeInfo resolvedType = new ResolvedJavaTypeInfo();
 		String typeSignature = AbstractTypeResolver.resolveJavaTypeSignature(type);
-		resolvedType.setSource(isTypeSource);
+		resolvedType.setBinary(type.isBinary());
 		resolvedType.setSignature(typeSignature);
 		resolvedType.setFields(fieldsInfo);
 		resolvedType.setMethods(methodsInfo);

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/quarkus/InjectNamespaceResolverSupport.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/quarkus/InjectNamespaceResolverSupport.java
@@ -27,6 +27,7 @@ import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 
 import com.redhat.qute.commons.datamodel.resolvers.ValueResolverInfo;
+import com.redhat.qute.commons.datamodel.resolvers.ValueResolverKind;
 import com.redhat.qute.jdt.QuteSupportForTemplate;
 import com.redhat.qute.jdt.internal.resolver.ITypeResolver;
 import com.redhat.qute.jdt.template.datamodel.AbstractAnnotationTypeReferenceDataModelProvider;
@@ -115,6 +116,7 @@ public class InjectNamespaceResolverSupport extends AbstractAnnotationTypeRefere
 		resolver.setSourceType(type.getFullyQualifiedName());
 		resolver.setSignature(type.getFullyQualifiedName());
 		resolver.setNamespace(INJECT_NAMESPACE);
+		resolver.setKind(ValueResolverKind.InjectedBean);
 		resolvers.add(resolver);
 	}
 
@@ -125,6 +127,7 @@ public class InjectNamespaceResolverSupport extends AbstractAnnotationTypeRefere
 		resolver.setSourceType(javaMember.getDeclaringType().getFullyQualifiedName());
 		resolver.setSignature(typeResolver.resolveSignature(javaMember));
 		resolver.setNamespace(INJECT_NAMESPACE);
+		resolver.setKind(ValueResolverKind.InjectedBean);
 		resolvers.add(resolver);
 	}
 

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/ls/QuteSupportForTemplateDelegateCommandHandler.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/ls/QuteSupportForTemplateDelegateCommandHandler.java
@@ -370,7 +370,15 @@ public class QuteSupportForTemplateDelegateCommandHandler extends AbstractQuteDe
 					commandId));
 		}
 
-		return new GenerateMissingJavaMemberParams(memberType, missingProperty, javaType, projectUri);
+		String templateClass = getString(obj, "templateClass");
+		if (templateClass == null && memberType == GenerateMissingJavaMemberParams.MemberType.AppendTemplateExtension) {
+			throw new UnsupportedOperationException(String.format(
+					"Command '%s' must be called with required GenerateMissingJavaMemberParams.templateClass when memberType == memberType.AppendTemplateExtension !",
+					commandId));
+		}
+
+		
+		return new GenerateMissingJavaMemberParams(memberType, missingProperty, javaType, projectUri, templateClass);
 
 	}
 

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/template/datamodel/TemplateDataAnnotationSupport.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/template/datamodel/TemplateDataAnnotationSupport.java
@@ -29,6 +29,7 @@ import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 
 import com.redhat.qute.commons.datamodel.resolvers.ValueResolverInfo;
+import com.redhat.qute.commons.datamodel.resolvers.ValueResolverKind;
 import com.redhat.qute.jdt.QuteSupportForTemplate;
 import com.redhat.qute.jdt.internal.resolver.ITypeResolver;
 import com.redhat.qute.jdt.template.datamodel.AbstractAnnotationTypeReferenceDataModelProvider;
@@ -131,6 +132,7 @@ public class TemplateDataAnnotationSupport extends AbstractAnnotationTypeReferen
 				resolver.setSourceType(sourceType);
 				resolver.setSignature(typeResolver.resolveSignature(member));
 				resolver.setNamespace(StringUtils.isNotEmpty(namespace) ? namespace : sourceType.replace('.', '_'));
+				resolver.setKind(ValueResolverKind.TemplateData);
 				if (!resolvers.contains(resolver)) {
 					resolvers.add(resolver);
 				}

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/template/datamodel/TemplateEnumAnnotationSupport.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/template/datamodel/TemplateEnumAnnotationSupport.java
@@ -27,6 +27,7 @@ import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 
 import com.redhat.qute.commons.datamodel.resolvers.ValueResolverInfo;
+import com.redhat.qute.commons.datamodel.resolvers.ValueResolverKind;
 import com.redhat.qute.jdt.QuteSupportForTemplate;
 import com.redhat.qute.jdt.internal.resolver.ITypeResolver;
 import com.redhat.qute.jdt.template.datamodel.AbstractAnnotationTypeReferenceDataModelProvider;
@@ -104,6 +105,7 @@ public class TemplateEnumAnnotationSupport extends AbstractAnnotationTypeReferen
 		ValueResolverInfo resolver = new ValueResolverInfo();
 		resolver.setSourceType(field.getDeclaringType().getFullyQualifiedName());
 		resolver.setSignature(typeResolver.resolveFieldSignature(field));
+		resolver.setKind(ValueResolverKind.TemplateEnum);
 		// This annotation is functionally equivalent to @TemplateData(namespace =
 		// TemplateData.SIMPLENAME),
 		// i.e. a namespace resolver is automatically generated for the target enum and

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/template/datamodel/TemplateGlobalAnnotationSupport.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/template/datamodel/TemplateGlobalAnnotationSupport.java
@@ -29,6 +29,7 @@ import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 
 import com.redhat.qute.commons.datamodel.resolvers.ValueResolverInfo;
+import com.redhat.qute.commons.datamodel.resolvers.ValueResolverKind;
 import com.redhat.qute.jdt.QuteSupportForTemplate;
 import com.redhat.qute.jdt.internal.resolver.ITypeResolver;
 import com.redhat.qute.jdt.template.datamodel.AbstractAnnotationTypeReferenceDataModelProvider;
@@ -122,6 +123,7 @@ public class TemplateGlobalAnnotationSupport extends AbstractAnnotationTypeRefer
 			ValueResolverInfo resolver = new ValueResolverInfo();
 			resolver.setSourceType(sourceType);
 			resolver.setSignature(typeResolver.resolveSignature(member));
+			resolver.setKind(ValueResolverKind.TemplateGlobal);
 			// Constant value for {@link #name()} indicating that the field/method name
 			// should be used
 			try {

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/GenerateMissingJavaMemberParams.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/GenerateMissingJavaMemberParams.java
@@ -46,6 +46,7 @@ public class GenerateMissingJavaMemberParams {
 	private String missingProperty;
 	private String javaType;
 	private String projectUri;
+	private String templateClass;
 
 	public GenerateMissingJavaMemberParams() {
 		this(null, null, null, null);
@@ -59,13 +60,30 @@ public class GenerateMissingJavaMemberParams {
 	 * @param missingProperty the name of the java member that's missing
 	 * @param javaType        the java type to generate the missing member in
 	 * @param projectUri      the uri of the project
+	 * @param templateClass   the template class to generate the member in (when
+	 *                        {@code memberType == MemberType.AppendTemplateExtension})
 	 */
 	public GenerateMissingJavaMemberParams(MemberType memberType, String missingProperty, String javaType,
-			String projectUri) {
+			String projectUri, String templateClass) {
 		this.memberType = memberType;
 		this.missingProperty = missingProperty;
 		this.javaType = javaType;
 		this.projectUri = projectUri;
+		this.templateClass = templateClass;
+	}
+
+	/**
+	 * Returns the parameters for generate a missing java member that is referenced
+	 * in a template but doesn't exist.
+	 * 
+	 * @param memberType      the type of member to generate
+	 * @param missingProperty the name of the java member that's missing
+	 * @param javaType        the java type to generate the missing member in
+	 * @param projectUri      the uri of the project
+	 */
+	public GenerateMissingJavaMemberParams(MemberType memberType, String missingProperty, String javaType,
+			String projectUri) {
+		this(memberType, missingProperty, javaType, projectUri, null);
 	}
 
 	public MemberType getMemberType() {
@@ -100,6 +118,14 @@ public class GenerateMissingJavaMemberParams {
 		this.projectUri = projectUri;
 	}
 
+	public String getTemplateClass() {
+		return this.templateClass;
+	}
+
+	public void setTemplateClass(String templateClass) {
+		this.templateClass = templateClass;
+	}
+
 	@Override
 	public String toString() {
 		ToStringBuilder builder = new ToStringBuilder(this);
@@ -107,6 +133,7 @@ public class GenerateMissingJavaMemberParams {
 		builder.add("missingProperty", missingProperty);
 		builder.add("javaType", javaType);
 		builder.add("projectUri", projectUri);
+		builder.add("templateClass", templateClass);
 		return builder.toString();
 	}
 
@@ -120,7 +147,9 @@ public class GenerateMissingJavaMemberParams {
 				&& ((this.missingProperty == null && that.missingProperty == null)
 						|| this.missingProperty.equals(that.missingProperty)) //
 				&& ((this.javaType == null && that.javaType == null) || this.javaType.equals(that.javaType)) //
-				&& ((this.projectUri == null && that.projectUri == null) || this.projectUri.equals(that.projectUri));
+				&& ((this.projectUri == null && that.projectUri == null) || this.projectUri.equals(that.projectUri)) //
+				&& ((this.templateClass == null && that.templateClass == null)
+						|| this.templateClass.equals(that.templateClass));
 	}
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/ResolvedJavaTypeInfo.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/ResolvedJavaTypeInfo.java
@@ -43,7 +43,7 @@ public class ResolvedJavaTypeInfo extends JavaTypeInfo {
 
 	private Boolean isIterable;
 
-	private Boolean source;
+	private Boolean binary;
 
 	private RegisterForReflectionAnnotation registerForReflectionAnnotation;
 
@@ -154,23 +154,23 @@ public class ResolvedJavaTypeInfo extends JavaTypeInfo {
 	}
 
 	/**
-	 * Returns true if this Java type is in a user modifiable source file, and false
+	 * Returns true if this Java type is in a binary file, and false
 	 * otherwise.
 	 * 
-	 * @return true if this Java type is in a user modifiable source file, and false
+	 * @return true if this Java type is in a binary file, and false
 	 *         otherwise
 	 */
-	public boolean isSource() {
-		return source != null && source.booleanValue();
+	public boolean isBinary() {
+		return binary != null && binary.booleanValue();
 	}
 
 	/**
-	 * Set if this type comes from a source file.
+	 * Set if this type comes from a binary file.
 	 * 
-	 * @param source true if the type comes from a source file, false otherwise
+	 * @param binary true if the type comes from a binary file, false otherwise
 	 */
-	public void setSource(Boolean source) {
-		this.source = source;
+	public void setBinary(Boolean binary) {
+		this.binary = binary;
 	}
 
 	/**
@@ -256,7 +256,7 @@ public class ResolvedJavaTypeInfo extends JavaTypeInfo {
 		ToStringBuilder b = new ToStringBuilder(this);
 		b.add("name", this.getName());
 		b.add("signature", this.getSignature());
-		b.add("source", this.isSource() ? "SOURCE" : "BINARY");
+		b.add("binary", this.isBinary() ? "BINARY" : "SOURCE");
 		b.add("iterableOf", this.getIterableOf());
 		b.add("iterableType", this.getIterableType());
 		b.add("templateDataAnnotations", this.getTemplateDataAnnotations());

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/datamodel/resolvers/ValueResolverInfo.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/datamodel/resolvers/ValueResolverInfo.java
@@ -32,6 +32,10 @@ public class ValueResolverInfo {
 	private String signature;
 
 	private String sourceType;
+	
+	private Boolean binary;
+	
+	private ValueResolverKind kind;
 
 	private Boolean globalVariable;
 
@@ -113,6 +117,42 @@ public class ValueResolverInfo {
 	 */
 	public void setSourceType(String sourceType) {
 		this.sourceType = sourceType;
+	}
+	
+	/**
+	 * Returns true if the source type is a source file and false otherwise.
+	 * 
+	 * @return true if the source type is a source file and false otherwise
+	 */
+	public boolean isBinary() {
+		return binary != null && binary.booleanValue();
+	}
+	
+	/**
+	 * Sets if the source type is a binary file.
+	 * 
+	 * @param binary true if the source type is a binary file and false otherwise
+	 */
+	public void setBinary(boolean binary) {
+		this.binary = binary;
+	}
+	
+	/**
+	 * Returns the kind of the value resolver.
+	 * 
+	 * @return the kind of the value resolver
+	 */
+	public ValueResolverKind getKind() {
+		return this.kind;
+	}
+	
+	/**
+	 * Sets the kind of the value resolver.
+	 * 
+	 * @param kind the kind of the value resolver
+	 */
+	public void setKind(ValueResolverKind kind) {
+		this.kind = kind;
 	}
 
 	/**

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/datamodel/resolvers/ValueResolverKind.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/datamodel/resolvers/ValueResolverKind.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.commons.datamodel.resolvers;
+
+/**
+ * Represents the kind of a value resolver.
+ * 
+ * @author datho7561
+ */
+public enum ValueResolverKind {
+	TemplateData(0), //
+	TemplateEnum(1), //
+	TemplateExtensionOnMethod(2), //
+	TemplateExtensionOnClass(3), //
+	TemplateGlobal(4), //
+	InjectedBean(5);
+
+	private final int value;
+
+	ValueResolverKind(int value) {
+		this.value = value;
+	}
+
+	public int getValue() {
+		return value;
+	}
+
+	public static ValueResolverKind forValue(int value) {
+		ValueResolverKind[] allValues = ValueResolverKind.values();
+		if (value < 1 || value > allValues.length)
+			throw new IllegalArgumentException("Illegal enum value: " + value);
+		return allValues[value - 1];
+	}
+
+	public String toString() {
+		return this.name();
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/QuteProjectRegistry.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/QuteProjectRegistry.java
@@ -841,6 +841,25 @@ public class QuteProjectRegistry implements QuteProjectInfoProvider, QuteDataMod
 		ExtendedDataModelProject dataModel = project.getDataModelProject().getNow(null);
 		return dataModel != null ? dataModel.getAllNamespaces() : Collections.emptySet();
 	}
+	
+	/**
+	 * Return all template extensions classes from the given Qute project Uri.
+	 *
+	 * @param projectUri the Qute project Uri
+	 *
+	 * @return all template extensions classes from the given Qute project Uri.
+	 */
+	public Set<String> getAllTemplateExtensionsClasses(String projectUri) {
+		if (StringUtils.isEmpty(projectUri)) {
+			return Collections.emptySet();
+		}
+		QuteProject project = getProject(projectUri);
+		if (project == null) {
+			return Collections.emptySet();
+		}
+		ExtendedDataModelProject dataModel = project.getDataModelProject().getNow(null);
+		return dataModel != null ? dataModel.getAllTemplateExtensionsClasses() : Collections.emptySet();
+	}
 
 	public CompletableFuture<JavaElementInfo> findJavaElementWithNamespace(String namespace, String partName,
 			String projectUri) {

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/ExtendedDataModelProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/ExtendedDataModelProject.java
@@ -30,6 +30,7 @@ import com.redhat.qute.commons.datamodel.DataModelParameter;
 import com.redhat.qute.commons.datamodel.DataModelProject;
 import com.redhat.qute.commons.datamodel.DataModelTemplate;
 import com.redhat.qute.commons.datamodel.resolvers.NamespaceResolverInfo;
+import com.redhat.qute.commons.datamodel.resolvers.ValueResolverKind;
 import com.redhat.qute.parser.expression.NamespacePart;
 import com.redhat.qute.project.datamodel.resolvers.FieldValueResolver;
 import com.redhat.qute.project.datamodel.resolvers.MethodValueResolver;
@@ -39,6 +40,8 @@ import com.redhat.qute.utils.StringUtils;
 public class ExtendedDataModelProject extends DataModelProject<ExtendedDataModelTemplate> {
 
 	private final Set<String> allNamespaces;
+
+	private final Set<String> allTemplateExtensionsClasses;
 
 	private final List<TypeValueResolver> typeValueResolvers;
 
@@ -68,6 +71,7 @@ public class ExtendedDataModelProject extends DataModelProject<ExtendedDataModel
 			return 0;
 		});
 		allNamespaces = getAllNamespaces(project);
+		allTemplateExtensionsClasses = getAllTemplateExtensionsClasses(project);
 		similarNamespaces = getSimilarNamespaces(project);
 	}
 
@@ -128,6 +132,16 @@ public class ExtendedDataModelProject extends DataModelProject<ExtendedDataModel
 		return allNamespaces;
 	}
 
+	private static Set<String> getAllTemplateExtensionsClasses(
+			DataModelProject<DataModelTemplate<DataModelParameter>> project) {
+		return project.getValueResolvers().stream() //
+				.filter(resolver -> ValueResolverKind.TemplateExtensionOnClass.equals(resolver.getKind())
+						&& !resolver.isBinary()) //
+				.map(resolver -> resolver.getSourceType()) //
+				.distinct() //
+				.collect(Collectors.toSet());
+	}
+
 	private static Map<String, String> getSimilarNamespaces(
 			DataModelProject<DataModelTemplate<DataModelParameter>> project) {
 		Map<String, String> similar = new HashMap<>();
@@ -154,6 +168,10 @@ public class ExtendedDataModelProject extends DataModelProject<ExtendedDataModel
 
 	public Set<String> getAllNamespaces() {
 		return allNamespaces;
+	}
+
+	public Set<String> getAllTemplateExtensionsClasses() {
+		return allTemplateExtensionsClasses;
 	}
 
 	public String getSimilarNamespace(String namespace) {
@@ -216,7 +234,7 @@ public class ExtendedDataModelProject extends DataModelProject<ExtendedDataModel
 							javaTypesSupportedInNativeMode.add(parameterType.getType());
 						}
 					} else {
-						javaTypesSupportedInNativeMode.add(sourceType);	
+						javaTypesSupportedInNativeMode.add(sourceType);
 					}
 				}
 			}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/JavaDataModelCache.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/JavaDataModelCache.java
@@ -276,6 +276,16 @@ public class JavaDataModelCache implements DataModelTemplateProvider {
 	public Set<String> getAllNamespaces(String projectUri) {
 		return projectRegistry.getAllNamespaces(projectUri);
 	}
+	
+	/**
+	 * Returns a set of the fully qualified names of all classes in the given project that are annotated with {@code TemplateExtension}.
+	 * 
+	 * @param projectUri the URI of the project in which to search for the template extension classes
+	 * @return a set of the fully qualified names of all classes in the given project that are annotated with {@code TemplateExtension}
+	 */
+	public Set<String> getAllTemplateExtensionsClasses(String projectUri) {
+		return projectRegistry.getAllTemplateExtensionsClasses(projectUri);
+	}
 
 	public CompletableFuture<JavaElementInfo> findJavaElementWithNamespace(String namespace, String partName,
 			String projectUri) {

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/codeactions/QuteCodeActionForUnknownProperty.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/codeactions/QuteCodeActionForUnknownProperty.java
@@ -16,6 +16,7 @@ import static com.redhat.qute.ls.commons.CodeActionFactory.createCodeActionWithD
 import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -45,7 +46,7 @@ public class QuteCodeActionForUnknownProperty extends AbstractQuteCodeAction {
 
 	private static final Logger LOGGER = Logger.getLogger(QuteCodeActionForUnknownProperty.class.getName());
 
-	private static final String APPEND_TO_TEMPLATE_EXTENSIONS = "Create template extension `{0}()` in detected template extensions class.";
+	private static final String APPEND_TO_TEMPLATE_EXTENSIONS = "Create template extension `{0}()` in class `{1}`.";
 
 	private static final String CREATE_TEMPLATE_EXTENSIONS = "Create template extension `{0}()` in a new template extensions class.";
 
@@ -69,13 +70,32 @@ public class QuteCodeActionForUnknownProperty extends AbstractQuteCodeAction {
 			Diagnostic diagnostic = request.getDiagnostic();
 			QuteTemplateGenerateMissingJavaMember resolver = request.getResolver();
 			SharedSettings sharedSettings = request.getSharedSettings();
+			Set<String> namespaces = this.javaCache.getAllTemplateExtensionsClasses(template.getProjectUri());
 
 			Part propertyPart = (Part) request.getCoveredNode();
 			ResolvedJavaTypeInfo baseResolvedType = request.getJavaTypeOfCoveredNode(javaCache);
 
 			if (baseResolvedType != null) {
-				doCodeActionToCreateProperty(propertyPart, baseResolvedType, template, diagnostic, resolver,
-						sharedSettings, codeActionResolveFutures, codeActions);
+
+				String missingProperty = propertyPart.getPartName();
+				String resolvedType = baseResolvedType.getSignature();
+				String projectUri = template.getProjectUri();
+				String propertyCapitalized = missingProperty.substring(0, 1).toUpperCase()
+						+ missingProperty.substring(1);
+
+				if (!baseResolvedType.isBinary()) {
+					doCodeActionToCreateField(missingProperty, resolvedType, projectUri, propertyCapitalized, diagnostic,
+							resolver, sharedSettings, codeActionResolveFutures, codeActions);
+					doCodeActionToCreateGetter(missingProperty, resolvedType, projectUri, propertyCapitalized, diagnostic,
+							resolver, sharedSettings, codeActionResolveFutures, codeActions);
+				}
+
+				doCodeActionToAddTemplateExtension(missingProperty, resolvedType, projectUri, diagnostic, resolver,
+						namespaces, sharedSettings, codeActionResolveFutures, codeActions);
+				doCodeActionToCreateTemplateExtensionsClass(missingProperty, resolvedType, projectUri,
+						propertyCapitalized, diagnostic, resolver, sharedSettings, codeActionResolveFutures,
+						codeActions);
+				;
 			}
 
 		} catch (BadLocationException e) {
@@ -83,60 +103,71 @@ public class QuteCodeActionForUnknownProperty extends AbstractQuteCodeAction {
 		}
 	}
 
-	private static void doCodeActionToCreateProperty(Part propertyPart, ResolvedJavaTypeInfo baseResolvedType,
-			Template template, Diagnostic diagnostic, QuteTemplateGenerateMissingJavaMember resolver,
+	private static void doCodeActionToCreateField(String missingProperty, String resolvedType, String projectUri,
+			String propertyCapitalized, Diagnostic diagnostic, QuteTemplateGenerateMissingJavaMember resolver,
 			SharedSettings settings, List<CompletableFuture<Void>> registrations, List<CodeAction> codeActions) {
-
-		String missingProperty = propertyPart.getPartName();
-		String resolvedType = baseResolvedType.getSignature();
-		String propertyCapitalized = missingProperty.substring(0, 1).toUpperCase() + missingProperty.substring(1);
-
-		String projectUri = template.getProjectUri();
-
-		if (baseResolvedType.isSource()) {
-			GenerateMissingJavaMemberParams publicFieldParams = new GenerateMissingJavaMemberParams(MemberType.Field,
-					missingProperty, resolvedType, projectUri);
-			GenerateMissingJavaMemberParams getterParams = new GenerateMissingJavaMemberParams(MemberType.Getter,
-					missingProperty, resolvedType, projectUri);
-			CodeAction createPublicField = createCodeActionWithData(
-					MessageFormat.format(CREATE_PUBLIC_FIELD, missingProperty, resolvedType), publicFieldParams,
-					Collections.singletonList(diagnostic));
-			CodeAction createGetter = createCodeActionWithData(
-					MessageFormat.format(CREATE_GETTER, propertyCapitalized, resolvedType), getterParams,
-					Collections.singletonList(diagnostic));
-			codeActions.add(createPublicField);
-			codeActions.add(createGetter);
-			registrations.add(resolver.generateMissingJavaMember(publicFieldParams) //
-					.thenAccept((workspaceEdit) -> {
-						if (workspaceEdit == null) {
-							return;
-						}
-						createPublicField.setEdit(workspaceEdit);
-					}));
-
-			registrations.add(resolver.generateMissingJavaMember(getterParams) //
-					.thenAccept((workspaceEdit) -> {
-						if (workspaceEdit == null) {
-							return;
-						}
-						createGetter.setEdit(workspaceEdit);
-					}));
-		}
-
-		GenerateMissingJavaMemberParams appendToTemplateExtensionsParams = new GenerateMissingJavaMemberParams(
-				MemberType.AppendTemplateExtension, missingProperty, resolvedType, projectUri);
-		CodeAction appendToTemplateExtensions = createCodeActionWithData(
-				MessageFormat.format(APPEND_TO_TEMPLATE_EXTENSIONS, missingProperty), appendToTemplateExtensionsParams,
+		GenerateMissingJavaMemberParams publicFieldParams = new GenerateMissingJavaMemberParams(MemberType.Field,
+				missingProperty, resolvedType, projectUri);
+		CodeAction createPublicField = createCodeActionWithData(
+				MessageFormat.format(CREATE_PUBLIC_FIELD, missingProperty, resolvedType), publicFieldParams,
 				Collections.singletonList(diagnostic));
-		codeActions.add(appendToTemplateExtensions);
-		registrations.add(resolver.generateMissingJavaMember(appendToTemplateExtensionsParams) //
+		codeActions.add(createPublicField);
+		registrations.add(resolver.generateMissingJavaMember(publicFieldParams) //
 				.thenAccept((workspaceEdit) -> {
 					if (workspaceEdit == null) {
 						return;
 					}
-					appendToTemplateExtensions.setEdit(workspaceEdit);
+					createPublicField.setEdit(workspaceEdit);
 				}));
+	}
 
+	private static void doCodeActionToCreateGetter(String missingProperty, String resolvedType, String projectUri,
+			String propertyCapitalized, Diagnostic diagnostic, QuteTemplateGenerateMissingJavaMember resolver,
+			SharedSettings settings, List<CompletableFuture<Void>> registrations, List<CodeAction> codeActions) {
+		GenerateMissingJavaMemberParams getterParams = new GenerateMissingJavaMemberParams(MemberType.Getter,
+				missingProperty, resolvedType, projectUri);
+		CodeAction createGetter = createCodeActionWithData(
+				MessageFormat.format(CREATE_GETTER, propertyCapitalized, resolvedType), getterParams,
+				Collections.singletonList(diagnostic));
+		codeActions.add(createGetter);
+		registrations.add(resolver.generateMissingJavaMember(getterParams) //
+				.thenAccept((workspaceEdit) -> {
+					if (workspaceEdit == null) {
+						return;
+					}
+					createGetter.setEdit(workspaceEdit);
+				}));
+	}
+
+	private static void doCodeActionToAddTemplateExtension(String missingProperty, String resolvedType,
+			String projectUri, Diagnostic diagnostic, QuteTemplateGenerateMissingJavaMember resolver,
+			Set<String> templateExtensionsClasses, SharedSettings sharedSettings,
+			List<CompletableFuture<Void>> registrations, List<CodeAction> codeActions) {
+
+		for (String templateExtensionsClass : templateExtensionsClasses) {
+
+			GenerateMissingJavaMemberParams appendToTemplateExtensionsParams = new GenerateMissingJavaMemberParams(
+					MemberType.AppendTemplateExtension, missingProperty, resolvedType, projectUri,
+					templateExtensionsClass);
+			CodeAction appendToTemplateExtensions = createCodeActionWithData(
+					MessageFormat.format(APPEND_TO_TEMPLATE_EXTENSIONS, missingProperty, templateExtensionsClass),
+					appendToTemplateExtensionsParams, Collections.singletonList(diagnostic));
+			codeActions.add(appendToTemplateExtensions);
+			registrations.add(resolver.generateMissingJavaMember(appendToTemplateExtensionsParams) //
+					.thenAccept((workspaceEdit) -> {
+						if (workspaceEdit == null) {
+							return;
+						}
+						appendToTemplateExtensions.setEdit(workspaceEdit);
+					}));
+		}
+
+	}
+
+	private static void doCodeActionToCreateTemplateExtensionsClass(String missingProperty, String resolvedType,
+			String projectUri, String propertyCapitalized, Diagnostic diagnostic,
+			QuteTemplateGenerateMissingJavaMember resolver, SharedSettings settings,
+			List<CompletableFuture<Void>> registrations, List<CodeAction> codeActions) {
 		GenerateMissingJavaMemberParams createTemplateExtensionsParams = new GenerateMissingJavaMemberParams(
 				MemberType.CreateTemplateExtension, missingProperty, resolvedType, projectUri);
 		CodeAction createTemplateExtensions = createCodeActionWithData(
@@ -150,7 +181,6 @@ public class QuteCodeActionForUnknownProperty extends AbstractQuteCodeAction {
 					}
 					createTemplateExtensions.setEdit(workspaceEdit);
 				}));
-
 	}
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/MockQuteProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/MockQuteProject.java
@@ -32,6 +32,7 @@ import com.redhat.qute.commons.datamodel.DataModelParameter;
 import com.redhat.qute.commons.datamodel.DataModelProject;
 import com.redhat.qute.commons.datamodel.DataModelTemplate;
 import com.redhat.qute.commons.datamodel.resolvers.NamespaceResolverInfo;
+import com.redhat.qute.commons.datamodel.resolvers.ValueResolverKind;
 import com.redhat.qute.commons.datamodel.resolvers.ValueResolverInfo;
 import com.redhat.qute.ls.api.QuteDataModelProjectProvider;
 import com.redhat.qute.ls.api.QuteUserTagProvider;
@@ -106,16 +107,16 @@ public abstract class MockQuteProject extends QuteProject {
 		return typeInfo;
 	}
 
-	protected static ResolvedJavaTypeInfo createResolvedJavaTypeInfo(String typeName, List<ResolvedJavaTypeInfo> cache, boolean isSource,
+	protected static ResolvedJavaTypeInfo createResolvedJavaTypeInfo(String typeName, List<ResolvedJavaTypeInfo> cache, boolean binary,
 			ResolvedJavaTypeInfo... extended) {
-		return createResolvedJavaTypeInfo(typeName, null, null, cache, isSource, extended);
+		return createResolvedJavaTypeInfo(typeName, null, null, cache, binary, extended);
 	}
 
 	protected static ResolvedJavaTypeInfo createResolvedJavaTypeInfo(String signature, String iterableType,
-			String iterableOf, List<ResolvedJavaTypeInfo> cache, boolean isSource, ResolvedJavaTypeInfo... extended) {
+			String iterableOf, List<ResolvedJavaTypeInfo> cache, boolean binary, ResolvedJavaTypeInfo... extended) {
 		ResolvedJavaTypeInfo resolvedType = new ResolvedJavaTypeInfo();
 		resolvedType.setKind(JavaTypeKind.Class);
-		resolvedType.setSource(isSource);
+		resolvedType.setBinary(binary);
 		resolvedType.setSignature(signature);
 		resolvedType.setIterableType(iterableType);
 		resolvedType.setIterableOf(iterableOf);
@@ -139,14 +140,19 @@ public abstract class MockQuteProject extends QuteProject {
 		project.setNamespaceResolverInfos(namespaceResolverInfos);
 		return CompletableFuture.completedFuture(new ExtendedDataModelProject(project));
 	}
-
+	
 	protected static ValueResolverInfo createValueResolver(String namespace, String named, String matchName,
-			String sourceType, String signature) {
-		return createValueResolver(namespace, named, matchName, sourceType, signature, false);
+			String sourceType, String signature, ValueResolverKind kind) {
+		return createValueResolver(namespace, named, matchName, sourceType, signature, kind, false);
+	}
+	
+	protected static ValueResolverInfo createValueResolver(String namespace, String named, String matchName,
+			String sourceType, String signature, ValueResolverKind kind, boolean globalVariable) {
+		return createValueResolver(namespace, named, matchName, sourceType, signature, kind, globalVariable, false);
 	}
 
 	protected static ValueResolverInfo createValueResolver(String namespace, String named, String matchName,
-			String sourceType, String signature, boolean globalVariable) {
+			String sourceType, String signature, ValueResolverKind kind, boolean globalVariable, boolean binary) {
 		ValueResolverInfo resolver = new ValueResolverInfo();
 		resolver.setNamespace(namespace);
 		resolver.setNamed(named);
@@ -154,6 +160,8 @@ public abstract class MockQuteProject extends QuteProject {
 		resolver.setSourceType(sourceType);
 		resolver.setSignature(signature);
 		resolver.setGlobalVariable(globalVariable);
+		resolver.setBinary(binary);
+		resolver.setKind(kind);
 		return resolver;
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/QuteQuickStartProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/QuteQuickStartProject.java
@@ -27,6 +27,7 @@ import com.redhat.qute.commons.annotations.TemplateDataAnnotation;
 import com.redhat.qute.commons.datamodel.DataModelParameter;
 import com.redhat.qute.commons.datamodel.DataModelTemplate;
 import com.redhat.qute.commons.datamodel.resolvers.NamespaceResolverInfo;
+import com.redhat.qute.commons.datamodel.resolvers.ValueResolverKind;
 import com.redhat.qute.commons.datamodel.resolvers.ValueResolverInfo;
 import com.redhat.qute.ls.api.QuteDataModelProjectProvider;
 import com.redhat.qute.ls.api.QuteUserTagProvider;
@@ -55,9 +56,9 @@ public class QuteQuickStartProject extends MockQuteProject {
 
 		createResolvedJavaTypeInfo("org.acme", cache, true).setKind(JavaTypeKind.Package);
 
-		createResolvedJavaTypeInfo("java.lang.Object", cache, false);
+		createResolvedJavaTypeInfo("java.lang.Object", cache, true);
 
-		ResolvedJavaTypeInfo string = createResolvedJavaTypeInfo("java.lang.String", cache, false);
+		ResolvedJavaTypeInfo string = createResolvedJavaTypeInfo("java.lang.String", cache, true);
 		registerField("UTF16 : byte", string);
 		registerMethod("isEmpty() : boolean", string);
 		registerMethod("codePointCount(beginIndex : int,endIndex : int) : int", string);
@@ -67,36 +68,36 @@ public class QuteQuickStartProject extends MockQuteProject {
 		registerMethod("getBytes(charsetName : java.lang.String) : byte[]", string);
 		registerMethod("getBytes() : byte[]", string);
 
-		createResolvedJavaTypeInfo("java.lang.Boolean", cache, false);
-		createResolvedJavaTypeInfo("java.lang.Integer", cache, false);
-		createResolvedJavaTypeInfo("java.lang.Double", cache, false);
-		createResolvedJavaTypeInfo("java.lang.Long", cache, false);
-		createResolvedJavaTypeInfo("java.lang.Float", cache, false);
-		createResolvedJavaTypeInfo("java.math.BigDecimal", cache, false);
+		createResolvedJavaTypeInfo("java.lang.Boolean", cache, true);
+		createResolvedJavaTypeInfo("java.lang.Integer", cache, true);
+		createResolvedJavaTypeInfo("java.lang.Double", cache, true);
+		createResolvedJavaTypeInfo("java.lang.Long", cache, true);
+		createResolvedJavaTypeInfo("java.lang.Float", cache, true);
+		createResolvedJavaTypeInfo("java.math.BigDecimal", cache, true);
 
-		ResolvedJavaTypeInfo bigInteger = createResolvedJavaTypeInfo("java.math.BigInteger", cache, false);
+		ResolvedJavaTypeInfo bigInteger = createResolvedJavaTypeInfo("java.math.BigInteger", cache, true);
 		registerMethod("divide(val : java.math.BigInteger) : java.math.BigInteger", bigInteger);
 
-		ResolvedJavaTypeInfo bean = createResolvedJavaTypeInfo("org.acme.Bean", cache, true);
+		ResolvedJavaTypeInfo bean = createResolvedJavaTypeInfo("org.acme.Bean", cache, false);
 		registerField("bean : java.lang.String", bean);
 
-		ResolvedJavaTypeInfo review = createResolvedJavaTypeInfo("org.acme.Review", cache, true);
+		ResolvedJavaTypeInfo review = createResolvedJavaTypeInfo("org.acme.Review", cache, false);
 		registerField("name : java.lang.String", review);
 		registerField("average : java.lang.Integer", review);
 		registerMethod("getReviews() : java.util.List<org.acme.Review>", review);
 
 		// Item <- BaseItem <- AbstractItem
-		ResolvedJavaTypeInfo abstractItem = createResolvedJavaTypeInfo("org.acme.AbstractItem", cache, true);
+		ResolvedJavaTypeInfo abstractItem = createResolvedJavaTypeInfo("org.acme.AbstractItem", cache, false);
 		registerField("abstractName : java.lang.String", abstractItem);
 		registerMethod("convert(item : org.acme.AbstractItem) : int", abstractItem);
 
-		ResolvedJavaTypeInfo baseItem = createResolvedJavaTypeInfo("org.acme.BaseItem", cache, true, abstractItem);
+		ResolvedJavaTypeInfo baseItem = createResolvedJavaTypeInfo("org.acme.BaseItem", cache, false, abstractItem);
 		registerField("base : java.lang.String", baseItem);
 		registerField("name : java.lang.String", baseItem);
 		registerMethod("getReviews() : java.util.List<org.acme.Review>", baseItem);
 
 		// org.acme.Item
-		ResolvedJavaTypeInfo item = createResolvedJavaTypeInfo("org.acme.Item", cache, true, baseItem);
+		ResolvedJavaTypeInfo item = createResolvedJavaTypeInfo("org.acme.Item", cache, false, baseItem);
 		registerField("name : java.lang.String", item); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", item);
 		registerField("review : org.acme.Review", item);
@@ -104,20 +105,20 @@ public class QuteQuickStartProject extends MockQuteProject {
 		registerMethod("getReview2() : org.acme.Review", item);
 		// Override BaseItem#getReviews()
 		registerMethod("getReviews() : java.util.List<org.acme.Review>", item);
-		createResolvedJavaTypeInfo("java.util.List<org.acme.Review>", "java.util.List", "org.acme.Review", cache, false, null);
+		createResolvedJavaTypeInfo("java.util.List<org.acme.Review>", "java.util.List", "org.acme.Review", cache, true, null);
 		registerField("derivedItems : java.util.List<org.acme.Item>", item);
 		registerField("derivedItemArray : org.acme.Item[]", item);
 		item.setInvalidMethod("staticMethod", InvalidMethodReason.Static); // public static BigDecimal
 																			// staticMethod(Item item)
 
-		createResolvedJavaTypeInfo("java.util.List<org.acme.Item>", "java.util.List", "org.acme.Item", cache, false);
-		createResolvedJavaTypeInfo("java.lang.Iterable<org.acme.Item>", "java.lang.Iterable", "org.acme.Item", cache, false);
-		createResolvedJavaTypeInfo("org.acme.Item[]", null, "org.acme.Item", cache, false);
+		createResolvedJavaTypeInfo("java.util.List<org.acme.Item>", "java.util.List", "org.acme.Item", cache, true);
+		createResolvedJavaTypeInfo("java.lang.Iterable<org.acme.Item>", "java.lang.Iterable", "org.acme.Item", cache, true);
+		createResolvedJavaTypeInfo("org.acme.Item[]", null, "org.acme.Item", cache, true);
 
 		// @TemplateData
 		// public class ItemWithTemplateData
 		ResolvedJavaTypeInfo itemWithTemplateData = createResolvedJavaTypeInfo("org.acme.ItemWithTemplateData", cache,
-				true, baseItem);
+				false, baseItem);
 		registerField("name : java.lang.String", itemWithTemplateData); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithTemplateData);
 		registerMethod("getReview2() : org.acme.Review", itemWithTemplateData);
@@ -128,7 +129,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @TemplateData(target = BigInteger.class)
 		// public class ItemWithTemplateDataWithTarget
 		ResolvedJavaTypeInfo itemWithTemplateDataWithTarget = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithTemplateDataWithTarget", cache, true, baseItem);
+				"org.acme.ItemWithTemplateDataWithTarget", cache, false, baseItem);
 		registerField("name : java.lang.String", itemWithTemplateDataWithTarget); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithTemplateDataWithTarget);
 		registerMethod("getReview2() : org.acme.Review", itemWithTemplateDataWithTarget);
@@ -141,7 +142,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @TemplateData(properties = true)
 		// public class ItemWithTemplateDataProperties
 		ResolvedJavaTypeInfo itemWithTemplateDataProperties = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithTemplateDataProperties", cache, true, baseItem);
+				"org.acme.ItemWithTemplateDataProperties", cache, false, baseItem);
 		registerField("name : java.lang.String", itemWithTemplateDataProperties); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithTemplateDataProperties);
 		registerMethod("getReview2() : org.acme.Review", itemWithTemplateDataProperties);
@@ -153,7 +154,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @TemplateData(ignoreSuperclasses = true)
 		// public class ItemWithTemplateDataIgnoreSubClasses
 		ResolvedJavaTypeInfo itemWithTemplateDataIgnoreSubClasses = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithTemplateDataIgnoreSubClasses", cache, true, baseItem);
+				"org.acme.ItemWithTemplateDataIgnoreSubClasses", cache, false, baseItem);
 		registerField("name : java.lang.String", itemWithTemplateDataIgnoreSubClasses); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithTemplateDataIgnoreSubClasses);
 		registerMethod("getReview2() : org.acme.Review", itemWithTemplateDataIgnoreSubClasses);
@@ -165,7 +166,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @RegisterForReflection
 		// public class ItemWithRegisterForReflection
 		ResolvedJavaTypeInfo itemWithRegisterForReflection = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithRegisterForReflection", cache, true, baseItem);
+				"org.acme.ItemWithRegisterForReflection", cache, false, baseItem);
 		registerField("name : java.lang.String", itemWithRegisterForReflection); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithRegisterForReflection);
 		registerMethod("getReview2() : org.acme.Review", itemWithRegisterForReflection);
@@ -175,7 +176,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @RegisterForReflection(fields = false)
 		// public class ItemWithRegisterForReflectionNoFields
 		ResolvedJavaTypeInfo itemWithRegisterForReflectionNoFields = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithRegisterForReflectionNoFields", cache, true, baseItem);
+				"org.acme.ItemWithRegisterForReflectionNoFields", cache, false, baseItem);
 		registerField("name : java.lang.String", itemWithRegisterForReflectionNoFields); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithRegisterForReflectionNoFields);
 		registerMethod("getReview2() : org.acme.Review", itemWithRegisterForReflectionNoFields);
@@ -186,7 +187,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @RegisterForReflection(methods = false)
 		// public class ItemWithRegisterForReflectionNoMethods
 		ResolvedJavaTypeInfo itemWithRegisterForReflectionNoMethods = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithRegisterForReflectionNoMethods", cache, true, baseItem);
+				"org.acme.ItemWithRegisterForReflectionNoMethods", cache, false, baseItem);
 		registerField("name : java.lang.String", itemWithRegisterForReflectionNoMethods); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithRegisterForReflectionNoMethods);
 		registerMethod("getReview2() : org.acme.Review", itemWithRegisterForReflectionNoMethods);
@@ -195,17 +196,17 @@ public class QuteQuickStartProject extends MockQuteProject {
 		itemWithRegisterForReflectionNoMethods.setRegisterForReflectionAnnotation(registerForReflectionAnnotation);
 
 		ResolvedJavaTypeInfo iterable = createResolvedJavaTypeInfo("java.lang.Iterable<T>", "java.lang.Iterable", "T",
-				cache, false);
+				cache, true);
 
-		ResolvedJavaTypeInfo list = createResolvedJavaTypeInfo("java.util.List<E>", "java.util.List", "E", cache, false);
+		ResolvedJavaTypeInfo list = createResolvedJavaTypeInfo("java.util.List<E>", "java.util.List", "E", cache, true);
 		list.setExtendedTypes(Arrays.asList("java.lang.Iterable"));
 		registerMethod("size() : int", list);
 		registerMethod("get(index : int) : E", list);
 
-		ResolvedJavaTypeInfo map = createResolvedJavaTypeInfo("java.util.Map", cache, false);
+		ResolvedJavaTypeInfo map = createResolvedJavaTypeInfo("java.util.Map", cache, true);
 
 		// RawString for raw and safe resolver tests
-		ResolvedJavaTypeInfo rawString = createResolvedJavaTypeInfo("io.quarkus.qute.RawString", cache, false);
+		ResolvedJavaTypeInfo rawString = createResolvedJavaTypeInfo("io.quarkus.qute.RawString", cache, true);
 		registerMethod("getValue() : java.lang.String", rawString);
 		registerMethod("toString() : java.lang.String", rawString);
 
@@ -298,34 +299,41 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// Type value resolvers
 		resolvers.add(createValueResolver("inject", "plexux", null,
 				"org.eclipse.aether.internal.transport.wagon.PlexusWagonConfigurator",
-				"org.eclipse.aether.internal.transport.wagon.PlexusWagonConfigurator"));
+				"org.eclipse.aether.internal.transport.wagon.PlexusWagonConfigurator", ValueResolverKind.InjectedBean, false, true));
 		resolvers.add(createValueResolver("inject", "plexux", null,
 				"org.eclipse.aether.internal.transport.wagon.PlexusWagonProvider",
-				"org.eclipse.aether.internal.transport.wagon.PlexusWagonProvider"));
+				"org.eclipse.aether.internal.transport.wagon.PlexusWagonProvider", ValueResolverKind.InjectedBean, false, true));
 
 		// Method value resolvers
 		// No namespace
 		resolvers.add(createValueResolver(null, null, null, "org.acme.ItemResource",
-				"discountedPrice(item : org.acme.Item) : java.math.BigDecimal"));
+				"discountedPrice(item : org.acme.Item) : java.math.BigDecimal", ValueResolverKind.TemplateExtensionOnMethod, false, false));
 		resolvers.add(
 				createValueResolver(null, null, null, "io.quarkus.qute.runtime.extensions.CollectionTemplateExtensions",
-						"getByIndex(list : java.util.List<T>, index : int) : T"));
+						"getByIndex(list : java.util.List<T>, index : int) : T", ValueResolverKind.TemplateExtensionOnClass, false, true));
 		resolvers.add(createValueResolver(null, null, null, "org.acme.ItemResource",
-				"pretty(item : org.acme.Item, elements : java.lang.String...) : java.lang.String"));
+				"pretty(item : org.acme.Item, elements : java.lang.String...) : java.lang.String", ValueResolverKind.TemplateExtensionOnMethod, false, false));
+		
+		// @TemplateExtension
+		// org.acme.TemplateExtensions
+		resolvers.add(createValueResolver(null, null, null, "org.acme.TemplateExtensions", "", ValueResolverKind.TemplateExtensionOnClass, false, false));
+		// @TemplateExtension
+		// org.acme.foo.TemplateExtensions
+		resolvers.add(createValueResolver(null, null, null, "org.acme.foo.TemplateExtensions", "", ValueResolverKind.TemplateExtensionOnClass, false, false));
 
 		// 'config' namespace
 		resolvers.add(
 				createValueResolver("config", null, "*", "io.quarkus.qute.runtime.extensions.ConfigTemplateExtensions",
-						"getConfigProperty(propertyName : java.lang.String) : java.lang.Object"));
+						"getConfigProperty(propertyName : java.lang.String) : java.lang.Object", ValueResolverKind.TemplateExtensionOnMethod, false, true));
 		resolvers.add(
 				createValueResolver("config", null, null, "io.quarkus.qute.runtime.extensions.ConfigTemplateExtensions",
-						"property(propertyName : java.lang.String) : java.lang.Object"));
+						"property(propertyName : java.lang.String) : java.lang.Object", ValueResolverKind.TemplateExtensionOnMethod, false, true));
 
 		// Field value resolvers
-		resolvers.add(createValueResolver("inject", "bean", null, "org.acme.Bean", "bean : java.lang.String"));
+		resolvers.add(createValueResolver("inject", "bean", null, "org.acme.Bean", "bean : java.lang.String", ValueResolverKind.InjectedBean));
 
 		// Static field value resolvers
-		resolvers.add(createValueResolver(null, "GLOBAL", null, "org.acme.Bean", "bean : java.lang.String", true));
+		resolvers.add(createValueResolver(null, "GLOBAL", null, "org.acme.Bean", "bean : java.lang.String", ValueResolverKind.TemplateGlobal, true));
 
 		return resolvers;
 	}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteGenerateMissingMemberCodeActionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteGenerateMissingMemberCodeActionTest.java
@@ -47,7 +47,9 @@ public class QuteGenerateMissingMemberCodeActionTest {
 				ca(d, new GenerateMissingJavaMemberParams(MemberType.Getter, "asdf", "org.acme.Item",
 						"qute-quickstart")), //
 				ca(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "asdf", "org.acme.Item",
-						"qute-quickstart")), //
+						"qute-quickstart", "org.acme.TemplateExtensions")), //
+				ca(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "asdf", "org.acme.Item",
+						"qute-quickstart", "org.acme.foo.TemplateExtensions")), //
 				ca(d, new GenerateMissingJavaMemberParams(MemberType.CreateTemplateExtension, "asdf", "org.acme.Item",
 						"qute-quickstart")));
 	}
@@ -66,7 +68,9 @@ public class QuteGenerateMissingMemberCodeActionTest {
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
 				ca(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "asdf",
-						"java.lang.String", "qute-quickstart")), //
+						"java.lang.String", "qute-quickstart", "org.acme.TemplateExtensions")), //
+				ca(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "asdf",
+						"java.lang.String", "qute-quickstart", "org.acme.foo.TemplateExtensions")), //
 				ca(d, new GenerateMissingJavaMemberParams(MemberType.CreateTemplateExtension, "asdf",
 						"java.lang.String", "qute-quickstart")));
 	}


### PR DESCRIPTION
For CodeActions for a missing member in a Qute template, generate one "add template extension to existing class" CodeAction for each class file that is annotated with @TemplateExtension.

Closes #677

Signed-off-by: David Thompson <davthomp@redhat.com>
