### PR TITLE
fix: separate user tag parameters inlay hint

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/inlayhint/InlayHintASTVistor.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/inlayhint/InlayHintASTVistor.java
@@ -302,6 +302,7 @@ public class InlayHintASTVistor extends ASTVisitor {
 			InlayHint hint = new InlayHint();
 			hint.setKind(InlayHintKind.Parameter);
 			hint.setLabel(Either.forLeft(name + "=" + defaultValue));
+			hint.setPaddingRight(Boolean.TRUE);
 			int end = node.getEndParametersOffset();
 			Position position = template.positionAt(end);
 			hint.setPosition(position);


### PR DESCRIPTION
fix: separate user tag parameters inlay hint

This PR uses the paddingRight property of inlay hint to separate user tag parameters.

Here the result of vscode:

![image](https://github.com/redhat-developer/quarkus-ls/assets/1932211/447db541-be82-4243-a0ac-aa872f5ff207)

We will have to support this property in LSP4IJ.