### PR TITLE
Support itemDefaults for Qute parameter declaration

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/QuteCompletionSettings.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/settings/QuteCompletionSettings.java
@@ -89,4 +89,18 @@ public class QuteCompletionSettings {
 		}
 		return InsertTextMode.AsIs;
 	}
+	
+	/**
+	 * Returns true if the client supports the given parameter in itemDefaults support and
+	 * false otherwise.
+	 *
+	 * @param  param the completion itemDefaults parameter to be checked
+	 * @return true if the client supports the given parameter in itemDefaults support and
+	 *         false otherwise.
+	 */
+	public boolean isCompletionListItemDefaultsSupport(String param) {
+		return completionCapabilities != null && completionCapabilities.getCompletionList() != null
+				&& completionCapabilities.getCompletionList().getItemDefaults() != null
+				&& completionCapabilities.getCompletionList().getItemDefaults().contains(param);
+	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInNativeModeTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInNativeModeTest.java
@@ -194,7 +194,7 @@ public class QuteCompletionInNativeModeTest {
 		QuteNativeSettings nativeImagesSettings = new QuteNativeSettings();
 		nativeImagesSettings.setEnabled(true);
 
-		QuteAssert.testCompletionFor(template, false, templateUri, null, QuteQuickStartProject.PROJECT_URI,
+		QuteAssert.testCompletionFor(template, false, false, templateUri, null, QuteQuickStartProject.PROJECT_URI,
 				QuteAssert.TEMPLATE_BASE_DIR, expectedCount, nativeImagesSettings, expected);
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInParameterDeclarationTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInParameterDeclarationTest.java
@@ -49,7 +49,35 @@ public class QuteCompletionInParameterDeclarationTest {
 				c("org.acme.Review", "org.acme.Review ${1:review}$0", r(0, 2, 0, 2)), //
 				c("java.util.List<E>", "java.util.List<${1:E}> ${2:list}$0", r(0, 2, 0, 2)), //
 				c("java.util.Map<K,V>", "java.util.Map<${1:K},${2:V}> ${3:map}$0", r(0, 2, 0, 2)));
+	}
+	
+	@Test
+	public void completionInParameterDeclarationForJavaClassItemDefaults() throws Exception {
+		String template = "{@|}\r\n";
 
+		// Without snippet
+		testCompletionFor(template, //
+				false, // snippet support
+				true, // completion item defaults support
+				// Package completion
+				c("org.acme", "org.acme", r(0, 2, 0, 2)), //
+				// Class completion
+				c("org.acme.Item", "org.acme.Item item", r(0, 2, 0, 2)), //
+				c("org.acme.Review", "org.acme.Review review", r(0, 2, 0, 2)), //
+				c("java.util.List<E>", "java.util.List<E> list", r(0, 2, 0, 2)), //
+				c("java.util.Map<K,V>", "java.util.Map<K,V> map", r(0, 2, 0, 2)));
+
+		// With snippet support
+		testCompletionFor(template, //
+				true, // snippet support
+				true, // completion item defaults support
+				// Package completion
+				c("org.acme", "org.acme", r(0, 2, 0, 2)), //
+				// Class completion
+				c("org.acme.Item", "org.acme.Item ${1:item}$0", r(0, 2, 0, 2)), //
+				c("org.acme.Review", "org.acme.Review ${1:review}$0", r(0, 2, 0, 2)), //
+				c("java.util.List<E>", "java.util.List<${1:E}> ${2:list}$0", r(0, 2, 0, 2)), //
+				c("java.util.Map<K,V>", "java.util.Map<${1:K},${2:V}> ${3:map}$0", r(0, 2, 0, 2)));
 	}
 
 	@Test

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionWithInsertTextModeTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionWithInsertTextModeTest.java
@@ -169,7 +169,7 @@ public class QuteCompletionWithInsertTextModeTest {
 		completionSettings.setCapabilities(completionCapabilities);
 
 		QuteAssert.testCompletionFor(value, "test.qute", null, QuteQuickStartProject.PROJECT_URI,
-				QuteAssert.TEMPLATE_BASE_DIR, null, null, completionSettings, expectedItems);
+				QuteAssert.TEMPLATE_BASE_DIR, null, null, completionSettings, false, expectedItems);
 	}
 
 	public static CompletionItem c(String label, String newText, Range range, InsertTextMode insertTextMode) {


### PR DESCRIPTION
Fixes #900 
* moves `editRange` and `insertTextFormat` to `itemDefaults` when supported