### PR TITLE
Prevent resolving code actions that run commands

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/CodeActionFactory.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/commons/CodeActionFactory.java
@@ -201,6 +201,7 @@ public class CodeActionFactory {
 		codeAction.setCommand(command);
 		codeAction.setDiagnostics(diagnostics);
 		codeAction.setKind(CodeActionKind.QuickFix);
+		codeAction.setEdit(new WorkspaceEdit());
 		return codeAction;
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
@@ -769,6 +769,7 @@ public class QuteAssert {
 		codeAction.setTitle("");
 		codeAction.setDiagnostics(Arrays.asList(d));
 		codeAction.setCommand(c);
+		codeAction.setEdit(new WorkspaceEdit());
 		return codeAction;
 	}
 


### PR DESCRIPTION
Some clients, like VS Code, will attempt to resolve a code action if `edit` is missing, even if a command is provided. In order to prevent this from happening, pass an empty `WorkspaceEdit` object as the `edit` for code actions that run commands.

Fixes redhat-developer/vscode-quarkus#598

Signed-off-by: David Thompson <davthomp@redhat.com>
