### PR TITLE
Fix support ? in parameter let section

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/Parameter.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/Parameter.java
@@ -34,6 +34,8 @@ public class Parameter extends Node implements JavaTypeInfoProvider {
 
 	private ParametersContainer container;
 
+	private boolean hasDefaultValue; // #let name?="foo"
+
 	public Parameter(int start, int end) {
 		super(start, end);
 		this.startName = start;
@@ -109,9 +111,11 @@ public class Parameter extends Node implements JavaTypeInfoProvider {
 		if (name == null) {
 			int endName = getEndName();
 			Section section = getOwnerSection();
-			if (section != null && section.getSectionKind() == SectionKind.LET) {
+			if (section != null
+					&& (section.getSectionKind() == SectionKind.LET || section.getSectionKind() == SectionKind.SET)) {
 				String text = getOwnerTemplate().getText();
 				if (text.charAt(endName - 1) == '?') {
+					hasDefaultValue = true;
 					// ex : {#let name?"=main"}
 					// name? --> name
 					endName--;
@@ -240,5 +244,18 @@ public class Parameter extends Node implements JavaTypeInfoProvider {
 	public boolean isOptional() {
 		Expression expression = getJavaTypeExpression();
 		return expression != null ? expression.isOptional() : false;
+	}
+
+	/**
+	 * Returns true if the parameter uses '?' to assign value (ex : #let
+	 * name?="foo")
+	 * which means that name has default value and false other.
+	 * 
+	 * @return true if the parameter uses '?' to assign value (ex : #let
+	 *         name?="foo")
+	 *         which means that name has default value and false other.
+	 */
+	public boolean hasDefaultValue() {
+		return hasDefaultValue;
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/tags/UserTag.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/tags/UserTag.java
@@ -115,16 +115,38 @@ public abstract class UserTag extends Snippet {
 	 */
 	public static void generateUserTagParameter(UserTagParameter parameter, boolean snippetsSupported, int index,
 			StringBuilder snippet) {
+		// Generate parameter name
 		snippet.append(parameter.getName());
 		snippet.append("=");
-		snippet.append("\"");
-		if (snippetsSupported) {
-			SnippetsBuilder.placeholders(index, parameter.getName(), snippet);
-		} else {
-			snippet.append(parameter.getName());
-		}
-		snippet.append("\"");
 
+		// Generate parameter value
+		String value = parameter.getName();
+		Character quote = '"';
+		String defaultValue = parameter.getDefaultValue();
+		if (defaultValue != null && !defaultValue.isEmpty()) {
+			value = defaultValue;
+			// there is a default value, remove the quote if needed
+			char start = defaultValue.charAt(0);
+			if (start == '"' || start == '\'') {
+				quote = start;
+				value = value.substring(1, value.length() - (value.endsWith(start + "") ? 1 : 0));
+			} else {
+				quote = null;
+			}
+		}
+		
+		if (quote != null) {
+			snippet.append(quote);
+		}
+		
+		if (snippetsSupported) {
+			SnippetsBuilder.placeholders(index, value, snippet);
+		} else {
+			snippet.append(value);
+		}
+		if (quote != null) {
+			snippet.append(quote);
+		}
 	}
 
 	/**

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/tags/UserTagParameter.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/tags/UserTagParameter.java
@@ -23,8 +23,19 @@ public class UserTagParameter {
 
 	private boolean required;
 
+	private String defaultValue;
+
 	public UserTagParameter(String name) {
 		this.name = name;
+	}
+
+	/**
+	 * Returns the user tag parameter name.
+	 * 
+	 * @return the user tag parameter name.
+	 */
+	public String getName() {
+		return name;
 	}
 
 	/**
@@ -45,12 +56,14 @@ public class UserTagParameter {
 		return required;
 	}
 
-	/**
-	 * Returns the user tag parameter name.
-	 * 
-	 * @return the user tag parameter name.
-	 */
-	public String getName() {
-		return name;
+	public String getDefaultValue() {
+		return defaultValue;
+	}
+
+	public void setDefaultValue(String defaultValue) {
+		this.defaultValue = defaultValue;
+		if (defaultValue != null) {
+			setRequired(false);
+		}
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/QuteInlayHintSettings.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/QuteInlayHintSettings.java
@@ -25,9 +25,12 @@ public class QuteInlayHintSettings {
 
 	private boolean showSectionParameterType;
 
+	private boolean showSectionParameterDefaultValue;
+
 	public QuteInlayHintSettings() {
 		setEnabled(true);
 		setShowSectionParameterType(true);
+		setShowSectionParameterDefaultValue(true);
 	}
 
 	/**
@@ -58,9 +61,18 @@ public class QuteInlayHintSettings {
 		this.showSectionParameterType = showSectionParameterType;
 	}
 
+	public boolean isShowSectionParameterDefaultValue() {
+		return showSectionParameterDefaultValue;
+	}
+
+	public void setShowSectionParameterDefaultValue(boolean showSectionParameterDefaultValue) {
+		this.showSectionParameterDefaultValue = showSectionParameterDefaultValue;
+	}
+
 	public void update(QuteInlayHintSettings newInlayHint) {
 		this.setEnabled(newInlayHint.isEnabled());
 		this.setShowSectionParameterType(newInlayHint.isShowSectionParameterType());
+		this.setShowSectionParameterDefaultValue(newInlayHint.isShowSectionParameterDefaultValue());
 	}
 
 	@Override
@@ -68,6 +80,7 @@ public class QuteInlayHintSettings {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + (enabled ? 1231 : 1237);
+		result = prime * result + (showSectionParameterDefaultValue ? 1231 : 1237);
 		result = prime * result + (showSectionParameterType ? 1231 : 1237);
 		return result;
 	}
@@ -82,6 +95,8 @@ public class QuteInlayHintSettings {
 			return false;
 		QuteInlayHintSettings other = (QuteInlayHintSettings) obj;
 		if (enabled != other.enabled)
+			return false;
+		if (showSectionParameterDefaultValue != other.showSectionParameterDefaultValue)
 			return false;
 		if (showSectionParameterType != other.showSectionParameterType)
 			return false;

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionWithUserTagTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionWithUserTagTest.java
@@ -50,6 +50,26 @@ public class QuteCompletionWithUserTagTest {
 	}
 	
 	@Test
+	public void bundleStyleWithingParameter() throws Exception {
+		String template = "{#bundleStyle |";
+
+		// Without snippet
+		testCompletionFor(template, //
+				false, // no snippet support
+				1, //
+				c("name", //
+						"name=\"main.css\"", //
+						r(0, 14, 0, 14)));
+
+		// With snippet support
+		testCompletionFor(template, //
+				true, // snippet support
+				1, //
+				c("name", //
+						"name=\"${1:main.css}\"$0", //
+						r(0, 14, 0, 14)));
+	}
+	@Test
 	public void input() throws Exception {
 		String template = "{#|";
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsWithUserTagTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsWithUserTagTest.java
@@ -33,7 +33,15 @@ public class QuteDiagnosticsWithUserTagTest {
 
 	@Test
 	public void bundleStyle() {
+		// test with default value declared in bundleStyle.html user tag
+		// {#let name?="main.css"}
+		// In this case:
+		
+		// - name is optional
 		String template = "{#bundleStyle /}";
+		testDiagnosticsFor(template);
+		// - name can be overridden
+		template = "{#bundleStyle name='foo.css'/}";
 		testDiagnosticsFor(template);
 	}
 	


### PR DESCRIPTION
Fix support ? in parameter let section

Fixes #906

This PR provides the capability to have name as completion item in bundleScript and it displays as hinlay the default value of let . Here a demo:

![BundleScriptDemo](https://github.com/redhat-developer/quarkus-ls/assets/1932211/36566b74-4275-4786-a724-6d549c180739)


//cc @ia3andy 