### PR TITLE
Prevent infinite recursion in validation, completion, code actions

### DIFF
--- a/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-quickstart/src/main/java/org/acme/qute/cyclic/ClassA.java
+++ b/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-quickstart/src/main/java/org/acme/qute/cyclic/ClassA.java
@@ -1,0 +1,11 @@
+package org.acme.qute.cyclic;
+
+public class ClassA extends ClassC {
+
+    public String name;
+
+    public String convert() {
+        return "hello";
+    }
+
+}

--- a/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-quickstart/src/main/java/org/acme/qute/cyclic/ClassB.java
+++ b/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-quickstart/src/main/java/org/acme/qute/cyclic/ClassB.java
@@ -1,0 +1,5 @@
+package org.acme.qute.cyclic;
+
+public class ClassB extends ClassA {
+
+}

--- a/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-quickstart/src/main/java/org/acme/qute/cyclic/ClassC.java
+++ b/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-quickstart/src/main/java/org/acme/qute/cyclic/ClassC.java
@@ -1,0 +1,5 @@
+package org.acme.qute.cyclic;
+
+public class ClassC extends ClassB {
+
+}

--- a/qute.jdt/com.redhat.qute.jdt.test/src/main/java/com/redhat/qute/jdt/template/TemplateGetJavaTypeTest.java
+++ b/qute.jdt/com.redhat.qute.jdt.test/src/main/java/com/redhat/qute/jdt/template/TemplateGetJavaTypeTest.java
@@ -91,6 +91,19 @@ public class TemplateGetJavaTypeTest {
 				t("org.acme.qute.NestedClass.Foo", JavaTypeKind.Class), //
 				t("org.acme.qute.NestedClass.Bar", JavaTypeKind.Class));
 	}
+	
+	@Test
+	public void cyclic() throws Exception {
+		loadMavenProject(QuteMavenProjectName.qute_quickstart);
+		
+		QuteJavaTypesParams params = new QuteJavaTypesParams("org.acme.qute.cyclic.", QuteMavenProjectName.qute_quickstart);
+		List<JavaTypeInfo> actual = QuteSupportForTemplate.getInstance().getJavaTypes(params, getJDTUtils(),
+				new NullProgressMonitor());
+		assertJavaTypes(actual, //
+				t("org.acme.qute.cyclic.ClassA", JavaTypeKind.Class), //
+				t("org.acme.qute.cyclic.ClassB", JavaTypeKind.Class), //
+				t("org.acme.qute.cyclic.ClassC", JavaTypeKind.Class));
+	}
 
 	public static JavaTypeInfo t(String typeName, JavaTypeKind kind) {
 		JavaTypeInfo javaType = new JavaTypeInfo();

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/codeactions/QuteCodeActionForUnknownMethod.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/codeactions/QuteCodeActionForUnknownMethod.java
@@ -115,6 +115,18 @@ public class QuteCodeActionForUnknownMethod extends AbstractQuteCodeAction {
 	private void collectSimilarCodeActionsForJavaMethods(MethodPart part, Template template, String projectUri,
 			ResolvedJavaTypeInfo baseResolvedType, JavaTypeFilter filter, Set<String> existingProperties,
 			Diagnostic diagnostic, List<CodeAction> codeActions) {
+		collectSimilarCodeActionsForJavaMethods(part, template, projectUri, baseResolvedType, filter,
+				existingProperties, diagnostic, codeActions, new HashSet<>());
+	}
+
+	private void collectSimilarCodeActionsForJavaMethods(MethodPart part, Template template, String projectUri,
+			ResolvedJavaTypeInfo baseResolvedType, JavaTypeFilter filter, Set<String> existingProperties,
+			Diagnostic diagnostic, List<CodeAction> codeActions, Set<ResolvedJavaTypeInfo> visited) {
+		if (visited.contains(baseResolvedType)) {
+			return;
+		}
+		visited.add(baseResolvedType);
+
 		// Java method similar code actions
 		for (JavaMethodInfo method : baseResolvedType.getMethods()) {
 			doCodeActionsForSimilarValue(part, method.getName(), template, existingProperties, diagnostic, codeActions);
@@ -131,7 +143,7 @@ public class QuteCodeActionForUnknownMethod extends AbstractQuteCodeAction {
 							.getNow(null);
 					if (resolvedExtendedType != null) {
 						collectSimilarCodeActionsForJavaMethods(part, template, projectUri, resolvedExtendedType,
-								filter, existingProperties, diagnostic, codeActions);
+								filter, existingProperties, diagnostic, codeActions, visited);
 					}
 				}
 			}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/codeactions/QuteCodeActionForUnknownProperty.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/codeactions/QuteCodeActionForUnknownProperty.java
@@ -161,6 +161,18 @@ public class QuteCodeActionForUnknownProperty extends AbstractQuteCodeAction {
 	private void collectSimilarCodeActionsForJavaProperties(PropertyPart part, Template template, String projectUri,
 			ResolvedJavaTypeInfo baseResolvedType, JavaTypeFilter filter, Set<String> existingProperties,
 			Diagnostic diagnostic, List<CodeAction> codeActions) {
+		collectSimilarCodeActionsForJavaProperties(part, template, projectUri, baseResolvedType, filter,
+				existingProperties, diagnostic, codeActions, new HashSet<>());
+	}
+
+	private void collectSimilarCodeActionsForJavaProperties(PropertyPart part, Template template, String projectUri,
+			ResolvedJavaTypeInfo baseResolvedType, JavaTypeFilter filter, Set<String> existingProperties,
+			Diagnostic diagnostic, List<CodeAction> codeActions, Set<ResolvedJavaTypeInfo> visited) {
+
+		if (visited.contains(baseResolvedType)) {
+			return;
+		}
+		visited.add(baseResolvedType);
 
 		// Java field similar code actions
 		for (JavaFieldInfo field : baseResolvedType.getFields()) {
@@ -186,7 +198,7 @@ public class QuteCodeActionForUnknownProperty extends AbstractQuteCodeAction {
 							.getNow(null);
 					if (resolvedExtendedType != null) {
 						collectSimilarCodeActionsForJavaProperties(part, template, projectUri, resolvedExtendedType,
-								filter, existingProperties, diagnostic, codeActions);
+								filter, existingProperties, diagnostic, codeActions, visited);
 					}
 				}
 			}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/MockQuteProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/MockQuteProject.java
@@ -12,6 +12,7 @@
 package com.redhat.qute.project;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -108,12 +109,12 @@ public abstract class MockQuteProject extends QuteProject {
 	}
 
 	protected static ResolvedJavaTypeInfo createResolvedJavaTypeInfo(String typeName, List<ResolvedJavaTypeInfo> cache, boolean binary,
-			ResolvedJavaTypeInfo... extended) {
+			String... extended) {
 		return createResolvedJavaTypeInfo(typeName, null, null, cache, binary, extended);
 	}
-
+	
 	protected static ResolvedJavaTypeInfo createResolvedJavaTypeInfo(String signature, String iterableType,
-			String iterableOf, List<ResolvedJavaTypeInfo> cache, boolean binary, ResolvedJavaTypeInfo... extended) {
+			String iterableOf, List<ResolvedJavaTypeInfo> cache, boolean binary, String... extended) {
 		ResolvedJavaTypeInfo resolvedType = new ResolvedJavaTypeInfo();
 		resolvedType.setJavaTypeKind(JavaTypeKind.Class);
 		resolvedType.setBinary(binary);
@@ -123,9 +124,7 @@ public abstract class MockQuteProject extends QuteProject {
 		resolvedType.setFields(new ArrayList<>());
 		resolvedType.setMethods(new ArrayList<>());
 		if (extended != null) {
-			List<String> extendedTypes = Stream.of(extended).map(type -> type.getSignature())
-					.collect(Collectors.toList());
-			resolvedType.setExtendedTypes(extendedTypes);
+			resolvedType.setExtendedTypes(Arrays.asList(extended));
 		}
 		resolvedType.setInvalidMethods(new HashMap<>());
 		cache.add(resolvedType);

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/QuteQuickStartProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/QuteQuickStartProject.java
@@ -91,13 +91,13 @@ public class QuteQuickStartProject extends MockQuteProject {
 		registerField("abstractName : java.lang.String", abstractItem);
 		registerMethod("convert(item : org.acme.AbstractItem) : int", abstractItem);
 
-		ResolvedJavaTypeInfo baseItem = createResolvedJavaTypeInfo("org.acme.BaseItem", cache, false, abstractItem);
+		ResolvedJavaTypeInfo baseItem = createResolvedJavaTypeInfo("org.acme.BaseItem", cache, false, abstractItem.getSignature());
 		registerField("base : java.lang.String", baseItem);
 		registerField("name : java.lang.String", baseItem);
 		registerMethod("getReviews() : java.util.List<org.acme.Review>", baseItem);
 
 		// org.acme.Item
-		ResolvedJavaTypeInfo item = createResolvedJavaTypeInfo("org.acme.Item", cache, false, baseItem);
+		ResolvedJavaTypeInfo item = createResolvedJavaTypeInfo("org.acme.Item", cache, false, baseItem.getSignature());
 		registerField("name : java.lang.String", item); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", item);
 		registerField("review : org.acme.Review", item);
@@ -114,6 +114,12 @@ public class QuteQuickStartProject extends MockQuteProject {
 		createResolvedJavaTypeInfo("java.util.List<org.acme.Item>", "java.util.List", "org.acme.Item", cache, true);
 		createResolvedJavaTypeInfo("java.lang.Iterable<org.acme.Item>", "java.lang.Iterable", "org.acme.Item", cache, true);
 		createResolvedJavaTypeInfo("org.acme.Item[]", null, "org.acme.Item", cache, true);
+
+		ResolvedJavaTypeInfo classA = createResolvedJavaTypeInfo("org.acme.qute.cyclic.ClassA", cache, false, "org.acme.qute.cyclic.ClassC");
+		createResolvedJavaTypeInfo("org.acme.qute.cyclic.ClassB", cache, false, "org.acme.qute.cyclic.ClassA");
+		createResolvedJavaTypeInfo("org.acme.qute.cyclic.ClassC", cache, false, "org.acme.qute.cyclic.ClassB");
+		registerMethod("convert() : java.lang.String", classA);
+		registerField("name : java.lang.String", classA);
 
 		// org.acme.MachineStatus
 		ResolvedJavaTypeInfo machineStatus = createResolvedJavaTypeInfo("org.acme.MachineStatus", cache, false);
@@ -132,7 +138,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @TemplateData
 		// public class ItemWithTemplateData
 		ResolvedJavaTypeInfo itemWithTemplateData = createResolvedJavaTypeInfo("org.acme.ItemWithTemplateData", cache,
-				false, baseItem);
+				false, baseItem.getSignature());
 		registerField("name : java.lang.String", itemWithTemplateData); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithTemplateData);
 		registerMethod("getReview2() : org.acme.Review", itemWithTemplateData);
@@ -143,7 +149,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @TemplateData(target = BigInteger.class)
 		// public class ItemWithTemplateDataWithTarget
 		ResolvedJavaTypeInfo itemWithTemplateDataWithTarget = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithTemplateDataWithTarget", cache, false, baseItem);
+				"org.acme.ItemWithTemplateDataWithTarget", cache, false, baseItem.getSignature());
 		registerField("name : java.lang.String", itemWithTemplateDataWithTarget); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithTemplateDataWithTarget);
 		registerMethod("getReview2() : org.acme.Review", itemWithTemplateDataWithTarget);
@@ -156,7 +162,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @TemplateData(properties = true)
 		// public class ItemWithTemplateDataProperties
 		ResolvedJavaTypeInfo itemWithTemplateDataProperties = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithTemplateDataProperties", cache, false, baseItem);
+				"org.acme.ItemWithTemplateDataProperties", cache, false, baseItem.getSignature());
 		registerField("name : java.lang.String", itemWithTemplateDataProperties); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithTemplateDataProperties);
 		registerMethod("getReview2() : org.acme.Review", itemWithTemplateDataProperties);
@@ -168,7 +174,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @TemplateData(ignoreSuperclasses = true)
 		// public class ItemWithTemplateDataIgnoreSubClasses
 		ResolvedJavaTypeInfo itemWithTemplateDataIgnoreSubClasses = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithTemplateDataIgnoreSubClasses", cache, false, baseItem);
+				"org.acme.ItemWithTemplateDataIgnoreSubClasses", cache, false, baseItem.getSignature());
 		registerField("name : java.lang.String", itemWithTemplateDataIgnoreSubClasses); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithTemplateDataIgnoreSubClasses);
 		registerMethod("getReview2() : org.acme.Review", itemWithTemplateDataIgnoreSubClasses);
@@ -180,7 +186,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @RegisterForReflection
 		// public class ItemWithRegisterForReflection
 		ResolvedJavaTypeInfo itemWithRegisterForReflection = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithRegisterForReflection", cache, false, baseItem);
+				"org.acme.ItemWithRegisterForReflection", cache, false, baseItem.getSignature());
 		registerField("name : java.lang.String", itemWithRegisterForReflection); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithRegisterForReflection);
 		registerMethod("getReview2() : org.acme.Review", itemWithRegisterForReflection);
@@ -190,7 +196,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @RegisterForReflection(fields = false)
 		// public class ItemWithRegisterForReflectionNoFields
 		ResolvedJavaTypeInfo itemWithRegisterForReflectionNoFields = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithRegisterForReflectionNoFields", cache, false, baseItem);
+				"org.acme.ItemWithRegisterForReflectionNoFields", cache, false, baseItem.getSignature());
 		registerField("name : java.lang.String", itemWithRegisterForReflectionNoFields); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithRegisterForReflectionNoFields);
 		registerMethod("getReview2() : org.acme.Review", itemWithRegisterForReflectionNoFields);
@@ -201,7 +207,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		// @RegisterForReflection(methods = false)
 		// public class ItemWithRegisterForReflectionNoMethods
 		ResolvedJavaTypeInfo itemWithRegisterForReflectionNoMethods = createResolvedJavaTypeInfo(
-				"org.acme.ItemWithRegisterForReflectionNoMethods", cache, false, baseItem);
+				"org.acme.ItemWithRegisterForReflectionNoMethods", cache, false, baseItem.getSignature());
 		registerField("name : java.lang.String", itemWithRegisterForReflectionNoMethods); // Override BaseItem#name
 		registerField("price : java.math.BigInteger", itemWithRegisterForReflectionNoMethods);
 		registerMethod("getReview2() : org.acme.Review", itemWithRegisterForReflectionNoMethods);
@@ -327,7 +333,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 						"getByIndex(list : java.util.List<T>, index : int) : T", ValueResolverKind.TemplateExtensionOnClass, false, true));
 		resolvers.add(createValueResolver(null, null, null, "org.acme.ItemResource",
 				"pretty(item : org.acme.Item, elements : java.lang.String...) : java.lang.String", ValueResolverKind.TemplateExtensionOnMethod, false, false));
-		
+
 		// @TemplateExtension
 		// org.acme.TemplateExtensions
 		resolvers.add(createValueResolver(null, null, null, "org.acme.TemplateExtensions", "", ValueResolverKind.TemplateExtensionOnClass, false, false));

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionForSimilarTextSuggestionsForUnknownMethodTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionForSimilarTextSuggestionsForUnknownMethodTest.java
@@ -109,4 +109,20 @@ public class QuteCodeActionForSimilarTextSuggestionsForUnknownMethodTest {
 				ca(d, te(0, 10, 0, 15, "charAt")));
 	}
 
+	@Test
+	public void similarTextSuggestionQuickFixForUndefinedMethodFromClassWithCyclicInheritance() throws Exception {
+		String template = "{@org.acme.qute.cyclic.ClassA classA}\r\n" + //
+				"{classA.conver()}";
+
+		Diagnostic d = d(1, 8, 1, 14, //
+				QuteErrorCode.UnknownMethod, //
+				"`conver` cannot be resolved or is not a method of `org.acme.qute.cyclic.ClassA` Java type.", //
+				DiagnosticSeverity.Error);
+		d.setData(new JavaBaseTypeOfPartData("org.acme.qute.cyclic.ClassA"));
+
+		testDiagnosticsFor(template, d);
+		testCodeActionsFor(template, d, //
+				ca(d, te(1, 8, 1, 14, "convert")));
+	}
+
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionForSimilarTextSuggestionsForUnknownPropertyTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionForSimilarTextSuggestionsForUnknownPropertyTest.java
@@ -120,4 +120,32 @@ public class QuteCodeActionForSimilarTextSuggestionsForUnknownPropertyTest {
 						"org.acme.Item", QuteQuickStartProject.PROJECT_URI)));
 	}
 
+	@Test
+	public void similarWithJavaFieldWithClassWithCyclicInheritance() throws Exception {
+		// Similar with Item.name
+
+		String template = "{@org.acme.qute.cyclic.ClassA classA}\r\n" + //
+				"{classA.nme}";
+
+		Diagnostic d = d(1, 8, 1, 11, //
+				QuteErrorCode.UnknownProperty, //
+				"`nme` cannot be resolved or is not a field of `org.acme.qute.cyclic.ClassA` Java type.", //
+				DiagnosticSeverity.Error);
+		d.setData(new JavaBaseTypeOfPartData("org.acme.qute.cyclic.ClassA"));
+
+		testDiagnosticsFor(template, d);
+		testCodeActionsFor(template, d, //
+				ca(d, te(1, 8, 1, 11, "name")), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.Field, "nme", "org.acme.qute.cyclic.ClassA",
+						QuteQuickStartProject.PROJECT_URI)), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.Getter, "nme", "org.acme.qute.cyclic.ClassA",
+						QuteQuickStartProject.PROJECT_URI)), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "nme", "org.acme.qute.cyclic.ClassA",
+						QuteQuickStartProject.PROJECT_URI, "org.acme.TemplateExtensions")), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "nme", "org.acme.qute.cyclic.ClassA",
+						QuteQuickStartProject.PROJECT_URI, "org.acme.foo.TemplateExtensions")), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.CreateTemplateExtension, "nme", "org.acme.qute.cyclic.ClassA",
+						QuteQuickStartProject.PROJECT_URI)));
+	}
+
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInExpressionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInExpressionTest.java
@@ -366,4 +366,12 @@ public class QuteCompletionInExpressionTest {
 				c("getBytes(charsetName : String) : byte[]", "getBytes(${1:charsetName})$0", r(0, 8, 0, 8)),
 				c("charAt(index : int) : char", "charAt(${1:index})$0", r(0, 8, 0, 8)));
 	}
+
+	@Test
+	public void objectWithCyclesObjectPart() throws Exception {
+		String template = "{@org.acme.qute.cyclic.ClassA classA}\n" + //
+				"{classA.|";
+		// Base resolvers for an object, plus a method and a field from ClassA
+		testCompletionFor(template, 7);
+	}
 }


### PR DESCRIPTION
Prevent types from being visited twice while collecting type information. This prevents validation, completion, and code actions from freezing when working with objects of classes that have cyclic inheritance.

Closes #725

Signed-off-by: David Thompson <davthomp@redhat.com>
