### PR TITLE
Locate spot to generate `TemplateExtensions.java` better

### DIFF
--- a/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-quickstart/.classpath
+++ b/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-quickstart/.classpath
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="target/classes" path="src/main/java">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
@@ -16,6 +10,12 @@
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">


### PR DESCRIPTION
When locating the folder to generate `TemplateExtension.java` into
during the "generate missing member" Qute quick fix:
- Filter out classpath entries that are in the output (`target`) folder
- Filter out classpath entries that represent test code
- Filter out classpath entries that represent resource folders (folders
  with no Java source files)

Fixes #831

Signed-off-by: David Thompson <davthomp@redhat.com>
