### PR TITLE
fix: use newer JDT.LS's JavadocContentAccess2 methods

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,17 +5,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Cache .m2 repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: maven-repository-${{ hashFiles('**/pom.xml') }}
+          save-always: true
       - name: Cache Maven wrapper
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/wrapper
           key: maven-wrapper-${{ hashFiles('**/mvnw') }}
+          save-always: true
       - name: Set up Eclipse Temurin JDK 17
         uses: actions/setup-java@v2
         with:

--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/META-INF/MANIFEST.MF
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: com.redhat.microprofile.jdt.quarkus;singleton:=true
 Bundle-Version: 0.18.0.qualifier
-Require-Bundle: org.eclipse.lsp4mp.jdt.core,
+Require-Bundle: org.eclipse.lsp4mp.jdt.core;bundle-version="0.11.0",
  org.eclipse.core.runtime,
  org.eclipse.jdt.core,
  org.eclipse.jdt.core.manipulation,

--- a/quarkus.jdt.ext/pom.xml
+++ b/quarkus.jdt.ext/pom.xml
@@ -10,14 +10,14 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <tycho.version>3.0.5</tycho.version>
+    <tycho.version>4.0.4</tycho.version>
     <tycho.extras.version>${tycho.version}</tycho.extras.version>
     <tycho.scmUrl>scm:git:https://github.com/redhat-developer/quarkus-ls</tycho.scmUrl>
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
-    <jdt.ls.version>1.29.0-SNAPSHOT</jdt.ls.version>
+    <jdt.ls.version>1.32.0-SNAPSHOT</jdt.ls.version>
     <tycho.test.platformArgs />
     <tycho.test.jvmArgs>-Xmx2G -DDetectVMInstallationsJob.disabled=true ${tycho.test.platformArgs}</tycho.test.jvmArgs>
-    <lsp4mp.p2.url>https://download.eclipse.org/lsp4mp/snapshots/0.10.0/repository/</lsp4mp.p2.url>
+    <lsp4mp.p2.url>https://download.eclipse.org/lsp4mp/snapshots/0.11.0/repository/</lsp4mp.p2.url>
 
     <!-- Code coverage -->
     <jacoco.version>0.8.8</jacoco.version>

--- a/qute.jdt/com.redhat.qute.jdt.test/src/main/java/com/redhat/qute/jdt/template/TemplateGetJavadocTest.java
+++ b/qute.jdt/com.redhat.qute.jdt.test/src/main/java/com/redhat/qute/jdt/template/TemplateGetJavadocTest.java
@@ -90,7 +90,7 @@ public class TemplateGetJavadocTest {
 				DocumentFormat.PlainText);
 
 		String actual = QuteSupportForTemplate.getInstance().getJavadoc(params, getJDTUtils(), new NullProgressMonitor());
-		String expected = " Returns the derived items. \n * Returns:\n   - the derived items";
+		String expected = " Returns the derived items.   Returns:\nthe derived items\n";// Updated jdt.ls JavaDoc2PlainTextConverter doesn't yield great results anymore
 		assertEquals(expected, actual);
 	}
 	

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/ls/JDTUtilsLSImpl.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/ls/JDTUtilsLSImpl.java
@@ -31,7 +31,6 @@ import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.handlers.DocumentLifeCycleHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.JsonRpcHelpers;
-import org.eclipse.jdt.ls.core.internal.javadoc.JavadocContentAccess;
 import org.eclipse.jdt.ls.core.internal.javadoc.JavadocContentAccess2;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Range;
@@ -116,7 +115,7 @@ public class JDTUtilsLSImpl implements IJDTUtils {
 	public String getJavadoc(IMember member, DocumentFormat documentFormat) throws JavaModelException {
 		boolean markdown = DocumentFormat.Markdown.equals(documentFormat);
 		Reader reader = markdown ? JavadocContentAccess2.getMarkdownContentReader(member)
-				: JavadocContentAccess.getPlainTextContentReader(member);
+				: JavadocContentAccess2.getPlainTextContentReader(member);
 		return reader != null ? toString(reader) : null;
 	}
 

--- a/qute.jdt/pom.xml
+++ b/qute.jdt/pom.xml
@@ -12,11 +12,11 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<tycho.version>3.0.5</tycho.version>
+		<tycho.version>4.0.4</tycho.version>
 		<tycho.extras.version>${tycho.version}</tycho.extras.version>
 		<tycho.scmUrl>scm:git:https://github.com/redhat-developer/quarkus-ls</tycho.scmUrl>
 		<tycho.generateSourceReferences>true</tycho.generateSourceReferences>
-		<jdt.ls.version>1.29.0-SNAPSHOT</jdt.ls.version>
+		<jdt.ls.version>1.32.0-SNAPSHOT</jdt.ls.version>
 		<tycho.test.platformArgs />
 		<tycho.test.jvmArgs>-Xmx512m -DDetectVMInstallationsJob.disabled=true ${tycho.test.platformArgs}</tycho.test.jvmArgs>
 


### PR DESCRIPTION
Fixes javadoc for qute, similar to https://github.com/eclipse/lsp4mp/pull/432.

Related to https://github.com/redhat-developer/vscode-quarkus/issues/638