### PR TITLE
Ignore 'UndefinedObject' + 'UndefinedNamespace' problem code action should appear only if LSP client can support update configuration.

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/codeactions/QuteCodeActionForUndefinedNamespace.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/codeactions/QuteCodeActionForUndefinedNamespace.java
@@ -26,6 +26,7 @@ import com.redhat.qute.parser.expression.NamespacePart;
 import com.redhat.qute.parser.template.Node;
 import com.redhat.qute.parser.template.Template;
 import com.redhat.qute.project.QuteProject;
+import com.redhat.qute.services.commands.QuteClientCommandConstants;
 import com.redhat.qute.services.diagnostics.QuteErrorCode;
 
 /**
@@ -55,10 +56,13 @@ public class QuteCodeActionForUndefinedNamespace extends AbstractQuteCodeAction 
 			// CodeAction(s) to replace text with similar suggestions
 			doCodeActionsForSimilarValues(part, template, diagnostic, codeActions);
 
-			// CodeAction to set validation severity to ignore
-			doCodeActionToSetIgnoreSeverity(template, diagnostic, QuteErrorCode.UndefinedNamespace, codeActions,
-					UNDEFINED_NAMESPACE_SEVERITY_SETTING);
-
+			boolean canUpdateConfiguration = request.getSharedSettings().getCommandCapabilities()
+					.isCommandSupported(QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE);
+			if (canUpdateConfiguration) {
+				// CodeAction to set validation severity to ignore
+				doCodeActionToSetIgnoreSeverity(template, diagnostic, QuteErrorCode.UndefinedNamespace, codeActions,
+						UNDEFINED_NAMESPACE_SEVERITY_SETTING);
+			}
 		} catch (BadLocationException e) {
 			LOGGER.log(Level.SEVERE, "Creation of undefined namespace code action failed", e);
 		}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/codeactions/QuteCodeActionForUndefinedObject.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/codeactions/QuteCodeActionForUndefinedObject.java
@@ -44,6 +44,7 @@ import com.redhat.qute.project.QuteProject;
 import com.redhat.qute.project.datamodel.ExtendedDataModelParameter;
 import com.redhat.qute.project.datamodel.ExtendedDataModelTemplate;
 import com.redhat.qute.project.datamodel.resolvers.ValueResolver;
+import com.redhat.qute.services.commands.QuteClientCommandConstants;
 import com.redhat.qute.services.diagnostics.QuteErrorCode;
 import com.redhat.qute.utils.StringUtils;
 import com.redhat.qute.utils.UserTagUtils;
@@ -83,9 +84,13 @@ public class QuteCodeActionForUndefinedObject extends AbstractQuteCodeAction {
 			// CodeAction to append ?? to object to make it optional
 			doCodeActionToAddOptionalSuffix(template, diagnostic, codeActions);
 
-			// CodeAction to set validation severity to ignore
-			doCodeActionToSetIgnoreSeverity(template, diagnostic, QuteErrorCode.UndefinedObject, codeActions,
-					UNDEFINED_OBJECT_SEVERITY_SETTING);
+			boolean canUpdateConfiguration = request.getSharedSettings().getCommandCapabilities()
+					.isCommandSupported(QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE);
+			if (canUpdateConfiguration) {
+				// CodeAction to set validation severity to ignore
+				doCodeActionToSetIgnoreSeverity(template, diagnostic, QuteErrorCode.UndefinedObject, codeActions,
+						UNDEFINED_OBJECT_SEVERITY_SETTING);
+			}
 
 		} catch (BadLocationException e) {
 			LOGGER.log(Level.SEVERE, "Creation of undefined object code action failed", e);

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
@@ -117,7 +117,7 @@ public class QuteAssert {
 												 */;
 
 	public static final int SECTION_SNIPPET_SIZE = 15 /* #each, #for, ... #fragment ... */ + USER_TAG_SIZE;
-	
+
 	public static final int RESOLVERS_SIZE = 9;
 
 	public static String getFileUri(String templateFile) {
@@ -606,7 +606,7 @@ public class QuteAssert {
 		template.setTemplateId(templateId);
 
 		QuteLanguageService languageService = new QuteLanguageService(projectRegistry);
-		SharedSettings sharedSettings = createSharedSettings();
+		SharedSettings sharedSettings = createSharedSettings(false);
 		List<? extends CodeLens> actual = languageService.getCodeLens(template, sharedSettings, () -> {
 		}).get();
 		assertCodeLens(actual, expected);
@@ -647,7 +647,7 @@ public class QuteAssert {
 		Template template = createTemplate(value, fileUri, projectUri, templateBaseDir, projectRegistry);
 		template.setTemplateId(templateId);
 
-		SharedSettings settings = createSharedSettings();
+		SharedSettings settings = createSharedSettings(false);
 		if (inlayHintSettings != null) {
 			settings.getInlayHintSettings().update(inlayHintSettings);
 		}
@@ -689,9 +689,14 @@ public class QuteAssert {
 
 	// ------------------- CodeAction assert
 
+	public static void testCodeActionsWithConfigurationUpdateFor(String value, Diagnostic diagnostic, CodeAction... expected)
+			throws Exception {
+		testCodeActionsFor(value, diagnostic, createSharedSettings(true), expected);
+	}
+	
 	public static void testCodeActionsFor(String value, Diagnostic diagnostic, CodeAction... expected)
 			throws Exception {
-		testCodeActionsFor(value, diagnostic, new SharedSettings(), expected);
+		testCodeActionsFor(value, diagnostic, createSharedSettings(false), expected);
 	}
 
 	public static void testCodeActionsFor(String value, Diagnostic diagnostic, SharedSettings settings,
@@ -1022,12 +1027,16 @@ public class QuteAssert {
 		return template;
 	}
 
-	private static SharedSettings createSharedSettings() {
+	public static SharedSettings createSharedSettings(boolean withConfigurationUpdate) {
 		SharedSettings sharedSettings = new SharedSettings();
 		CommandCapabilities commandCapabilities = new CommandCapabilities();
 		CommandKindCapabilities kinds = new CommandKindCapabilities(
-				Arrays.asList(QuteClientCommandConstants.COMMAND_JAVA_DEFINITION,
-						QuteClientCommandConstants.COMMAND_SHOW_REFERENCES));
+				withConfigurationUpdate ? 
+						Arrays.asList(QuteClientCommandConstants.COMMAND_JAVA_DEFINITION,
+						QuteClientCommandConstants.COMMAND_SHOW_REFERENCES,
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE) : 
+							Arrays.asList(QuteClientCommandConstants.COMMAND_JAVA_DEFINITION,
+									QuteClientCommandConstants.COMMAND_SHOW_REFERENCES));
 		commandCapabilities.setCommandKind(kinds);
 		sharedSettings.getCommandCapabilities().setCapabilities(commandCapabilities);
 		return sharedSettings;

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionForSimilarTextSuggestionsForUndefinedNamespaceTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionForSimilarTextSuggestionsForUndefinedNamespaceTest.java
@@ -16,6 +16,7 @@ import static com.redhat.qute.QuteAssert.ca;
 import static com.redhat.qute.QuteAssert.d;
 import static com.redhat.qute.QuteAssert.te;
 import static com.redhat.qute.QuteAssert.testCodeActionsFor;
+import static com.redhat.qute.QuteAssert.testCodeActionsWithConfigurationUpdateFor;
 import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 
 import org.eclipse.lsp4j.Diagnostic;
@@ -27,7 +28,8 @@ import com.redhat.qute.services.commands.QuteClientCommandConstants;
 import com.redhat.qute.services.diagnostics.QuteErrorCode;
 
 /**
- * Test code action for similar text suggestions for {@link QuteErrorCode#UndefinedNamespace}.
+ * Test code action for similar text suggestions for
+ * {@link QuteErrorCode#UndefinedNamespace}.
  *
  */
 public class QuteCodeActionForSimilarTextSuggestionsForUndefinedNamespaceTest {
@@ -42,12 +44,26 @@ public class QuteCodeActionForSimilarTextSuggestionsForUndefinedNamespaceTest {
 
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
+				ca(d, te(0, 1, 0, 5, "inject")));
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
 				ca(d, te(0, 1, 0, 5, "inject")), //
 				ca(d, c("Ignore `UndefinedNamespace` problem.", //
 						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
 						"qute.validation.undefinedNamespace.severity", //
 						"test.qute", //
 						ConfigurationItemEditType.update, "ignore", //
+						d)),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
 						d)));
 	}
 
@@ -60,13 +76,26 @@ public class QuteCodeActionForSimilarTextSuggestionsForUndefinedNamespaceTest {
 				DiagnosticSeverity.Warning);
 
 		testDiagnosticsFor(template, d);
-		testCodeActionsFor(template, d, //
+		testCodeActionsFor(template, d);
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
 				ca(d, c("Ignore `UndefinedNamespace` problem.", //
 						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
 						"qute.validation.undefinedNamespace.severity", //
 						"test.qute", //
 						ConfigurationItemEditType.update, "ignore", //
-						d)));
+						d)),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
+						d)));		
 	}
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionForSimilarTextSuggestionsForUndefinedObjectTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionForSimilarTextSuggestionsForUndefinedObjectTest.java
@@ -16,6 +16,7 @@ import static com.redhat.qute.QuteAssert.ca;
 import static com.redhat.qute.QuteAssert.d;
 import static com.redhat.qute.QuteAssert.te;
 import static com.redhat.qute.QuteAssert.testCodeActionsFor;
+import static com.redhat.qute.QuteAssert.testCodeActionsWithConfigurationUpdateFor;
 import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 
 import org.eclipse.lsp4j.Diagnostic;
@@ -47,13 +48,30 @@ public class QuteCodeActionForSimilarTextSuggestionsForUndefinedObjectTest {
 		testCodeActionsFor(template, d, //
 				ca(d, te(1, 1, 1, 5, "string")), //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String stri}\r\n")), //
+				ca(d, te(1, 5, 1, 5, "??")));
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
+				ca(d, te(1, 1, 1, 5, "string")), //
+				ca(d, te(0, 0, 0, 0, "{@java.lang.String stri}\r\n")), //
 				ca(d, te(1, 5, 1, 5, "??")), //
 				ca(d, c("Ignore `UndefinedObject` problem.", //
 						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
 						"qute.validation.undefinedObject.severity", //
 						"test.qute", //
 						ConfigurationItemEditType.update, "ignore", //
+						d)),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
 						d)));
+
 	}
 
 	@Test
@@ -70,13 +88,30 @@ public class QuteCodeActionForSimilarTextSuggestionsForUndefinedObjectTest {
 		testCodeActionsFor(template, d, //
 				ca(d, te(1, 1, 1, 5, "string")), //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String trin}\r\n")), //
+				ca(d, te(1, 5, 1, 5, "??")));
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
+				ca(d, te(1, 1, 1, 5, "string")), //
+				ca(d, te(0, 0, 0, 0, "{@java.lang.String trin}\r\n")), //
 				ca(d, te(1, 5, 1, 5, "??")), //
 				ca(d, c("Ignore `UndefinedObject` problem.", //
 						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
 						"qute.validation.undefinedObject.severity", //
 						"test.qute", //
 						ConfigurationItemEditType.update, "ignore", //
+						d)),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
 						d)));
+
 	}
 
 	@Test
@@ -92,13 +127,30 @@ public class QuteCodeActionForSimilarTextSuggestionsForUndefinedObjectTest {
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String abc}" + //
 						System.lineSeparator())), //
+				ca(d, te(0, 4, 0, 4, "??")));
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
+				ca(d, te(0, 0, 0, 0, "{@java.lang.String abc}" + //
+						System.lineSeparator())), //
 				ca(d, te(0, 4, 0, 4, "??")), //
 				ca(d, c("Ignore `UndefinedObject` problem.", //
 						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
 						"qute.validation.undefinedObject.severity", //
 						"test.qute", //
 						ConfigurationItemEditType.update, "ignore", //
+						d)),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
 						d)));
+
 	}
 
 	@Test
@@ -118,13 +170,30 @@ public class QuteCodeActionForSimilarTextSuggestionsForUndefinedObjectTest {
 		testCodeActionsFor(template, d, //
 				ca(d, te(2, 21, 2, 25, "index")), //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String inde}\r\n")), //
+				ca(d, te(2, 25, 2, 25, "??")));
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
+				ca(d, te(2, 21, 2, 25, "index")), //
+				ca(d, te(0, 0, 0, 0, "{@java.lang.String inde}\r\n")), //
 				ca(d, te(2, 25, 2, 25, "??")), //
 				ca(d, c("Ignore `UndefinedObject` problem.", //
 						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
 						"qute.validation.undefinedObject.severity", //
 						"test.qute", //
 						ConfigurationItemEditType.update, "ignore", //
+						d)),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
 						d)));
+
 	}
 
 	@Test
@@ -142,12 +211,28 @@ public class QuteCodeActionForSimilarTextSuggestionsForUndefinedObjectTest {
 		testCodeActionsFor(template, d, //
 				ca(d, te(2, 2, 2, 5, "item")), //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String ite}\r\n")), //
+				ca(d, te(2, 5, 2, 5, "??")));
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
+				ca(d, te(2, 2, 2, 5, "item")), //
+				ca(d, te(0, 0, 0, 0, "{@java.lang.String ite}\r\n")), //
 				ca(d, te(2, 5, 2, 5, "??")), //
 				ca(d, c("Ignore `UndefinedObject` problem.", //
 						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
 						"qute.validation.undefinedObject.severity", //
 						"test.qute", //
 						ConfigurationItemEditType.update, "ignore", //
+						d)),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
 						d)));
 	}
 
@@ -168,13 +253,30 @@ public class QuteCodeActionForSimilarTextSuggestionsForUndefinedObjectTest {
 				ca(d, te(2, 2, 2, 5, "item")), //
 				ca(d, te(2, 2, 2, 5, "items")), //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String ite}\r\n")), //
+				ca(d, te(2, 5, 2, 5, "??")));
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
+				ca(d, te(2, 2, 2, 5, "item")), //
+				ca(d, te(2, 2, 2, 5, "items")), //
+				ca(d, te(0, 0, 0, 0, "{@java.lang.String ite}\r\n")), //
 				ca(d, te(2, 5, 2, 5, "??")), //
 				ca(d, c("Ignore `UndefinedObject` problem.", //
 						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
 						"qute.validation.undefinedObject.severity", //
 						"test.qute", //
 						ConfigurationItemEditType.update, "ignore", //
-						d)));
+						d)),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
+						d)));		
 	}
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionForSimilarTextSuggestionsForUnknownMethodTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionForSimilarTextSuggestionsForUnknownMethodTest.java
@@ -11,16 +11,20 @@
 *******************************************************************************/
 package com.redhat.qute.services.codeaction;
 
+import static com.redhat.qute.QuteAssert.c;
 import static com.redhat.qute.QuteAssert.ca;
 import static com.redhat.qute.QuteAssert.d;
 import static com.redhat.qute.QuteAssert.te;
 import static com.redhat.qute.QuteAssert.testCodeActionsFor;
+import static com.redhat.qute.QuteAssert.testCodeActionsWithConfigurationUpdateFor;
 import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.jupiter.api.Test;
 
+import com.redhat.qute.ls.commons.client.ConfigurationItemEditType;
+import com.redhat.qute.services.commands.QuteClientCommandConstants;
 import com.redhat.qute.services.diagnostics.JavaBaseTypeOfPartData;
 import com.redhat.qute.services.diagnostics.QuteErrorCode;
 
@@ -45,6 +49,20 @@ public class QuteCodeActionForSimilarTextSuggestionsForUnknownMethodTest {
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
 				ca(d, te(1, 8, 1, 13, "charAt")));
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
+				ca(d, te(1, 8, 1, 13, "charAt")),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
+						d)));
 	}
 
 	@Test
@@ -61,6 +79,20 @@ public class QuteCodeActionForSimilarTextSuggestionsForUnknownMethodTest {
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
 				ca(d, te(1, 8, 1, 13, "orEmpty")));
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
+				ca(d, te(1, 8, 1, 13, "orEmpty")),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
+						d)));
 	}
 
 	@Test
@@ -77,6 +109,20 @@ public class QuteCodeActionForSimilarTextSuggestionsForUnknownMethodTest {
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
 				ca(d, te(1, 6, 1, 12, "convert")));
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
+				ca(d, te(1, 6, 1, 12, "convert")),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
+						d)));
 	}
 
 	@Test
@@ -92,6 +138,19 @@ public class QuteCodeActionForSimilarTextSuggestionsForUnknownMethodTest {
 
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d);
+		testCodeActionsWithConfigurationUpdateFor(template, d,
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
+						d)));
 	}
 
 	@Test
@@ -107,6 +166,21 @@ public class QuteCodeActionForSimilarTextSuggestionsForUnknownMethodTest {
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 10, 0, 15, "charAt")));
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
+				ca(d, te(0, 10, 0, 15, "charAt")),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
+						d)));
+
 	}
 
 	@Test
@@ -123,6 +197,20 @@ public class QuteCodeActionForSimilarTextSuggestionsForUnknownMethodTest {
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
 				ca(d, te(1, 8, 1, 14, "convert")));
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
+				ca(d, te(1, 8, 1, 14, "convert")),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
+						d)));
 	}
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionForSimilarTextSuggestionsForUnknownPropertyTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionForSimilarTextSuggestionsForUnknownPropertyTest.java
@@ -11,11 +11,13 @@
 *******************************************************************************/
 package com.redhat.qute.services.codeaction;
 
+import static com.redhat.qute.QuteAssert.c;
 import static com.redhat.qute.QuteAssert.ca;
 import static com.redhat.qute.QuteAssert.cad;
 import static com.redhat.qute.QuteAssert.d;
 import static com.redhat.qute.QuteAssert.te;
 import static com.redhat.qute.QuteAssert.testCodeActionsFor;
+import static com.redhat.qute.QuteAssert.testCodeActionsWithConfigurationUpdateFor;
 import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 
 import org.eclipse.lsp4j.Diagnostic;
@@ -24,7 +26,9 @@ import org.junit.jupiter.api.Test;
 
 import com.redhat.qute.commons.GenerateMissingJavaMemberParams;
 import com.redhat.qute.commons.GenerateMissingJavaMemberParams.MemberType;
+import com.redhat.qute.ls.commons.client.ConfigurationItemEditType;
 import com.redhat.qute.project.QuteQuickStartProject;
+import com.redhat.qute.services.commands.QuteClientCommandConstants;
 import com.redhat.qute.services.diagnostics.JavaBaseTypeOfPartData;
 import com.redhat.qute.services.diagnostics.QuteErrorCode;
 
@@ -61,6 +65,31 @@ public class QuteCodeActionForSimilarTextSuggestionsForUnknownPropertyTest {
 						QuteQuickStartProject.PROJECT_URI, "org.acme.foo.TemplateExtensions")), //
 				cad(d, new GenerateMissingJavaMemberParams(MemberType.CreateTemplateExtension, "nme", "org.acme.Item",
 						QuteQuickStartProject.PROJECT_URI)));
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
+				ca(d, te(1, 6, 1, 9, "name")), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.Field, "nme", "org.acme.Item",
+						QuteQuickStartProject.PROJECT_URI)), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.Getter, "nme", "org.acme.Item",
+						QuteQuickStartProject.PROJECT_URI)), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "nme", "org.acme.Item",
+						QuteQuickStartProject.PROJECT_URI, "org.acme.TemplateExtensions")), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "nme", "org.acme.Item",
+						QuteQuickStartProject.PROJECT_URI, "org.acme.foo.TemplateExtensions")), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.CreateTemplateExtension, "nme", "org.acme.Item",
+						QuteQuickStartProject.PROJECT_URI)),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
+						d)));
+
 	}
 
 	@Test
@@ -89,6 +118,30 @@ public class QuteCodeActionForSimilarTextSuggestionsForUnknownPropertyTest {
 						"org.acme.Item", QuteQuickStartProject.PROJECT_URI, "org.acme.foo.TemplateExtensions")), //
 				cad(d, new GenerateMissingJavaMemberParams(MemberType.CreateTemplateExtension, "avilable",
 						"org.acme.Item", QuteQuickStartProject.PROJECT_URI)));
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
+				ca(d, te(1, 6, 1, 14, "available")), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.Field, "avilable", "org.acme.Item",
+						QuteQuickStartProject.PROJECT_URI)), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.Getter, "avilable", "org.acme.Item",
+						QuteQuickStartProject.PROJECT_URI)), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "avilable",
+						"org.acme.Item", QuteQuickStartProject.PROJECT_URI, "org.acme.TemplateExtensions")), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "avilable",
+						"org.acme.Item", QuteQuickStartProject.PROJECT_URI, "org.acme.foo.TemplateExtensions")), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.CreateTemplateExtension, "avilable",
+						"org.acme.Item", QuteQuickStartProject.PROJECT_URI)),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
+						d)));
 	}
 
 	@Test
@@ -118,6 +171,30 @@ public class QuteCodeActionForSimilarTextSuggestionsForUnknownPropertyTest {
 						"org.acme.Item", QuteQuickStartProject.PROJECT_URI, "org.acme.foo.TemplateExtensions")), //
 				cad(d, new GenerateMissingJavaMemberParams(MemberType.CreateTemplateExtension, "discountedPrce",
 						"org.acme.Item", QuteQuickStartProject.PROJECT_URI)));
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
+				ca(d, te(1, 6, 1, 20, "discountedPrice")), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.Field, "discountedPrce", "org.acme.Item",
+						QuteQuickStartProject.PROJECT_URI)), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.Getter, "discountedPrce", "org.acme.Item",
+						QuteQuickStartProject.PROJECT_URI)), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "discountedPrce",
+						"org.acme.Item", QuteQuickStartProject.PROJECT_URI, "org.acme.TemplateExtensions")), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "discountedPrce",
+						"org.acme.Item", QuteQuickStartProject.PROJECT_URI, "org.acme.foo.TemplateExtensions")), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.CreateTemplateExtension, "discountedPrce",
+						"org.acme.Item", QuteQuickStartProject.PROJECT_URI)),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
+						d)));
 	}
 
 	@Test
@@ -140,12 +217,42 @@ public class QuteCodeActionForSimilarTextSuggestionsForUnknownPropertyTest {
 						QuteQuickStartProject.PROJECT_URI)), //
 				cad(d, new GenerateMissingJavaMemberParams(MemberType.Getter, "nme", "org.acme.qute.cyclic.ClassA",
 						QuteQuickStartProject.PROJECT_URI)), //
-				cad(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "nme", "org.acme.qute.cyclic.ClassA",
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "nme",
+						"org.acme.qute.cyclic.ClassA",
 						QuteQuickStartProject.PROJECT_URI, "org.acme.TemplateExtensions")), //
-				cad(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "nme", "org.acme.qute.cyclic.ClassA",
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "nme",
+						"org.acme.qute.cyclic.ClassA",
 						QuteQuickStartProject.PROJECT_URI, "org.acme.foo.TemplateExtensions")), //
-				cad(d, new GenerateMissingJavaMemberParams(MemberType.CreateTemplateExtension, "nme", "org.acme.qute.cyclic.ClassA",
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.CreateTemplateExtension, "nme",
+						"org.acme.qute.cyclic.ClassA",
 						QuteQuickStartProject.PROJECT_URI)));
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
+				ca(d, te(1, 8, 1, 11, "name")), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.Field, "nme", "org.acme.qute.cyclic.ClassA",
+						QuteQuickStartProject.PROJECT_URI)), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.Getter, "nme", "org.acme.qute.cyclic.ClassA",
+						QuteQuickStartProject.PROJECT_URI)), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "nme",
+						"org.acme.qute.cyclic.ClassA",
+						QuteQuickStartProject.PROJECT_URI, "org.acme.TemplateExtensions")), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.AppendTemplateExtension, "nme",
+						"org.acme.qute.cyclic.ClassA",
+						QuteQuickStartProject.PROJECT_URI, "org.acme.foo.TemplateExtensions")), //
+				cad(d, new GenerateMissingJavaMemberParams(MemberType.CreateTemplateExtension, "nme",
+						"org.acme.qute.cyclic.ClassA",
+						QuteQuickStartProject.PROJECT_URI)),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
+						d)));
 	}
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionWithSettingsTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteCodeActionWithSettingsTest.java
@@ -16,6 +16,7 @@ import static com.redhat.qute.QuteAssert.ca;
 import static com.redhat.qute.QuteAssert.d;
 import static com.redhat.qute.QuteAssert.te;
 import static com.redhat.qute.QuteAssert.testCodeActionsFor;
+import static com.redhat.qute.QuteAssert.testCodeActionsWithConfigurationUpdateFor;
 import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 
 import java.util.Arrays;
@@ -53,13 +54,30 @@ public class QuteCodeActionWithSettingsTest {
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String item}" + //
 						System.lineSeparator())), //
+				ca(d, te(0, 5, 0, 5, "??")));
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
+				ca(d, te(0, 0, 0, 0, "{@java.lang.String item}" + //
+						System.lineSeparator())), //
 				ca(d, te(0, 5, 0, 5, "??")), //
 				ca(d, c("Ignore `UndefinedObject` problem.", //
 						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
 						"qute.validation.undefinedObject.severity", //
 						"test.qute", //
 						ConfigurationItemEditType.update, "ignore", //
+						d)),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
 						d)));
+								
 	}
 
 	@Test
@@ -72,13 +90,26 @@ public class QuteCodeActionWithSettingsTest {
 				DiagnosticSeverity.Warning);
 
 		testDiagnosticsFor(template, d);
-		testCodeActionsFor(template, d, //
+		testCodeActionsFor(template, d);
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
 				ca(d, c("Ignore `UndefinedNamespace` problem.", //
 						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
 						"qute.validation.undefinedNamespace.severity", //
 						"test.qute", //
 						ConfigurationItemEditType.update, "ignore", //
-						d)));
+						d)),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
+						d)));				
 	}
 
 	@Test

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteGenerateMissingMemberCodeActionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codeaction/QuteGenerateMissingMemberCodeActionTest.java
@@ -11,6 +11,8 @@
 *******************************************************************************/
 package com.redhat.qute.services.codeaction;
 
+import static com.redhat.qute.QuteAssert.c;
+import static com.redhat.qute.QuteAssert.ca;
 import static com.redhat.qute.QuteAssert.cad;
 import static com.redhat.qute.QuteAssert.d;
 import static com.redhat.qute.QuteAssert.testCodeActionsFor;
@@ -26,9 +28,11 @@ import org.junit.jupiter.api.Test;
 
 import com.redhat.qute.commons.GenerateMissingJavaMemberParams;
 import com.redhat.qute.commons.GenerateMissingJavaMemberParams.MemberType;
+import com.redhat.qute.ls.commons.client.ConfigurationItemEditType;
 import com.redhat.qute.project.QuteQuickStartProject;
 import com.redhat.qute.services.codeactions.CodeActionResolverKind;
 import com.redhat.qute.services.codeactions.CodeActionUnresolvedData;
+import com.redhat.qute.services.commands.QuteClientCommandConstants;
 import com.redhat.qute.services.diagnostics.JavaBaseTypeOfPartData;
 import com.redhat.qute.services.diagnostics.QuteErrorCode;
 import com.redhat.qute.settings.SharedSettings;
@@ -58,6 +62,7 @@ public class QuteGenerateMissingMemberCodeActionTest {
 						QuteQuickStartProject.PROJECT_URI, "org.acme.foo.TemplateExtensions")), //
 				cad(d, new GenerateMissingJavaMemberParams(MemberType.CreateTemplateExtension, "asdf", "org.acme.Item",
 						QuteQuickStartProject.PROJECT_URI)));
+
 	}
 
 	@Test

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionTest.java
@@ -16,6 +16,7 @@ import static com.redhat.qute.QuteAssert.ca;
 import static com.redhat.qute.QuteAssert.d;
 import static com.redhat.qute.QuteAssert.te;
 import static com.redhat.qute.QuteAssert.testCodeActionsFor;
+import static com.redhat.qute.QuteAssert.testCodeActionsWithConfigurationUpdateFor;
 import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 
 import org.eclipse.lsp4j.Diagnostic;
@@ -63,13 +64,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String trueX}" + //
 						System.lineSeparator())), //
-				ca(d, te(0, 6, 0, 6, "??")), //
-				ca(d, c("Ignore `UndefinedObject` problem.", //
-						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
-						"qute.validation.undefinedObject.severity", //
-						"test.qute", //
-						ConfigurationItemEditType.update, "ignore", //
-						d)));
+				ca(d, te(0, 6, 0, 6, "??")));
 
 		template = "{false}";
 		testDiagnosticsFor(template);
@@ -82,13 +77,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String falseX}" + //
 						System.lineSeparator())), //
-				ca(d, te(0, 7, 0, 7, "??")), //
-				ca(d, c("Ignore `UndefinedObject` problem.", //
-						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
-						"qute.validation.undefinedObject.severity", //
-						"test.qute", //
-						ConfigurationItemEditType.update, "ignore", //
-						d)));
+				ca(d, te(0, 7, 0, 7, "??")));
 	}
 
 	@Test
@@ -104,13 +93,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String nullX}" + //
 						System.lineSeparator())), //
-				ca(d, te(0, 6, 0, 6, "??")), //
-				ca(d, c("Ignore `UndefinedObject` problem.", //
-						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
-						"qute.validation.undefinedObject.severity", //
-						"test.qute", //
-						ConfigurationItemEditType.update, "ignore", //
-						d)));
+				ca(d, te(0, 6, 0, 6, "??")));
 	}
 
 	@Test
@@ -135,13 +118,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String 123X}" + //
 						System.lineSeparator())), //
-				ca(d, te(0, 5, 0, 5, "??")), //
-				ca(d, c("Ignore `UndefinedObject` problem.", //
-						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
-						"qute.validation.undefinedObject.severity", //
-						"test.qute", //
-						ConfigurationItemEditType.update, "ignore", //
-						d)));
+				ca(d, te(0, 5, 0, 5, "??")));
 	}
 
 	@Test
@@ -157,13 +134,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String 123LX}" + //
 						System.lineSeparator())), //
-				ca(d, te(0, 6, 0, 6, "??")), //
-				ca(d, c("Ignore `UndefinedObject` problem.", //
-						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
-						"qute.validation.undefinedObject.severity", //
-						"test.qute", //
-						ConfigurationItemEditType.update, "ignore", //
-						d)));
+				ca(d, te(0, 6, 0, 6, "??")));
 	}
 
 	@Test
@@ -179,13 +150,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String item}" + //
 						System.lineSeparator())), //
-				ca(d, te(0, 5, 0, 5, "??")), //
-				ca(d, c("Ignore `UndefinedObject` problem.", //
-						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
-						"qute.validation.undefinedObject.severity", //
-						"test.qute", //
-						ConfigurationItemEditType.update, "ignore", //
-						d)));
+				ca(d, te(0, 5, 0, 5, "??")));
 	}
 
 	@Test
@@ -201,13 +166,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String nested-content}" + //
 						System.lineSeparator())), //
-				ca(d, te(0, 15, 0, 15, "??")), //
-				ca(d, c("Ignore `UndefinedObject` problem.", //
-						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
-						"qute.validation.undefinedObject.severity", //
-						"test.qute", //
-						ConfigurationItemEditType.update, "ignore", //
-						d)));
+				ca(d, te(0, 15, 0, 15, "??")));
 	}
 
 	@Test
@@ -367,13 +326,7 @@ public class QuteDiagnosticsInExpressionTest {
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String person}" + //
 						System.lineSeparator())), //
-				ca(d, te(0, 7, 0, 7, "??")), //
-				ca(d, c("Ignore `UndefinedObject` problem.", //
-						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
-						"qute.validation.undefinedObject.severity", //
-						"test.qute", //
-						ConfigurationItemEditType.update, "ignore", //
-						d)));
+				ca(d, te(0, 7, 0, 7, "??")));
 	}
 
 	@Test
@@ -390,12 +343,25 @@ public class QuteDiagnosticsInExpressionTest {
 		Diagnostic d = d(1, 1, 1, 8, QuteErrorCode.UndefinedNamespace, "No namespace resolver found for: `dataXXX`.",
 				DiagnosticSeverity.Warning);
 		testDiagnosticsFor(template, d);
-		testCodeActionsFor(template, d, //
+		testCodeActionsFor(template, d);
+		testCodeActionsWithConfigurationUpdateFor(template, d, //
 				ca(d, c("Ignore `UndefinedNamespace` problem.", //
 						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
 						"qute.validation.undefinedNamespace.severity", //
 						"test.qute", //
 						ConfigurationItemEditType.update, "ignore", //
+						d)),
+				ca(d, c("Exclude this file from validation.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.excluded", //
+						"test.qute", //
+						ConfigurationItemEditType.add, "test.qute", //
+						d)),
+				ca(d, c("Disable Qute validation for the `qute-quickstart` project.", //
+						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
+						"qute.validation.enabled", //
+						"test.qute", //
+						ConfigurationItemEditType.update, false, //
 						d)));
 	}
 
@@ -733,7 +699,8 @@ public class QuteDiagnosticsInExpressionTest {
 		testDiagnosticsFor(template, //
 				d(0, 1, 0, 6, QuteErrorCode.UndefinedObject, "`items` cannot be resolved to an object.",
 						DiagnosticSeverity.Warning),
-				d(0, 7, 0, 17, QuteErrorCode.UnknownMethod, "`getByIndex` cannot be resolved or is not a method of `null` Java type.",
+				d(0, 7, 0, 17, QuteErrorCode.UnknownMethod,
+						"`getByIndex` cannot be resolved or is not a method of `null` Java type.",
 						DiagnosticSeverity.Error));
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithEachSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithEachSectionTest.java
@@ -43,13 +43,7 @@ public class QuteDiagnosticsInExpressionWithEachSectionTest {
 						DiagnosticSeverity.Error));
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.util.List itemsXXX}\r\n")), //
-				ca(d, te(2, 15, 2, 15, "??")), //
-				ca(d, c("Ignore `UndefinedObject` problem.", //
-						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
-						"qute.validation.undefinedObject.severity", //
-						"test.qute", //
-						ConfigurationItemEditType.update, "ignore", //
-						d)));
+				ca(d, te(2, 15, 2, 15, "??")));
 	}
 
 	@Test

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithForSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithForSectionTest.java
@@ -59,13 +59,7 @@ public class QuteDiagnosticsInExpressionWithForSectionTest {
 		testCodeActionsFor(template, d, //
 				ca(d, te(4, 2, 4, 6, "items")), //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String item}\r\n")), //
-				ca(d, te(4, 6, 4, 6, "??")), //
-				ca(d, c("Ignore `UndefinedObject` problem.", //
-						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
-						"qute.validation.undefinedObject.severity", //
-						"test.qute", //
-						ConfigurationItemEditType.update, "ignore", //
-						d)));
+				ca(d, te(4, 6, 4, 6, "??")));
 
 	}
 
@@ -86,13 +80,8 @@ public class QuteDiagnosticsInExpressionWithForSectionTest {
 						DiagnosticSeverity.Error));
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.util.List itemsXXX}\r\n")), //
-				ca(d, te(2, 22, 2, 22, "??")), //
-				ca(d, c("Ignore `UndefinedObject` problem.", //
-						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
-						"qute.validation.undefinedObject.severity", //
-						"test.qute", //
-						ConfigurationItemEditType.update, "ignore", //
-						d)));
+				ca(d, te(2, 22, 2, 22, "??")));
+
 	}
 
 	@Test

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithIfSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithIfSectionTest.java
@@ -11,7 +11,6 @@
 *******************************************************************************/
 package com.redhat.qute.services.diagnostics;
 
-import static com.redhat.qute.QuteAssert.c;
 import static com.redhat.qute.QuteAssert.ca;
 import static com.redhat.qute.QuteAssert.d;
 import static com.redhat.qute.QuteAssert.te;
@@ -21,9 +20,6 @@ import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.jupiter.api.Test;
-
-import com.redhat.qute.ls.commons.client.ConfigurationItemEditType;
-import com.redhat.qute.services.commands.QuteClientCommandConstants;
 
 /**
  * Test with #if section
@@ -63,22 +59,7 @@ public class QuteDiagnosticsInExpressionWithIfSectionTest {
 		testDiagnosticsFor(template, d1, d2);
 		testCodeActionsFor(template, d1, //
 				ca(d1, te(0, 0, 0, 0, "{@java.lang.String item}\r\n")), //
-				ca(d1, te(0, 9, 0, 9, "??")), //
-				ca(d1, c("Ignore `UndefinedObject` problem.", //
-						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
-						"qute.validation.undefinedObject.severity", //
-						"test.qute", //
-						ConfigurationItemEditType.update, "ignore", //
-						d1)));
-		testCodeActionsFor(template, d2, //
-				ca(d2, te(0, 0, 0, 0, "{@java.lang.String item}\r\n")), //
-				ca(d2, te(0, 28, 0, 28, "??")), //
-				ca(d2, c("Ignore `UndefinedObject` problem.", //
-						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
-						"qute.validation.undefinedObject.severity", //
-						"test.qute", //
-						ConfigurationItemEditType.update, "ignore", //
-						d2)));
+				ca(d1, te(0, 9, 0, 9, "??")));
 	}
 
 	@Test

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithLetSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithLetSectionTest.java
@@ -71,13 +71,8 @@ public class QuteDiagnosticsInExpressionWithLetSectionTest {
 						DiagnosticSeverity.Error));
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String item}\r\n")), //
-				ca(d, te(0, 15, 0, 15, "??")), //
-				ca(d, c("Ignore `UndefinedObject` problem.", //
-						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
-						"qute.validation.undefinedObject.severity", //
-						"test.qute", //
-						ConfigurationItemEditType.update, "ignore", //
-						d)));
+				ca(d, te(0, 15, 0, 15, "??")));
+
 	}
 
 	@Test
@@ -99,13 +94,8 @@ public class QuteDiagnosticsInExpressionWithLetSectionTest {
 				d);
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String name}\r\n")),
-				ca(d, te(1, 6, 1, 6, "??")), //
-				ca(d, c("Ignore `UndefinedObject` problem.", //
-						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
-						"qute.validation.undefinedObject.severity", //
-						"test.qute", //
-						ConfigurationItemEditType.update, "ignore", //
-						d)));
+				ca(d, te(1, 6, 1, 6, "??")));
+
 	}
 
 	@Test

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithNamespaceTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithNamespaceTest.java
@@ -39,13 +39,7 @@ public class QuteDiagnosticsInExpressionWithNamespaceTest {
 		Diagnostic d = d(1, 1, 1, 8, QuteErrorCode.UndefinedNamespace, "No namespace resolver found for: `dataXXX`.",
 				DiagnosticSeverity.Warning);
 		testDiagnosticsFor(template, d);
-		testCodeActionsFor(template, d, //
-				ca(d, c("Ignore `UndefinedNamespace` problem.", //
-						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
-						"qute.validation.undefinedNamespace.severity", //
-						"test.qute", //
-						ConfigurationItemEditType.update, "ignore", //
-						d)));
+		testCodeActionsFor(template, d);
 	}
 
 	@Test
@@ -151,12 +145,6 @@ public class QuteDiagnosticsInExpressionWithNamespaceTest {
 		template = "{X:bean}";
 		testDiagnosticsFor(template, d(0, 1, 0, 2, QuteErrorCode.UndefinedNamespace,
 				"No namespace resolver found for: `X`.", DiagnosticSeverity.Warning));
-		testCodeActionsFor(template, d, //
-				ca(d, c("Ignore `UndefinedNamespace` problem.", //
-						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
-						"qute.validation.undefinedNamespace.severity", //
-						"test.qute", //
-						ConfigurationItemEditType.update, "ignore", //
-						d)));
+		testCodeActionsFor(template, d);
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithWithSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithWithSectionTest.java
@@ -44,13 +44,7 @@ public class QuteDiagnosticsInExpressionWithWithSectionTest {
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String item}\r\n")), //
-				ca(d, te(0, 11, 0, 11, "??")), //
-				ca(d, c("Ignore `UndefinedObject` problem.", //
-						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
-						"qute.validation.undefinedObject.severity", //
-						"test.qute", //
-						ConfigurationItemEditType.update, "ignore", //
-						d)));
+				ca(d, te(0, 11, 0, 11, "??")));
 	}
 
 	@Test
@@ -84,13 +78,7 @@ public class QuteDiagnosticsInExpressionWithWithSectionTest {
 		testDiagnosticsFor(template, d);
 		testCodeActionsFor(template, d, //
 				ca(d, te(0, 0, 0, 0, "{@java.lang.String average}\r\n")), //
-				ca(d, te(6, 12, 6, 12, "??")), //
-				ca(d, c("Ignore `UndefinedObject` problem.", //
-						QuteClientCommandConstants.COMMAND_CONFIGURATION_UPDATE, //
-						"qute.validation.undefinedObject.severity", //
-						"test.qute", //
-						ConfigurationItemEditType.update, "ignore", //
-						d)));
+				ca(d, te(6, 12, 6, 12, "??")));
 
 	}
 }


### PR DESCRIPTION
Ignore 'UndefinedObject' problem code action should appear only if LSP client can support update configuration.

In IJ Quarkus, it doesn't support the capability to update configuration on client side. In otherwise the `Ignore 'UndefinedObject' problem` should not appear:

![image](https://user-images.githubusercontent.com/1932211/233319363-661f34c8-c170-4b27-bf00-639fb67e2d33.png)

This PR checks that LSP client can support the command which update LSP client settings.
