### PR TITLE
Update Target Platform to 1.19.0-SNAPSHOT version of JDT-LS target.

### DIFF
--- a/quarkus.jdt.ext/pom.xml
+++ b/quarkus.jdt.ext/pom.xml
@@ -10,14 +10,14 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <tycho.version>2.7.2</tycho.version>
+    <tycho.version>3.0.1</tycho.version>
     <tycho.extras.version>${tycho.version}</tycho.extras.version>
     <tycho.scmUrl>scm:git:https://github.com/redhat-developer/quarkus-ls</tycho.scmUrl>
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
-    <jdt.ls.version>1.16.0-SNAPSHOT</jdt.ls.version>
+    <jdt.ls.version>1.19.0-SNAPSHOT</jdt.ls.version>
     <tycho.test.platformArgs />
     <tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
-    <lsp4mp.p2.url>https://download.eclipse.org/lsp4mp/snapshots/0.6.0/repository/</lsp4mp.p2.url>
+    <lsp4mp.p2.url>https://download.eclipse.org/lsp4mp/snapshots/0.7.0/repository/</lsp4mp.p2.url>
 
     <!-- Code coverage -->
     <jacoco.version>0.8.8</jacoco.version>
@@ -33,7 +33,7 @@
     <repository>
       <id>jdt.ls.p2</id>
       <layout>p2</layout>
-      <url>https://download.eclipse.org/jdtls/milestones/1.15.0/repository/</url>
+      <url>https://download.eclipse.org/jdtls/snapshots/repository/latest/</url>
     </repository>
     <repository>
       <id>lsp4mp.p2</id>

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/pom.xml
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/pom.xml
@@ -39,7 +39,7 @@
 		<maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
 		<dev.build.timestamp>${maven.build.timestamp}</dev.build.timestamp>
 		<lsp4j.version>0.14.0</lsp4j.version>
-		<microprofile.ls.version>0.6.0-SNAPSHOT</microprofile.ls.version>
+		<microprofile.ls.version>0.7.0-SNAPSHOT</microprofile.ls.version>
 		<jboss.releases.repo.id>jboss-releases-repository</jboss.releases.repo.id>
 		<jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
 		<jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>

--- a/qute.jdt/pom.xml
+++ b/qute.jdt/pom.xml
@@ -12,11 +12,11 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<tycho.version>2.7.2</tycho.version>
+		<tycho.version>3.0.1</tycho.version>
 		<tycho.extras.version>${tycho.version}</tycho.extras.version>
 		<tycho.scmUrl>scm:git:https://github.com/redhat-developer/quarkus-ls</tycho.scmUrl>
 		<tycho.generateSourceReferences>true</tycho.generateSourceReferences>
-		<jdt.ls.version>1.16.0-SNAPSHOT</jdt.ls.version>
+		<jdt.ls.version>1.19.0-SNAPSHOT</jdt.ls.version>
 		<tycho.test.platformArgs />
 		<tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
 
@@ -34,7 +34,7 @@
 		<repository>
 			<id>jdt.ls.p2</id>
 			<layout>p2</layout>
-			<url>https://download.eclipse.org/jdtls/milestones/1.15.0/repository/</url>
+			<url>https://download.eclipse.org/jdtls/snapshots/repository/latest/</url>
 		</repository>
 		<repository>
 			<id>jdt.ls.maven</id>


### PR DESCRIPTION
- Update lsp4mp version to 0.7.0-SNAPSHOT for quarkus.jdt.ext
- Update Tycho 2.7.2 to 3.0.1

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>