### PR TITLE
Update Target Platform to 1.16.0-SNAPSHOT version of JDT-LS target.

### DIFF
--- a/buildAll.sh
+++ b/buildAll.sh
@@ -1,4 +1,4 @@
-cd quarkus.jdt.ext && ./mvnw clean verify && cd .. \
-cd quarkus.ls.ext/com.redhat.quarkus.ls && ./mvnw clean verify && cd ../.. \
-cd qute.jdt && ./mvnw clean verify && cd .. \
-cd qute.ls/com.redhat.qute.ls && ./mvnw clean verify && cd ../.. 
+cd quarkus.jdt.ext && ./mvnw clean verify && cd ..
+cd quarkus.ls.ext/com.redhat.quarkus.ls && ./mvnw clean verify && cd ../..
+cd qute.jdt && ./mvnw clean verify && cd ..
+cd qute.ls/com.redhat.qute.ls && ./mvnw clean verify && cd ../..

--- a/quarkus.jdt.ext/pom.xml
+++ b/quarkus.jdt.ext/pom.xml
@@ -14,7 +14,7 @@
     <tycho.extras.version>${tycho.version}</tycho.extras.version>
     <tycho.scmUrl>scm:git:https://github.com/redhat-developer/quarkus-ls</tycho.scmUrl>
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
-    <jdt.ls.version>1.14.0.20220721170741</jdt.ls.version>
+    <jdt.ls.version>1.16.0-SNAPSHOT</jdt.ls.version>
     <tycho.test.platformArgs />
     <tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
     <lsp4mp.p2.url>https://download.eclipse.org/lsp4mp/snapshots/0.6.0/repository/</lsp4mp.p2.url>
@@ -33,7 +33,7 @@
     <repository>
       <id>jdt.ls.p2</id>
       <layout>p2</layout>
-      <url>https://download.eclipse.org/jdtls/milestones/1.14.0/repository/</url>
+      <url>https://download.eclipse.org/jdtls/milestones/1.15.0/repository/</url>
     </repository>
     <repository>
       <id>lsp4mp.p2</id>
@@ -43,7 +43,7 @@
     <repository>
       <id>jdt.ls.maven</id>
       <!-- Used to resolve the jdt.ls TP -->
-      <url>https://repo.eclipse.org/content/repositories/jdtls-releases/</url>
+      <url>https://repo.eclipse.org/content/repositories/jdtls-snapshots/</url>
     </repository>
   </repositories>
   <build>

--- a/qute.jdt/pom.xml
+++ b/qute.jdt/pom.xml
@@ -16,7 +16,7 @@
 		<tycho.extras.version>${tycho.version}</tycho.extras.version>
 		<tycho.scmUrl>scm:git:https://github.com/redhat-developer/quarkus-ls</tycho.scmUrl>
 		<tycho.generateSourceReferences>true</tycho.generateSourceReferences>
-		<jdt.ls.version>1.14.0.20220721170741</jdt.ls.version>
+		<jdt.ls.version>1.16.0-SNAPSHOT</jdt.ls.version>
 		<tycho.test.platformArgs />
 		<tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
 
@@ -34,11 +34,11 @@
 		<repository>
 			<id>jdt.ls.p2</id>
 			<layout>p2</layout>
-			<url>https://download.eclipse.org/jdtls/milestones/1.14.0/repository/</url>
+			<url>https://download.eclipse.org/jdtls/milestones/1.15.0/repository/</url>
 		</repository>
 		<repository>
 			<id>jdt.ls.maven</id>
-			<url>https://repo.eclipse.org/content/repositories/jdtls-releases/</url>
+			<url>https://repo.eclipse.org/content/repositories/jdtls-snapshots/</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
- Use a proper release of JDT-LS 1.15.0 as it should be compatible
- Fix buildAll.sh on Linux so it runs all statements without halting

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>