### PR TITLE
fix: allow spaces inside section branch.

### DIFF
--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/template/datamodel/AbstractFieldDeclarationTypeReferenceDataModelProvider.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/template/datamodel/AbstractFieldDeclarationTypeReferenceDataModelProvider.java
@@ -77,6 +77,9 @@ public abstract class AbstractFieldDeclarationTypeReferenceDataModelProvider ext
 
 	private boolean isApplicable(IField field) {
 		String fieldTypeName = JDTTypeUtils.getResolvedTypeName(field);
+		if (fieldTypeName == null) {
+			return false;
+		}
 		for (String typeName : getTypeNames()) {
 			if (typeName.endsWith(fieldTypeName)) {
 				return true;

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/parameter/ParameterParser.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/parameter/ParameterParser.java
@@ -49,7 +49,7 @@ public class ParameterParser {
 			int tokenEnd = scanner.getTokenEnd();
 			switch (token) {
 			case Whitespace:
-				currentParameter = null;
+				// Do nothing
 				break;
 			case ParameterName:
 				currentParameter = new Parameter(tokenOffset, tokenEnd);

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/parameter/scanner/ParameterScanner.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/parameter/scanner/ParameterScanner.java
@@ -91,12 +91,11 @@ public class ParameterScanner extends AbstractScanner<TokenType, ScannerState> {
 
 			case WithinParameter: {
 				if (!methodParameters && splitWithEquals) {
+					if (stream.skipWhitespace()) {
+						return finishToken(offset, TokenType.Whitespace);
+					}
 					if (stream.advanceIfChar('=')) {
-						if (!stream.eos() && (stream.peekChar() == ' ' || stream.peekChar() == '=')) {
-							state = ScannerState.WithinParameters;
-						} else {
-							state = ScannerState.AfterAssign;
-						}
+						state = ScannerState.AfterAssign;
 						return finishToken(offset, TokenType.Assign);
 					}
 				}
@@ -105,6 +104,9 @@ public class ParameterScanner extends AbstractScanner<TokenType, ScannerState> {
 			}
 
 			case AfterAssign: {
+				if (stream.skipWhitespace()) {
+					return finishToken(offset, TokenType.Whitespace);
+				}
 				int c = stream.peekChar();
 				if (c == '"' || c == '\'') {
 					stream.advance(1);

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/parser/parameter/scanner/ParameterScannerTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/parser/parameter/scanner/ParameterScannerTest.java
@@ -55,15 +55,32 @@ public class ParameterScannerTest {
 	}
 
 	@Test
+	public void letSectionWithSpaces() {
+		// {#let    myParent  =order.item.parent   myPrice=    order.price}
+		scanner = ParameterScanner.createScanner("   myParent  =order.item.parent   myPrice=    order.price");
+		assertOffsetAndToken(0, TokenType.Whitespace, "   ");
+		assertOffsetAndToken(3, TokenType.ParameterName, "myParent");
+		assertOffsetAndToken(11, TokenType.Whitespace, "  ");
+		assertOffsetAndToken(13, TokenType.Assign, "=");
+		assertOffsetAndToken(14, TokenType.ParameterValue, "order.item.parent");
+		assertOffsetAndToken(31, TokenType.Whitespace, "   ");
+		assertOffsetAndToken(34, TokenType.ParameterName, "myPrice");
+		assertOffsetAndToken(41, TokenType.Assign, "=");
+		assertOffsetAndToken(42, TokenType.Whitespace, "    ");
+		assertOffsetAndToken(46, TokenType.ParameterValue, "order.price");
+		assertOffsetAndToken(57, TokenType.EOS, "");
+	}
+
+	@Test
 	public void parameterAndAssignOnly() {
 		// {#let myParent= myPrice=order.price}
 		scanner = ParameterScanner.createScanner("myParent= myPrice=order.price");
 		assertOffsetAndToken(0, TokenType.ParameterName, "myParent");
 		assertOffsetAndToken(8, TokenType.Assign, "=");
 		assertOffsetAndToken(9, TokenType.Whitespace, " ");
-		assertOffsetAndToken(10, TokenType.ParameterName, "myPrice");
-		assertOffsetAndToken(17, TokenType.Assign, "=");
-		assertOffsetAndToken(18, TokenType.ParameterValue, "order.price");
+		assertOffsetAndToken(10, TokenType.ParameterValue, "myPrice");
+		assertOffsetAndToken(17, TokenType.Unknown, "=");
+		assertOffsetAndToken(18, TokenType.ParameterName, "order.price");
 		assertOffsetAndToken(29, TokenType.EOS, "");
 	}
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInExpressionWithLetSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInExpressionWithLetSectionTest.java
@@ -43,6 +43,21 @@ public class QuteCompletionInExpressionWithLetSectionTest {
 	}
 
 	@Test
+	public void objectPartWithSpaces() throws Exception {
+		String template = "{@org.acme.Item item}\r\n" + //
+				"{#let myParent =  item.name         isActive =false age= 10} \r\n" + //
+				"  <h1>{myParent.name}</h1>\r\n" + //
+				"  Is active: {|}\r\n" + // <-- completion here
+				"  Age: {age}\r\n" + //
+				"{/let}";
+		testCompletionFor(template, //
+				c("item", "item", r(3, 14, 3, 14)), //
+				c("myParent", "myParent", r(3, 14, 3, 14)), //
+				c("isActive", "isActive", r(3, 14, 3, 14)), //
+				c("age", "age", r(3, 14, 3, 14)));
+	}
+	
+	@Test
 	public void objectPartWithOnlyStartBracket() throws Exception {
 		String template = "{@org.acme.Item item}\r\n" + //
 				"{#let myParent=item.name isActive=false age=10} \r\n" + //

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/inlayhint/QuteInlayHintTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/inlayhint/QuteInlayHintTest.java
@@ -81,6 +81,33 @@ public class QuteInlayHintTest {
 	}
 
 	@Test
+	public void parameterLetSectionWithSpaces() throws Exception {
+		String template = "{@org.acme.Item item}\r\n" + //
+				"{#let name    =item.name price   =  item.price   bad=  item.XXXX}\r\n" + // name[:String]=item.name
+																				// price[:BigInteger]=item.price
+																				// bad=item.XXXX
+				"  \r\n" + //
+				"{/let}";
+		testInlayHintFor(template, //
+				ih(p(1, 10), ihLabel(":"),
+						ihLabel("String", "Open `java.lang.String` Java type.", cd("java.lang.String"))), //
+				ih(p(1, 30), ihLabel(":"),
+						ihLabel("BigInteger", "Open `java.math.BigInteger` Java type.", cd("java.math.BigInteger"))));
+
+		// enabled=false
+		QuteInlayHintSettings settings = new QuteInlayHintSettings();
+		settings.setEnabled(false);
+		testInlayHintFor(template, //
+				settings);
+
+		// showSectionParameterType=false
+		settings = new QuteInlayHintSettings();
+		settings.setShowSectionParameterType(false);
+		testInlayHintFor(template, //
+				settings);
+	}
+
+	@Test
 	public void parameterCustomSection() throws Exception {
 		String template = "{@org.acme.Item item}\r\n" + //
 				"{#form name=item.name item.price bad=item.XXXX}\r\n" + // name[:String]=item.name


### PR DESCRIPTION
This PR provides the capability to add any spaces between parameters of section

Ex : 

```
{#let foo    =         "bar"       }
{foo}
```

will not report error in `{foo}` because foo can be computed correctly even with extra spaces.