### PR TITLE
Qute parser does not parse operator parameters with '=' correctly

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/Parameter.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/Parameter.java
@@ -96,6 +96,9 @@ public class Parameter extends Node implements JavaTypeInfoProvider {
 	 * @return the parameter name.
 	 */
 	public String getName() {
+		if (name != null) {
+			return name;
+		}
 		if (!hasValueAssigned()) {
 			// ex : {#if foo?? }
 			Expression expression = getJavaTypeExpression();

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/sections/CaseSection.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/sections/CaseSection.java
@@ -16,6 +16,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.redhat.qute.parser.parameter.ParameterParser;
 import com.redhat.qute.parser.template.ASTVisitor;
 import com.redhat.qute.parser.template.CaseOperator;
 import com.redhat.qute.parser.template.Parameter;
@@ -87,10 +88,28 @@ public class CaseSection extends Section {
 
 	@Override
 	protected void initializeParameters(List<Parameter> parameters) {
-		// All parameters can have expression (ex : {#case OFF})
+		// All parameters can have expression.
+		// Ex :
+		// - {#case OFF}
+		// - {#case in ON OFF}
 		for (Parameter parameter : parameters) {
+			// Force the compute of parameter name here to support '=' in the name for some
+			// operator like:
+			// - !=
+			// - >=
+			parameter.setStartValue(parameter.getEnd());
+			parameter.getName();
+			parameter.setStartValue(NULL_VALUE);
 			parameter.setCanHaveExpression(true);
 		}
+	}
+
+	protected List<Parameter> collectParameters() {
+		// Don't split parameters with '=' to support operator like
+		// - !=
+		// - >=
+		boolean splitWithEquals = false;
+		return ParameterParser.parse(this, false, splitWithEquals);
 	}
 
 	@Override

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithWhenSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithWhenSectionTest.java
@@ -291,6 +291,26 @@ public class QuteDiagnosticsInExpressionWithWhenSectionTest {
 	}
 
 	@Test
+	public void whenExpressionOperatorWhichContainsEquals() {
+		String template = "{@org.acme.Machine Machine}\r\n" + //
+				"		{#when Machine.getMachine()}\r\n" + //
+				"		{#is != ON}\r\n" + //
+				"		{#is <= ON}\r\n" + //
+				"		{/when}";
+		testDiagnosticsFor(template);
+		
+		template = "{@org.acme.Machine Machine}\r\n" + //
+				"		{#when Machine.getMachine()}\r\n" + //
+				"		{#is != ON OFF}\r\n" + //
+				"		{#is <= ON}\r\n" + //
+				"		{/when}";
+		testDiagnosticsFor(template, //
+				d(2, 13, 2, 16, QuteErrorCode.UnexpectedParameter,
+						"Unexpected operand `OFF`. The operator `!=` in the `#is` section expects only one parameter.",
+						DiagnosticSeverity.Error));
+	}
+	
+	@Test
 	public void whenExpressionOperatorNoParameters() {
 		String template = "{@org.acme.Machine Machine}\r\n" + //
 				"		{#when Machine.status}\r\n" + //


### PR DESCRIPTION
Qute parser does not parse operator parameters with '=' correctly

Fixes #742

Signed-off-by: azerr <azerr@redhat.com>