### PR TITLE
Use DetectVMInstallationsJob.disabled=true property from JDT Debug

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,11 +16,11 @@ jobs:
         with:
           path: ~/.m2/wrapper
           key: maven-wrapper-${{ hashFiles('**/mvnw') }}
-      - name: Set up Adoptium JDK 17
+      - name: Set up Eclipse Temurin JDK 17
         uses: actions/setup-java@v2
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Build and test Quarkus jdt component
         run: cd quarkus.jdt.ext && ./mvnw -B -U clean verify && cd ..
       - name: Build and test Quarkus language server component

--- a/quarkus.jdt.ext/pom.xml
+++ b/quarkus.jdt.ext/pom.xml
@@ -16,7 +16,7 @@
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
     <jdt.ls.version>1.25.0-SNAPSHOT</jdt.ls.version>
     <tycho.test.platformArgs />
-    <tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
+    <tycho.test.jvmArgs>-Xmx512m -DDetectVMInstallationsJob.disabled=true ${tycho.test.platformArgs}</tycho.test.jvmArgs>
     <lsp4mp.p2.url>https://download.eclipse.org/lsp4mp/snapshots/0.8.0/repository/</lsp4mp.p2.url>
 
     <!-- Code coverage -->

--- a/qute.jdt/pom.xml
+++ b/qute.jdt/pom.xml
@@ -18,7 +18,7 @@
 		<tycho.generateSourceReferences>true</tycho.generateSourceReferences>
 		<jdt.ls.version>1.25.0-SNAPSHOT</jdt.ls.version>
 		<tycho.test.platformArgs />
-		<tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
+		<tycho.test.jvmArgs>-Xmx512m -DDetectVMInstallationsJob.disabled=true ${tycho.test.platformArgs}</tycho.test.jvmArgs>
 
 		<!-- Code coverage -->
 		<jacoco.version>0.8.8</jacoco.version>


### PR DESCRIPTION
- Automatic JVM detection in JDT Debug seems to have introduced a regression in JDT indexing causing java.lang.OutOfMemory
- Use Eclipse Temurin for JDK distribution.

See https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/231 for (I believe) the root cause.

Note : The property is just a workaround, and will only apply for the tests, so that they can run. I really suspect this would hit people at runtime. I've imported quarkus projects in vscode-quarkus (with vscode-java) and seen the OOM error. :neutral_face: 