### PR TITLE
feat: Qute: add arguments metadata for user-defined tags

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/Template.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/Template.java
@@ -36,6 +36,7 @@ import com.redhat.qute.project.QuteTextDocument;
 import com.redhat.qute.project.datamodel.ExtendedDataModelParameter;
 import com.redhat.qute.project.datamodel.ExtendedDataModelTemplate;
 import com.redhat.qute.utils.FileUtils;
+import com.redhat.qute.utils.UserTagUtils;
 
 public class Template extends Node {
 
@@ -191,7 +192,15 @@ public class Template extends Node {
 				return parameter;
 			}
 			// Try to find the class name from @CheckedTemplate
-			return getParameterDataModel(partName).getNow(null);
+			parameter = getParameterDataModel(partName).getNow(null);
+			if (parameter != null) {
+				return parameter;
+			}
+			// Try special keys (ex: _args)
+			if (UserTagUtils.isUserTag(this)) {
+				return UserTagUtils.getSpecialKey(partName);
+			}
+			return null;
 		}
 		return null;
 	}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/tags/UserTag.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/tags/UserTag.java
@@ -41,6 +41,7 @@ public abstract class UserTag extends Snippet {
 	private final String templateId;
 	private Map<String, UserTagParameter> parameters;
 	private final QuteProject project;
+	private boolean hasArgs;
 
 	public UserTag(String fileName, QuteProject project) {
 		String name = UserTagUtils.getUserTagName(fileName);
@@ -182,9 +183,21 @@ public abstract class UserTag extends Snippet {
 	 */
 	public Collection<UserTagParameter> getParameters() {
 		if (parameters == null) {
-			parameters = collectParameters();
+			UserTagInfoCollector collector = getUserTagCollector();
+			if (collector != null) {
+				parameters = collector.getParameters();
+				hasArgs = collector.hasArgs();
+			} else {
+				parameters = Collections.emptyMap();
+				hasArgs = false;
+			}
 		}
 		return parameters.values();
+	}
+	
+	public boolean hasArgs() {
+		getParameters();
+		return hasArgs;
 	}
 
 	/**
@@ -223,14 +236,14 @@ public abstract class UserTag extends Snippet {
 	 * 
 	 * @return parameters of the user tag.
 	 */
-	private Map<String, UserTagParameter> collectParameters() {
+	private UserTagInfoCollector getUserTagCollector() {
 		Template template = getTemplate();
 		if (template == null) {
-			return Collections.emptyMap();
+			return null;
 		}
-		UserTagParameterCollector collector = new UserTagParameterCollector(project);
+		UserTagInfoCollector collector = new UserTagInfoCollector(project);
 		template.accept(collector);
-		return collector.getParameters();
+		return collector;
 	}
 
 	/**

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteDiagnostics.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteDiagnostics.java
@@ -52,7 +52,6 @@ import com.redhat.qute.parser.expression.Parts.PartKind;
 import com.redhat.qute.parser.expression.PropertyPart;
 import com.redhat.qute.parser.template.CaseOperator;
 import com.redhat.qute.parser.template.Expression;
-import com.redhat.qute.parser.template.ExpressionParameter;
 import com.redhat.qute.parser.template.JavaTypeInfoProvider;
 import com.redhat.qute.parser.template.LiteralSupport;
 import com.redhat.qute.parser.template.Node;
@@ -396,17 +395,18 @@ class QuteDiagnostics {
 							diagnostics.add(diagnostic);
 						} else {
 							existingParameters.add(paramName);
-							// Check if the declared parameter is defined in the user tag
-							UserTagParameter userTagParameter = userTag.findParameter(paramName);
-							if (userTagParameter == null) {
-								Range range = QutePositionUtility.selectParameterName(parameter);
-								Diagnostic diagnostic = createDiagnostic(range, DiagnosticSeverity.Warning,
-										QuteErrorCode.UndefinedParameter, paramName, tagName);
-								diagnostics.add(diagnostic);
+							if (!userTag.hasArgs()) {
+								// Check if the declared parameter is defined in the user tag
+								UserTagParameter userTagParameter = userTag.findParameter(paramName);
+								if (userTagParameter == null) {
+									Range range = QutePositionUtility.selectParameterName(parameter);
+									Diagnostic diagnostic = createDiagnostic(range, DiagnosticSeverity.Warning,
+											QuteErrorCode.UndefinedParameter, paramName, tagName);
+									diagnostics.add(diagnostic);
+								}
 							}
 						}
 					}
-
 					// Check if all required parameters are declared
 					List<String> missingRequiredParameters = new ArrayList<>();
 					for (UserTagParameter parameter : userTag.getParameters()) {

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/completions/QuteCompletionsForExpression.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/completions/QuteCompletionsForExpression.java
@@ -764,7 +764,7 @@ public class QuteCompletionsForExpression {
 			}
 
 			if (UserTagUtils.isUserTag(template)) {
-				// provide completion for 'it' and 'nested-content'
+				// provide completion for 'it', 'nested-content', '_args'
 				Collection<SectionMetadata> metadatas = UserTagUtils.getSpecialKeys();
 				for (SectionMetadata metadata : metadatas) {
 					String name = metadata.getName();

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/utils/UserTagUtils.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/utils/UserTagUtils.java
@@ -42,6 +42,7 @@ public class UserTagUtils {
 	public static final String IT_OBJECT_PART_NAME = "it";
 	public static final String NESTED_CONTENT_OBJECT_PART_NAME = "nested-content";
 	
+	public static final String ARGS_OBJECT_PART_NAME = "_args";
 	private static final Map<String, SectionMetadata> SPECIAL_KEYS;
 
 	static {
@@ -50,6 +51,9 @@ public class UserTagUtils {
 				"`it` is a special key that is replaced with the first unnamed parameter of the tag."));
 		register(new SectionMetadata(NESTED_CONTENT_OBJECT_PART_NAME, Object.class.getName(),
 				"`nested-content` is a special key that will be replaced by the content of the tag"));
+		register(new SectionMetadata(ARGS_OBJECT_PART_NAME, "io.quarkus.qute.UserTagSectionHelper.Arguments",
+				"`io.quarkus.qute.UserTagSectionHelper.Arguments` metadata are accessible in a tag using the `_args` alias."
+				+ "\nSee [here](https://quarkus.io/guides/qute-reference#arguments) for more information."));
 	}
 
 	private static void register(SectionMetadata metadata) {

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
@@ -114,9 +114,9 @@ public class QuteAssert {
 
 	public static final String FILE_URI = "test.qute";
 
-	public static final int USER_TAG_SIZE = 9 /*
+	public static final int USER_TAG_SIZE = 10 /*
 												 * #input, #bundleStyle, #form, #title, #simpleTitle, #user, #formElement,
-												 * #inputRequired, #myTag
+												 * #inputRequired, #myTag, #tagWithArgs
 												 */;
 
 	public static final int SECTION_SNIPPET_SIZE = 15 /* #each, #for, ... #fragment ... */ + USER_TAG_SIZE;

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInUserTagTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInUserTagTest.java
@@ -51,7 +51,7 @@ public class QuteCompletionInUserTagTest {
 		testCompletionFor(template, //
 				"src/main/resources/templates/tags/form.html", //
 				"tags/form", //
-				RESOLVERS_SIZE /* item, inject:bean, config:getConfigProperty */ + 2 /* it, nested-content */ + 1 /*
+				RESOLVERS_SIZE /* item, inject:bean, config:getConfigProperty */ + 3 /* it, nested-content, _args */ + 1 /*
 																													 * global
 																													 * variables
 																													 */, //
@@ -64,6 +64,7 @@ public class QuteCompletionInUserTagTest {
 				c("VARCHAR_SIZE", "VARCHAR_SIZE", r(1, 1, 1, 1)), //
 				c("it", "it", r(1, 1, 1, 1)), //
 				c("nested-content", "nested-content", r(1, 1, 1, 1)), //
+				c("_args", "_args", r(1, 1, 1, 1)), //
 				c("uri:Login", "uri:Login", r(1, 1, 1, 1)), //
 				c("msg:hello_name(name : String) : String", "msg:hello_name(name)", r(1, 1, 1, 1)), //
 				c("msg2:hello() : String", "msg2:hello", r(1, 1, 1, 1)), //

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionWithIncludeSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionWithIncludeSectionTest.java
@@ -36,7 +36,7 @@ public class QuteCompletionWithIncludeSectionTest {
 		// Without snippet
 		testCompletionFor(template, //
 				false, // no snippet support
-				15 /* all files from src/test/resources/templates */ - 1 /* README.md */ - USER_TAG_SIZE, //
+				16 /* all files from src/test/resources/templates */ - 1 /* README.md */ - USER_TAG_SIZE, //
 				c("base", "base", r(0, 10, 0, 10)),
 				c("test.json", "test.json", r(0, 10, 0, 10)),
 				c("test.html", "test.html", r(0, 10, 0, 10)),
@@ -55,7 +55,7 @@ public class QuteCompletionWithIncludeSectionTest {
 		testCompletionFor(template, //
 				"src/test/resources/templates/base.html",
 				false, // no snippet support
-				15 /* all files from src/test/resources/templates */ - 1 /* base.html */ - 1 /* README.md */
+				16 /* all files from src/test/resources/templates */ - 1 /* base.html */ - 1 /* README.md */
 						- USER_TAG_SIZE, //
 				// c("base", "base", r(0, 10, 0, 10)),
 				c("test.json", "test.json", r(0, 10, 0, 10)),

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionWithUserTagTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionWithUserTagTest.java
@@ -505,4 +505,24 @@ public class QuteCompletionWithUserTagTest {
 				0);
 	}
 
+	@Test
+	public void tagWithArgs() throws Exception {
+		// Here the content of tagWithArgs.html:
+		
+		// {_args.filter('readonly').asHtmlAttributes}
+		// {_args}
+		// {foo}
+		
+		String template = "{#tagWithArgs |}";
+
+		testCompletionFor(template, //
+				false, // no snippet support
+				1, //
+				c("foo", "foo=\"foo\"", r(0, 14, 0, 14)));
+
+		testCompletionFor(template, //
+				true, // snippet support
+				1, //
+				c("foo", "foo=\"${1:foo}\"$0", r(0, 14, 0, 14)));
+	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsWithUserTagTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsWithUserTagTest.java
@@ -36,7 +36,7 @@ public class QuteDiagnosticsWithUserTagTest {
 		// test with default value declared in bundleStyle.html user tag
 		// {#let name?="main.css"}
 		// In this case:
-		
+
 		// - name is optional
 		String template = "{#bundleStyle /}";
 		testDiagnosticsFor(template);
@@ -44,7 +44,7 @@ public class QuteDiagnosticsWithUserTagTest {
 		template = "{#bundleStyle name='foo.css'/}";
 		testDiagnosticsFor(template);
 	}
-	
+
 	@Test
 	public void definedRequiredParameterName() {
 		String template = "{#input name='' /}";
@@ -64,6 +64,22 @@ public class QuteDiagnosticsWithUserTagTest {
 				"No parameter `XXXX` found for `input` user tag.",
 				DiagnosticSeverity.Warning);
 		testDiagnosticsFor(template, d);
+	}
+
+	@Test
+	public void ignoreUndefinedParameterNameWhenArgs() throws Exception {
+		// tagWithArgs.html contains an expression which uses _args
+		// in this case, we ignore the QuteErrorCode.UndefinedParameter error.
+		String template = "{#tagWithArgs name='' XXXX='' /}";
+		
+		// There is no error with name (just an error with foo parameter which is required)
+		Diagnostic d = d(0, 1, 0, 13, QuteErrorCode.MissingRequiredParameter,
+				"Missing required parameter(s) `foo` of `tagWithArgs` user tag.",
+				DiagnosticSeverity.Warning);
+		testDiagnosticsFor(template, d);
+		testCodeActionsFor(template, d, //
+				ca(d, te(0, 29, 0, 30, //
+						" foo=\"foo\"")));
 	}
 
 	@Test

--- a/qute.ls/com.redhat.qute.ls/src/test/resources/templates/tags/tagWithArgs.html
+++ b/qute.ls/com.redhat.qute.ls/src/test/resources/templates/tags/tagWithArgs.html
@@ -1,0 +1,3 @@
+{_args.filter('readonly').asHtmlAttributes}
+{_args}
+{foo}


### PR DESCRIPTION
feat: Qute: add arguments metadata for user-defined tags

Fixes #928

Here a demo with _args support (no false positive validation + completion for _args.|) //cc @ia3andy 

![QuteArgsDemo](https://github.com/user-attachments/assets/fc08df7f-4339-48cd-ab44-c335d7945bfc)

