### PR TITLE
Tests for Renarde REST methods with no annotations

### DIFF
--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/projects/maven/quarkus-renarde-todo/src/main/java/rest/Application.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/projects/maven/quarkus-renarde-todo/src/main/java/rest/Application.java
@@ -31,4 +31,8 @@ public class Application extends Controller {
     public void test() {
 
     }
+
+    public String endpoint() {
+        return "asdf";
+    }
 }

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/renarde/RenardeJaxRsTest.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/src/main/java/com/redhat/microprofile/jdt/quarkus/renarde/RenardeJaxRsTest.java
@@ -46,9 +46,10 @@ public class RenardeJaxRsTest extends BasePropertiesManagerTest {
 		params.setUrlCodeLensEnabled(true);
 
 		assertCodeLens(params, JDT_UTILS, //
-				cl("http://localhost:8080/", "", r(20, 14, 20, 14)), //
-				cl("http://localhost:8080/about", "", r(25, 19, 25, 19)), //
-				cl("http://localhost:8080/Application/test", "", r(30, 9, 30, 9)));
+				cl("http://localhost:8080/", "", r(20, 14, 14)), //
+				cl("http://localhost:8080/about", "", r(25, 19, 19)), //
+				cl("http://localhost:8080/Application/test", "", r(30, 9, 9)), //
+				cl("http://localhost:8080/Application/endpoint", "", r(34, 18, 26)));
 	}
 
 	@Test
@@ -59,6 +60,7 @@ public class RenardeJaxRsTest extends BasePropertiesManagerTest {
 
 		assertWorkspaceSymbols(javaProject, JDT_UTILS, //
 				si("@/: GET", r(20, 28, 33)), //
+				si("@/Application/endpoint: GET", r(34, 18, 26)), //
 				si("@/Application/test: POST", r(30, 16, 20)), //
 				si("@/Login/complete: POST", r(174, 20, 28)), //
 				si("@/Login/confirm: GET", r(138, 28, 35)), //


### PR DESCRIPTION
Modifies the Renarde WorkspaceSymbol and CodeLens test cases in order to test that those features work on methods without any annotations on them.

Requires eclipse/lsp4mp#376

Signed-off-by: David Thompson <davthomp@redhat.com>
