### PR TITLE
Increase XmX to 2G for quarkus.jdt.ext tests.

### DIFF
--- a/quarkus.jdt.ext/pom.xml
+++ b/quarkus.jdt.ext/pom.xml
@@ -16,7 +16,7 @@
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
     <jdt.ls.version>1.29.0-SNAPSHOT</jdt.ls.version>
     <tycho.test.platformArgs />
-    <tycho.test.jvmArgs>-Xmx512m -DDetectVMInstallationsJob.disabled=true ${tycho.test.platformArgs}</tycho.test.jvmArgs>
+    <tycho.test.jvmArgs>-Xmx2G -DDetectVMInstallationsJob.disabled=true ${tycho.test.platformArgs}</tycho.test.jvmArgs>
     <lsp4mp.p2.url>https://download.eclipse.org/lsp4mp/snapshots/0.10.0/repository/</lsp4mp.p2.url>
 
     <!-- Code coverage -->


### PR DESCRIPTION
The GH Actions test run workflow doesn't seem to need this but certain environments are hitting OOM running the tests, and this helps. I'm pretty sure there's some regression that was introduced into Eclipse 4.29 but I haven't been able to investigate deeply to find the cause.