### PR TITLE
Update eclipse.jdt.ls to 1.24.0-SNAPSHOT

### DIFF
--- a/quarkus.jdt.ext/pom.xml
+++ b/quarkus.jdt.ext/pom.xml
@@ -14,7 +14,7 @@
     <tycho.extras.version>${tycho.version}</tycho.extras.version>
     <tycho.scmUrl>scm:git:https://github.com/redhat-developer/quarkus-ls</tycho.scmUrl>
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
-    <jdt.ls.version>1.23.0-SNAPSHOT</jdt.ls.version>
+    <jdt.ls.version>1.24.0-SNAPSHOT</jdt.ls.version>
     <tycho.test.platformArgs />
     <tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
     <lsp4mp.p2.url>https://download.eclipse.org/lsp4mp/snapshots/0.8.0/repository/</lsp4mp.p2.url>

--- a/qute.jdt/pom.xml
+++ b/qute.jdt/pom.xml
@@ -16,7 +16,7 @@
 		<tycho.extras.version>${tycho.version}</tycho.extras.version>
 		<tycho.scmUrl>scm:git:https://github.com/redhat-developer/quarkus-ls</tycho.scmUrl>
 		<tycho.generateSourceReferences>true</tycho.generateSourceReferences>
-		<jdt.ls.version>1.23.0-SNAPSHOT</jdt.ls.version>
+		<jdt.ls.version>1.24.0-SNAPSHOT</jdt.ls.version>
 		<tycho.test.platformArgs />
 		<tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
 


### PR DESCRIPTION
See https://github.com/eclipse/eclipse.jdt.ls/pull/2666 . m2e 2.3.0 snapshot repo is gone so the old JDT-LS TP won't build. Need to use a newer one.