### PR TITLE
Prevent StackOverflow by passing types processed in recursive call.

### DIFF
--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/core/properties/QuarkusConfigMappingProvider.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/core/properties/QuarkusConfigMappingProvider.java
@@ -211,7 +211,7 @@ public class QuarkusConfigMappingProvider extends AbstractAnnotationTypeReferenc
 					JDTQuarkusUtils.updateConverterKinds(metadata, method, enclosedType);
 				} else {
 					// Other type (App, etc)
-					populateConfigObject(returnType, propertyName, extensionName, new HashSet<>(),
+					populateConfigObject(returnType, propertyName, extensionName, typesAlreadyProcessed,
 							configMappingAnnotation, collector, monitor);
 				}
 			}


### PR DESCRIPTION
- Fixes https://github.com/redhat-developer/quarkus-ls/issues/924

See https://github.com/redhat-developer/quarkus-ls/blob/2bbcefc997e044702949b79b62c98b6ebb7b3995/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/core/properties/QuarkusConfigPropertiesProvider.java#L316-L317 . Very similar recursive call, but done correctly.