### PR TITLE
Detect cycles in inheritance graph during completion

### DIFF
--- a/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-quickstart/src/main/java/org/acme/qute/cyclic/ClassA.java
+++ b/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-quickstart/src/main/java/org/acme/qute/cyclic/ClassA.java
@@ -1,0 +1,5 @@
+package org.acme.qute.cyclic;
+
+public class ClassA extends ClassC {
+
+}

--- a/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-quickstart/src/main/java/org/acme/qute/cyclic/ClassB.java
+++ b/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-quickstart/src/main/java/org/acme/qute/cyclic/ClassB.java
@@ -1,0 +1,5 @@
+package org.acme.qute.cyclic;
+
+public class ClassB extends ClassA {
+
+}

--- a/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-quickstart/src/main/java/org/acme/qute/cyclic/ClassC.java
+++ b/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-quickstart/src/main/java/org/acme/qute/cyclic/ClassC.java
@@ -1,0 +1,5 @@
+package org.acme.qute.cyclic;
+
+public class ClassC extends ClassB {
+
+}

--- a/qute.jdt/com.redhat.qute.jdt.test/src/main/java/com/redhat/qute/jdt/template/TemplateGetJavaTypeTest.java
+++ b/qute.jdt/com.redhat.qute.jdt.test/src/main/java/com/redhat/qute/jdt/template/TemplateGetJavaTypeTest.java
@@ -91,6 +91,19 @@ public class TemplateGetJavaTypeTest {
 				t("org.acme.qute.NestedClass.Foo", JavaTypeKind.Class), //
 				t("org.acme.qute.NestedClass.Bar", JavaTypeKind.Class));
 	}
+	
+	@Test
+	public void cyclic() throws Exception {
+		loadMavenProject(QuteMavenProjectName.qute_quickstart);
+		
+		QuteJavaTypesParams params = new QuteJavaTypesParams("org.acme.qute.cyclic.", QuteMavenProjectName.qute_quickstart);
+		List<JavaTypeInfo> actual = QuteSupportForTemplate.getInstance().getJavaTypes(params, getJDTUtils(),
+				new NullProgressMonitor());
+		assertJavaTypes(actual, //
+				t("org.acme.qute.cyclic.ClassA", JavaTypeKind.Class), //
+				t("org.acme.qute.cyclic.ClassB", JavaTypeKind.Class), //
+				t("org.acme.qute.cyclic.ClassC", JavaTypeKind.Class));
+	}
 
 	public static JavaTypeInfo t(String typeName, JavaTypeKind kind) {
 		JavaTypeInfo javaType = new JavaTypeInfo();

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/IJavaTypeResolver.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/IJavaTypeResolver.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.project;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.redhat.qute.commons.ResolvedJavaTypeInfo;
+
+/**
+ * Represents an object that can resolve information about java types
+ * 
+ * @author datho7561
+ */
+public interface IJavaTypeResolver {
+
+	/**
+	 * Returns resolved type information for the given type as a future.
+	 * 
+	 * @param className  the fully qualified name of the Java type to the resolved
+	 *                   information of
+	 * @param projectUri the uri of the project that the Java type is in
+	 * @return resolved type information for the given type as a future
+	 */
+	CompletableFuture<ResolvedJavaTypeInfo> resolveJavaType(String className, String projectUri);
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/JavaDataModelCache.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/JavaDataModelCache.java
@@ -36,6 +36,7 @@ import com.redhat.qute.parser.template.NodeKind;
 import com.redhat.qute.parser.template.Parameter;
 import com.redhat.qute.parser.template.Section;
 import com.redhat.qute.parser.template.Template;
+import com.redhat.qute.project.IJavaTypeResolver;
 import com.redhat.qute.project.JavaMemberResult;
 import com.redhat.qute.project.QuteProjectRegistry;
 import com.redhat.qute.project.datamodel.resolvers.MethodValueResolver;
@@ -44,7 +45,7 @@ import com.redhat.qute.services.nativemode.JavaTypeFilter;
 import com.redhat.qute.settings.QuteNativeSettings;
 import com.redhat.qute.utils.StringUtils;
 
-public class JavaDataModelCache implements DataModelTemplateProvider {
+public class JavaDataModelCache implements DataModelTemplateProvider, IJavaTypeResolver {
 
 	private static final CompletableFuture<ResolvedJavaTypeInfo> RESOLVED_JAVA_TYPE_INFO_NULL_FUTURE = CompletableFuture
 			.completedFuture(null);

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/completions/TypeCycleUtils.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/completions/TypeCycleUtils.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.completions;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Set;
+
+import com.redhat.qute.commons.JavaTypeInfo;
+import com.redhat.qute.commons.ResolvedJavaTypeInfo;
+import com.redhat.qute.project.IJavaTypeResolver;
+
+/**
+ * Utilities class for checking for cycles in types
+ * 
+ * @author datho7561
+ */
+public class TypeCycleUtils {
+
+	private TypeCycleUtils() {
+	}
+
+	/**
+	 * Returns true if the given type is a part of a cyclic inheritance chain, and
+	 * false otherwise.
+	 * 
+	 * @param typeToCheck      the type to check for a cyclic inheritance chain
+	 * @param javaTypeResolver the java type resolver
+	 * @param projectUri       the project uri
+	 * @return true if the given type is a part of a cyclic inheritance chain, and
+	 *         false otherwise
+	 */
+	public static boolean hasCycle(ResolvedJavaTypeInfo typeToCheck, IJavaTypeResolver javaTypeResolver,
+			String projectUri) {
+		Queue<ResolvedJavaTypeInfo> toVisit = new LinkedList<>();
+		Set<JavaTypeInfo> visited = new HashSet<>();
+		toVisit.add(typeToCheck);
+
+		while (!toVisit.isEmpty()) {
+			ResolvedJavaTypeInfo current = toVisit.poll();
+			if (visited.contains(current)) {
+				return true;
+			}
+			visited.add(current);
+			if (current.getExtendedTypes() != null) {
+				for (String extendedTypeString : current.getExtendedTypes()) {
+					ResolvedJavaTypeInfo resolvedTypeInfo = javaTypeResolver.resolveJavaType(extendedTypeString, projectUri)
+							.getNow(null);
+					if (resolvedTypeInfo != null) {
+						toVisit.add(resolvedTypeInfo);
+					}
+				}
+			}
+		}
+		return false;
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/MockQuteProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/MockQuteProject.java
@@ -12,6 +12,7 @@
 package com.redhat.qute.project;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -108,12 +109,12 @@ public abstract class MockQuteProject extends QuteProject {
 	}
 
 	protected static ResolvedJavaTypeInfo createResolvedJavaTypeInfo(String typeName, List<ResolvedJavaTypeInfo> cache, boolean binary,
-			ResolvedJavaTypeInfo... extended) {
+			String... extended) {
 		return createResolvedJavaTypeInfo(typeName, null, null, cache, binary, extended);
 	}
-
+	
 	protected static ResolvedJavaTypeInfo createResolvedJavaTypeInfo(String signature, String iterableType,
-			String iterableOf, List<ResolvedJavaTypeInfo> cache, boolean binary, ResolvedJavaTypeInfo... extended) {
+			String iterableOf, List<ResolvedJavaTypeInfo> cache, boolean binary, String... extended) {
 		ResolvedJavaTypeInfo resolvedType = new ResolvedJavaTypeInfo();
 		resolvedType.setJavaTypeKind(JavaTypeKind.Class);
 		resolvedType.setBinary(binary);
@@ -123,9 +124,7 @@ public abstract class MockQuteProject extends QuteProject {
 		resolvedType.setFields(new ArrayList<>());
 		resolvedType.setMethods(new ArrayList<>());
 		if (extended != null) {
-			List<String> extendedTypes = Stream.of(extended).map(type -> type.getSignature())
-					.collect(Collectors.toList());
-			resolvedType.setExtendedTypes(extendedTypes);
+			resolvedType.setExtendedTypes(Arrays.asList(extended));
 		}
 		resolvedType.setInvalidMethods(new HashMap<>());
 		cache.add(resolvedType);

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/QuteQuickStartProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/QuteQuickStartProject.java
@@ -91,13 +91,13 @@ public class QuteQuickStartProject extends MockQuteProject {
 		registerField("abstractName : java.lang.String", abstractItem);
 		registerMethod("convert(item : org.acme.AbstractItem) : int", abstractItem);
 
-		ResolvedJavaTypeInfo baseItem = createResolvedJavaTypeInfo("org.acme.BaseItem", cache, false, abstractItem);
+		ResolvedJavaTypeInfo baseItem = createResolvedJavaTypeInfo("org.acme.BaseItem", cache, false, abstractItem.getSignature());
 		registerField("base : java.lang.String", baseItem);
 		registerField("name : java.lang.String", baseItem);
 		registerMethod("getReviews() : java.util.List<org.acme.Review>", baseItem);
 
 		// org.acme.Item
-		ResolvedJavaTypeInfo item = createResolvedJavaTypeInfo("org.acme.Item", cache, false, baseItem);
+		ResolvedJavaTypeInfo item = createResolvedJavaTypeInfo("org.acme.Item", cache, false, baseItem.getSignature());
 		registerField("name : java.lang.String", item); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", item);
 		registerField("review : org.acme.Review", item);
@@ -114,6 +114,10 @@ public class QuteQuickStartProject extends MockQuteProject {
 		createResolvedJavaTypeInfo("java.util.List<org.acme.Item>", "java.util.List", "org.acme.Item", cache, true);
 		createResolvedJavaTypeInfo("java.lang.Iterable<org.acme.Item>", "java.lang.Iterable", "org.acme.Item", cache, true);
 		createResolvedJavaTypeInfo("org.acme.Item[]", null, "org.acme.Item", cache, true);
+		
+		createResolvedJavaTypeInfo("org.acme.qute.cyclic.ClassA", cache, false, "org.acme.qute.cyclic.ClassC");
+		createResolvedJavaTypeInfo("org.acme.qute.cyclic.ClassB", cache, false, "org.acme.qute.cyclic.ClassA");
+		createResolvedJavaTypeInfo("org.acme.qute.cyclic.ClassC", cache, false, "org.acme.qute.cyclic.ClassB");
 
 		// org.acme.MachineStatus
 		ResolvedJavaTypeInfo machineStatus = createResolvedJavaTypeInfo("org.acme.MachineStatus", cache, false);
@@ -131,7 +135,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @TemplateData
 		// public class ItemWithTemplateData
 		ResolvedJavaTypeInfo itemWithTemplateData = createResolvedJavaTypeInfo("org.acme.ItemWithTemplateData", cache,
-				false, baseItem);
+				false, baseItem.getSignature());
 		registerField("name : java.lang.String", itemWithTemplateData); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithTemplateData);
 		registerMethod("getReview2() : org.acme.Review", itemWithTemplateData);
@@ -142,7 +146,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @TemplateData(target = BigInteger.class)
 		// public class ItemWithTemplateDataWithTarget
 		ResolvedJavaTypeInfo itemWithTemplateDataWithTarget = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithTemplateDataWithTarget", cache, false, baseItem);
+				"org.acme.ItemWithTemplateDataWithTarget", cache, false, baseItem.getSignature());
 		registerField("name : java.lang.String", itemWithTemplateDataWithTarget); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithTemplateDataWithTarget);
 		registerMethod("getReview2() : org.acme.Review", itemWithTemplateDataWithTarget);
@@ -155,7 +159,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @TemplateData(properties = true)
 		// public class ItemWithTemplateDataProperties
 		ResolvedJavaTypeInfo itemWithTemplateDataProperties = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithTemplateDataProperties", cache, false, baseItem);
+				"org.acme.ItemWithTemplateDataProperties", cache, false, baseItem.getSignature());
 		registerField("name : java.lang.String", itemWithTemplateDataProperties); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithTemplateDataProperties);
 		registerMethod("getReview2() : org.acme.Review", itemWithTemplateDataProperties);
@@ -167,7 +171,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @TemplateData(ignoreSuperclasses = true)
 		// public class ItemWithTemplateDataIgnoreSubClasses
 		ResolvedJavaTypeInfo itemWithTemplateDataIgnoreSubClasses = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithTemplateDataIgnoreSubClasses", cache, false, baseItem);
+				"org.acme.ItemWithTemplateDataIgnoreSubClasses", cache, false, baseItem.getSignature());
 		registerField("name : java.lang.String", itemWithTemplateDataIgnoreSubClasses); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithTemplateDataIgnoreSubClasses);
 		registerMethod("getReview2() : org.acme.Review", itemWithTemplateDataIgnoreSubClasses);
@@ -179,7 +183,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @RegisterForReflection
 		// public class ItemWithRegisterForReflection
 		ResolvedJavaTypeInfo itemWithRegisterForReflection = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithRegisterForReflection", cache, false, baseItem);
+				"org.acme.ItemWithRegisterForReflection", cache, false, baseItem.getSignature());
 		registerField("name : java.lang.String", itemWithRegisterForReflection); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithRegisterForReflection);
 		registerMethod("getReview2() : org.acme.Review", itemWithRegisterForReflection);
@@ -189,7 +193,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @RegisterForReflection(fields = false)
 		// public class ItemWithRegisterForReflectionNoFields
 		ResolvedJavaTypeInfo itemWithRegisterForReflectionNoFields = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithRegisterForReflectionNoFields", cache, false, baseItem);
+				"org.acme.ItemWithRegisterForReflectionNoFields", cache, false, baseItem.getSignature());
 		registerField("name : java.lang.String", itemWithRegisterForReflectionNoFields); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithRegisterForReflectionNoFields);
 		registerMethod("getReview2() : org.acme.Review", itemWithRegisterForReflectionNoFields);
@@ -200,7 +204,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @RegisterForReflection(methods = false)
 		// public class ItemWithRegisterForReflectionNoMethods
 		ResolvedJavaTypeInfo itemWithRegisterForReflectionNoMethods = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithRegisterForReflectionNoMethods", cache, false, baseItem);
+				"org.acme.ItemWithRegisterForReflectionNoMethods", cache, false, baseItem.getSignature());
 		registerField("name : java.lang.String", itemWithRegisterForReflectionNoMethods); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithRegisterForReflectionNoMethods);
 		registerMethod("getReview2() : org.acme.Review", itemWithRegisterForReflectionNoMethods);

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInExpressionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInExpressionTest.java
@@ -366,4 +366,11 @@ public class QuteCompletionInExpressionTest {
 				c("getBytes(charsetName : String) : byte[]", "getBytes(${1:charsetName})$0", r(0, 8, 0, 8)),
 				c("charAt(index : int) : char", "charAt(${1:index})$0", r(0, 8, 0, 8)));
 	}
+	
+	@Test
+	public void objectWithCyclesObjectPart() throws Exception {
+		String template = "{@org.acme.qute.cyclic.ClassA classA}\n" + //
+				"{classA.|";
+		testCompletionFor(template, 5);
+	}
 }


### PR DESCRIPTION
If a cycle is detected, don't return any of the properties or methods of the class. Prevent ResolvedJavaTypeInfo from being fetched from qute.jdt multiple times. This prevents completion from freezing when you try to complete the properties and methods of an object whose class is part of an inheritance cycle.

Closes #725

Signed-off-by: David Thompson <davthomp@redhat.com>
