### PR TITLE
fix: Qute highlight errors due to formatting

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/parser/parameter/scanner/ParameterScannerTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/parser/parameter/scanner/ParameterScannerTest.java
@@ -39,7 +39,45 @@ public class ParameterScannerTest {
 		assertOffsetAndToken(8, TokenType.ParameterName, "items");
 		assertOffsetAndToken(13, TokenType.EOS, "");
 	}
+	
+	@Test
+	public void forSectionWithMethod() {
+		// {#for item in map.values()}
+		scanner = ParameterScanner.createScanner("item in map.values()");
+		assertOffsetAndToken(0, TokenType.ParameterName, "item");
+		assertOffsetAndToken(4, TokenType.Whitespace, " ");
+		assertOffsetAndToken(5, TokenType.ParameterName, "in");
+		assertOffsetAndToken(7, TokenType.Whitespace, " ");
+		assertOffsetAndToken(8, TokenType.ParameterName, "map.values()");
+		assertOffsetAndToken(20, TokenType.EOS, "");
+	}
+	
+	@Test
+	public void forSectionWithTwoMethods() {
+		// {#for item in map.get('foo',  10).values()}
+		scanner = ParameterScanner.createScanner("item in map.get('foo',  10).values()");
+		assertOffsetAndToken(0, TokenType.ParameterName, "item");
+		assertOffsetAndToken(4, TokenType.Whitespace, " ");
+		assertOffsetAndToken(5, TokenType.ParameterName, "in");
+		assertOffsetAndToken(7, TokenType.Whitespace, " ");
+		assertOffsetAndToken(8, TokenType.ParameterName, "map.get('foo',  10).values()");
+		assertOffsetAndToken(36, TokenType.EOS, "");
+	}
 
+	@Test
+	public void forSectionWithTwoMethodsAndOneParameter() {
+		// {#for item in map.get('foo',  10).values()   bar}
+		scanner = ParameterScanner.createScanner("item in map.get('foo',  10).values()   bar");
+		assertOffsetAndToken(0, TokenType.ParameterName, "item");
+		assertOffsetAndToken(4, TokenType.Whitespace, " ");
+		assertOffsetAndToken(5, TokenType.ParameterName, "in");
+		assertOffsetAndToken(7, TokenType.Whitespace, " ");
+		assertOffsetAndToken(8, TokenType.ParameterName, "map.get('foo',  10).values()");
+		assertOffsetAndToken(36, TokenType.Whitespace, "   ");
+		assertOffsetAndToken(39, TokenType.ParameterName, "bar");
+		assertOffsetAndToken(42, TokenType.EOS, "");
+	}
+	
 	@Test
 	public void letSection() {
 		// {#let myParent=order.item.parent myPrice=order.price}
@@ -92,6 +130,65 @@ public class ParameterScannerTest {
 		assertOffsetAndToken(4, TokenType.Assign, "=");
 		assertOffsetAndToken(5, TokenType.ParameterValue, "\"User Name\"");
 		assertOffsetAndToken(16, TokenType.EOS, "");
+	}
+	
+	@Test
+	public void parameterWithMethod() {
+		// {#let foo= bar(0,1)}
+		scanner = ParameterScanner.createScanner("foo= bar(0,1)");
+		assertOffsetAndToken(0, TokenType.ParameterName, "foo");
+		assertOffsetAndToken(3, TokenType.Assign, "=");
+		assertOffsetAndToken(4, TokenType.Whitespace, " ");
+		assertOffsetAndToken(5, TokenType.ParameterValue, "bar(0,1)");
+		assertOffsetAndToken(13, TokenType.EOS, "");
+	}
+
+	@Test
+	public void parameterWithMethodAndSpaceInParameter() {
+		// {#let foo= bar(0,1)}
+		scanner = ParameterScanner.createScanner("foo= bar(0,  1)");
+		assertOffsetAndToken(0, TokenType.ParameterName, "foo");
+		assertOffsetAndToken(3, TokenType.Assign, "=");
+		assertOffsetAndToken(4, TokenType.Whitespace, " ");
+		assertOffsetAndToken(5, TokenType.ParameterValue, "bar(0,  1)");
+		assertOffsetAndToken(15, TokenType.EOS, "");
+	}
+
+	@Test
+	public void parameterWithSeveralMethodAndSpaceInParameter() {
+		// {#let p1 = 10  p2= bar(0,  1) p3= 10  p4 = foo(  0,  1, 3)}
+		scanner = ParameterScanner.createScanner("p1 = 10  p2= bar(0,  1) p3= 10  p4 = foo(  0,  1, 3)");
+		
+		// p1 = 10
+		assertOffsetAndToken(0, TokenType.ParameterName, "p1");
+		assertOffsetAndToken(2, TokenType.Whitespace, " ");
+		assertOffsetAndToken(3, TokenType.Assign, "=");
+		assertOffsetAndToken(4, TokenType.Whitespace, " ");
+		assertOffsetAndToken(5, TokenType.ParameterValue, "10");
+		assertOffsetAndToken(7, TokenType.Whitespace, "  ");
+		
+		// p2= bar(0,  1)
+		assertOffsetAndToken(9, TokenType.ParameterName, "p2");
+		assertOffsetAndToken(11, TokenType.Assign, "=");
+		assertOffsetAndToken(12, TokenType.Whitespace, " ");
+		assertOffsetAndToken(13, TokenType.ParameterValue, "bar(0,  1)");
+
+		// p3= 10
+		assertOffsetAndToken(23, TokenType.Whitespace, " ");
+		assertOffsetAndToken(24, TokenType.ParameterName, "p3");
+		assertOffsetAndToken(26, TokenType.Assign, "=");
+		assertOffsetAndToken(27, TokenType.Whitespace, " ");
+		assertOffsetAndToken(28, TokenType.ParameterValue, "10");
+		
+		// p4 = bar3(0,  1)
+		assertOffsetAndToken(30, TokenType.Whitespace, "  ");
+		assertOffsetAndToken(32, TokenType.ParameterName, "p4");
+		assertOffsetAndToken(34, TokenType.Whitespace, " ");
+		assertOffsetAndToken(35, TokenType.Assign, "=");
+		assertOffsetAndToken(36, TokenType.Whitespace, " ");
+		assertOffsetAndToken(37, TokenType.ParameterValue, "foo(  0,  1, 3)");
+
+		assertOffsetAndToken(52, TokenType.EOS, "");
 	}
 	
 	public void assertOffsetAndToken(int tokenOffset, TokenType tokenType) {

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/QuteQuickStartProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/QuteQuickStartProject.java
@@ -103,6 +103,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		list.setExtendedTypes(Arrays.asList("java.util.Collection<E>"));
 		registerMethod("size() : int", list);
 		registerMethod("get(index : int) : E", list);
+		registerMethod("subList(fromIndex : int, toIndex: int) : java.util.List<E>", list);
 
 		// Set
 		ResolvedJavaTypeInfo set = createResolvedJavaTypeInfo("java.util.Set<E>", cache, true);
@@ -113,6 +114,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 		registerMethod("keySet() : java.util.Set<K>", map);
 		registerMethod("values() : java.util.Collection<V>", map);
 		registerMethod("entrySet() : java.util.Set<java.util.Map$Entry<K,V>>", map);
+		registerMethod("get(key : K) : V", map);
 
 		// Map.Entry
 		ResolvedJavaTypeInfo mapEntry = createResolvedJavaTypeInfo("java.util.Map$Entry<K,V>", cache, true);

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/collections/CollectionsBracketIntegerValueResolverTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/collections/CollectionsBracketIntegerValueResolverTest.java
@@ -47,10 +47,11 @@ public class CollectionsBracketIntegerValueResolverTest {
 		// test to check @java.lang.Integer(base : T[]) : T is not returned by the
 		// completion
 		testCompletionFor(template, //
-				11, //				
+				12, //				
 				c("iterator() : Iterator<Item>", "iterator", r(1, 13, 1, 13)), //
 				c("size() : int", "size", r(1, 13, 1, 13)), //
 				c("get(index : int) : Item", "get(${1:index})$0", r(1, 13, 1, 13)), //
+				c("subList(fromIndex : int, toIndex : int) : List<Item>", "subList(${1:fromIndex}, ${2:toIndex})$0", r(1, 13, 1, 13)), //
 				c("raw(base : Object) : RawString", "raw", r(1, 13, 1, 13)), //
 				c("safe(base : Object) : RawString", "safe", r(1, 13, 1, 13)));
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/collections/CollectionsIntegerValueResolverTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/resolvers/collections/CollectionsIntegerValueResolverTest.java
@@ -47,10 +47,11 @@ public class CollectionsIntegerValueResolverTest {
 		// test to check @java.lang.Integer(base : T[]) : T is not returned by the
 		// completion
 		testCompletionFor(template, //
-				11, //				
+				12, //				
 				c("iterator() : Iterator<Item>", "iterator", r(1, 13, 1, 13)), //
 				c("size() : int", "size", r(1, 13, 1, 13)), //
 				c("get(index : int) : Item", "get(${1:index})$0", r(1, 13, 1, 13)), //
+				c("subList(fromIndex : int, toIndex : int) : List<Item>", "subList(${1:fromIndex}, ${2:toIndex})$0", r(1, 13, 1, 13)), //
 				c("raw(base : Object) : RawString", "raw", r(1, 13, 1, 13)), //
 				c("safe(base : Object) : RawString", "safe", r(1, 13, 1, 13)));
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithIfSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithIfSectionTest.java
@@ -90,6 +90,21 @@ public class QuteDiagnosticsInExpressionWithIfSectionTest {
 	}
 
 	@Test
+	public void conditionWithMethodAndParameter() throws Exception {
+		String template = "{@java.lang.String foo}\r\n" + //
+				"{#if foo.codePointCount(0, 0) != 0}OK{/if}";
+		testDiagnosticsFor(template);
+	}
+	
+	@Test
+	public void conditionWithMethodAndParameter2() throws Exception {
+		String template = "{@java.lang.String foo}\r\n" + //
+				"{@int index}\r\n" + //
+				"{#if foo.codePointCount(0, index) != 0 && (foo.or(false) || false || true) && (true)}OK{/if}";
+		testDiagnosticsFor(template);
+	}
+	
+	@Test
 	public void notOperatorWithObjectPart() {
 		String template = "{#if !true}NOK{#else}OK{/if}";
 		testDiagnosticsFor(template);

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithLetSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithLetSectionTest.java
@@ -11,7 +11,6 @@
 *******************************************************************************/
 package com.redhat.qute.services.diagnostics;
 
-import static com.redhat.qute.QuteAssert.c;
 import static com.redhat.qute.QuteAssert.ca;
 import static com.redhat.qute.QuteAssert.d;
 import static com.redhat.qute.QuteAssert.te;
@@ -22,9 +21,7 @@ import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.jupiter.api.Test;
 
-import com.redhat.qute.ls.commons.client.ConfigurationItemEditType;
 import com.redhat.qute.parser.validator.QuteSyntaxErrorCode;
-import com.redhat.qute.services.commands.QuteClientCommandConstants;
 
 /**
  * Test with #let section
@@ -102,6 +99,13 @@ public class QuteDiagnosticsInExpressionWithLetSectionTest {
 	public void notAsObjectPartName() throws Exception {
 		String template = "{@int !value}\r\n" + //
 				"{#let name=!value /}";
+		testDiagnosticsFor(template);
+	}
+	
+	@Test
+	public void letAssignedToMathodWithParametersWhichContainsSpaces() {
+		String template = "{@java.util.List items}\r\n" + //
+				"{#let name=items.subList(0, 5)}";
 		testDiagnosticsFor(template);
 	}
 }


### PR DESCRIPTION
fix: Qute highlight errors due to formatting

Fixes #966

This PR fixes the 2 problem of #966 issue:

 * avoid having false positive error (when a method in for or each section is used with parameters, those parameters was validated to check if the parameter type was iterable):
![image](https://github.com/redhat-developer/quarkus-ls/assets/1932211/a5b825cc-6b26-4227-99aa-0a56c2d1e78b)
 * provides thacapability to write spaces inside methode parameters.

@fbricon I had to do a big change in parameter parser. Hopefully we had alo of tests about that, I have written a lot of tests, but I hope I have not boken something.