### PR TITLE
feat: Available Ollama models support for quarkus.langchain4j.ollama.chat-model.model-id property value

### DIFF
--- a/quarkus.ls.ext/com.redhat.quarkus.ls/pom.xml
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/pom.xml
@@ -34,12 +34,12 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.target>1.8</maven.compiler.target>
-		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
 		<maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
 		<dev.build.timestamp>${maven.build.timestamp}</dev.build.timestamp>
 		<lsp4j.version>0.14.0</lsp4j.version>
-		<microprofile.ls.version>0.8.0</microprofile.ls.version>
+		<microprofile.ls.version>0.12.0-SNAPSHOT</microprofile.ls.version>
 		<jboss.releases.repo.id>jboss-releases-repository</jboss.releases.repo.id>
 		<jboss.releases.repo.url>https://repository.jboss.org/nexus/content/repositories/releases/</jboss.releases.repo.url>
 		<jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/extensions/ollama/OllamaConstants.java
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/extensions/ollama/OllamaConstants.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.extensions.ollama;
+
+/**
+ * Quarkus Ollama constants.
+ */
+public class OllamaConstants {
+
+	public static final String QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_ID_KEY = "quarkus.langchain4j.ollama.chat-model.model-id";
+
+	public static final String QUARKUS_LANGCHAIN4J_OLLAMA_BASE_URL_KEY = "quarkus.langchain4j.ollama.base-url";
+
+	public static final String DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434";
+
+}

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/extensions/ollama/OllamaExtension.java
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/extensions/ollama/OllamaExtension.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.extensions.ollama;
+
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4mp.services.properties.extensions.IPropertiesFileExtension;
+import org.eclipse.lsp4mp.services.properties.extensions.PropertiesFileExtensionRegistry;
+
+/**
+ * Ollama extension.
+ */
+public class OllamaExtension implements IPropertiesFileExtension {
+
+	private OllamaPropertyValidatorParticipant ollamaPropertyValidatorParticipant = new OllamaPropertyValidatorParticipant();
+
+	@Override
+	public void start(InitializeParams params, PropertiesFileExtensionRegistry registry) {
+		registry.registerPropertyValidatorParticipant(ollamaPropertyValidatorParticipant);
+
+	}
+
+	@Override
+	public void stop(PropertiesFileExtensionRegistry registry) {
+		registry.unregisterPropertyValidatorParticipant(ollamaPropertyValidatorParticipant);
+	}
+
+}

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/extensions/ollama/OllamaItemMetadataProvider.java
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/extensions/ollama/OllamaItemMetadataProvider.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.extensions.ollama;
+
+import static com.redhat.quarkus.extensions.ollama.OllamaConstants.DEFAULT_OLLAMA_BASE_URL;
+import static com.redhat.quarkus.extensions.ollama.OllamaConstants.QUARKUS_LANGCHAIN4J_OLLAMA_BASE_URL_KEY;
+import static com.redhat.quarkus.extensions.ollama.OllamaConstants.QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_ID_KEY;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.lsp4mp.commons.metadata.ItemHint;
+import org.eclipse.lsp4mp.commons.metadata.ItemMetadata;
+import org.eclipse.lsp4mp.commons.metadata.ValueHint;
+import org.eclipse.lsp4mp.commons.utils.StringUtils;
+import org.eclipse.lsp4mp.extensions.ExtendedMicroProfileProjectInfo;
+import org.eclipse.lsp4mp.extensions.ItemMetadataProvider;
+import org.eclipse.lsp4mp.model.Node;
+import org.eclipse.lsp4mp.model.Node.NodeType;
+import org.eclipse.lsp4mp.model.PropertiesModel;
+import org.eclipse.lsp4mp.model.Property;
+
+import com.redhat.quarkus.extensions.ollama.client.OllamaClient;
+
+/**
+ * Properties provider to collect available Ollama model values for the property
+ * 'quarkus.langchain4j.ollama.chat-model.model-id'.
+ * 
+ * The Ollama models are collected by using Ollama Search Api by using the
+ * following base url:
+ * 
+ * <ul>
+ * <li>defined with 'quarkus.langchain4j.ollama.base-url' property.
+ * <li>otherwise with 'http://localhost:11434'</li>
+ * </ul>
+ */
+public class OllamaItemMetadataProvider implements ItemMetadataProvider {
+
+	private ExtendedMicroProfileProjectInfo projectInfo;
+	private OllamaClient ollamaClient;
+
+	public OllamaItemMetadataProvider(ExtendedMicroProfileProjectInfo projectInfo) {
+		this.projectInfo = projectInfo;
+		// the Ollama models are collected only if
+		// 'quarkus.langchain4j.ollama.chat-model.model-id' property exists.
+		boolean available = this.projectInfo.getProperties().stream()
+				.anyMatch(p -> QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_ID_KEY.equals(p.getName()));
+		if (available) {
+			ItemHint hint = new ItemHint();
+			hint.setName(QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_ID_KEY);
+			hint.setValues(Collections.emptyList());
+			projectInfo.getHints().add(hint);
+			this.ollamaClient = new OllamaClient();
+		}
+	}
+
+	@Override
+	public boolean isAvailable() {
+		return ollamaClient != null;
+	}
+
+	@Override
+	public void update(PropertiesModel document) {
+		// Called when application.properties file is opened or updated (when user type
+		// something in the file).
+		boolean hasModelProperty = getProperty(document, QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_ID_KEY) != null;
+		ItemHint hint = projectInfo.getHint(QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_ID_KEY);
+		if (hasModelProperty && hint != null) {
+			// The application.properties declare the
+			// 'quarkus.langchain4j.ollama.chat-model.model-id' property,
+			// we need to collect available Ollama models by using Ollama Search Api
+			String baseUrl = getSearchBaseUrl(document);
+			if (ollamaClient.update(baseUrl) || ollamaClient.needToRefreshModels()) {
+				// The current search url is different with the new, collect Ollama models.
+				// Update the available models values for the property
+				// 'quarkus.langchain4j.ollama.chat-model.model-id'
+				hint.setValues(ollamaClient.getModels() //
+						.stream() //
+						.map(m -> {
+							ValueHint model = new ValueHint();
+							String modelId = m.getName();
+							if (modelId.endsWith(":latest")) {
+								modelId = modelId.substring(0, modelId.length() - 7);
+							}
+							model.setValue(modelId);
+							return model;
+						}) //
+						.collect(Collectors.toList()));
+			}
+		}
+	}
+
+	@Override
+	public List<ItemMetadata> getProperties() {
+		// This provider doesn't contribute to add/remove properties
+		return null;
+	}
+
+	private static Property getProperty(PropertiesModel document, String propertyName) {
+		for (Node node : document.getChildren()) {
+			if (node.getNodeType() == NodeType.PROPERTY) {
+				Property property = (Property) node;
+				if (propertyName.equals(property.getPropertyName())) {
+					return property;
+				}
+			}
+		}
+		return null;
+	}
+
+	private static String getSearchBaseUrl(PropertiesModel document) {
+		Property baseUrlProperty = getProperty(document, QUARKUS_LANGCHAIN4J_OLLAMA_BASE_URL_KEY);
+		if (baseUrlProperty != null) {
+			String propertyValue = baseUrlProperty.getPropertyValue();
+			if (StringUtils.hasText(propertyValue)) {
+				return propertyValue;
+			}
+		}
+		return DEFAULT_OLLAMA_BASE_URL;
+	}
+
+}

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/extensions/ollama/OllamaItemMetadataProviderFactory.java
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/extensions/ollama/OllamaItemMetadataProviderFactory.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.extensions.ollama;
+
+import org.eclipse.lsp4mp.extensions.ExtendedMicroProfileProjectInfo;
+import org.eclipse.lsp4mp.extensions.ItemMetadataProvider;
+import org.eclipse.lsp4mp.extensions.ItemMetadataProviderFactory;
+
+/**
+ * Factory for creating {@link ItemMetadataProvider} instance to collect
+ * available Ollama models.
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class OllamaItemMetadataProviderFactory implements ItemMetadataProviderFactory {
+
+	@Override
+	public ItemMetadataProvider create(ExtendedMicroProfileProjectInfo projectInfo) {
+		return new OllamaItemMetadataProvider(projectInfo);
+	}
+}

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/extensions/ollama/OllamaPropertyValidatorParticipant.java
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/extensions/ollama/OllamaPropertyValidatorParticipant.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.extensions.ollama;
+
+import static com.redhat.quarkus.extensions.ollama.OllamaConstants.QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_ID_KEY;
+
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.eclipse.lsp4mp.services.properties.ValidationValueContext;
+import org.eclipse.lsp4mp.services.properties.extensions.participants.IPropertyValidatorParticipant;
+
+/**
+ * Custom validation for 'quarkus.langchain4j.ollama.chat-model.model-id'.
+ */
+public class OllamaPropertyValidatorParticipant implements IPropertyValidatorParticipant {
+
+	@Override
+	public boolean validatePropertyValue(ValidationValueContext context, CancelChecker cancelChecker) {
+		if (QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_ID_KEY.equals(context.getPropertyName())) {
+			// No validation for Ollama model.
+			return true;
+		}
+		return false;
+	}
+}

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/extensions/ollama/client/OllamaClient.java
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/extensions/ollama/client/OllamaClient.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.extensions.ollama.client;
+
+import java.io.StringReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.google.gson.GsonBuilder;
+
+/**
+ * Ollama client.
+ */
+public class OllamaClient {
+
+	private static final Logger LOGGER = Logger.getLogger(OllamaClient.class.getName());
+
+	private static final long REFRESH_OLLAMA_CACHE_TIMEOUT = 60000L;
+
+	private String currentBaseUrl;
+
+	private List<OllamaModel> currentModels;
+
+	private long lastDate = -1;
+
+	/**
+	 * Update the base Url of the Ollama server.
+	 * 
+	 * @param baseUrl the the base Url of the Ollama server
+	 * @return true if base Url is different from the current base Url.
+	 */
+	public boolean update(String baseUrl) {
+		if (!Objects.equals(baseUrl, currentBaseUrl)) {
+			currentModels = null;
+		}
+		this.currentBaseUrl = baseUrl;
+		return currentModels == null;
+	}
+
+	/**
+	 * Returns true if the Ollama model cache must be evicted and false otherwise.
+	 * 
+	 * @return true if the Ollama model cache must be evicted and false otherwise.
+	 */
+	public boolean needToRefreshModels() {
+		return (System.currentTimeMillis() - lastDate) > REFRESH_OLLAMA_CACHE_TIMEOUT;
+	}
+
+	/**
+	 * Returns the list of the Ollama models retrieves with the /api/tags.
+	 * 
+	 * @return the list of the Ollama models retrieves with the /api/tags.
+	 */
+	public List<OllamaModel> getModels() {
+		if (currentModels == null) {
+			String apiTagsUrl = currentBaseUrl + "/api/tags";
+			currentModels = collectOllamaModels(apiTagsUrl);
+			lastDate = System.currentTimeMillis();
+		}
+		return currentModels;
+	}
+
+	private static List<OllamaModel> collectOllamaModels(String searchUrl) {
+		try {
+			// Call Http search Url (ex : http://localhost:11434/api/tags)
+			HttpRequest request = HttpRequest.newBuilder() //
+					.uri(new URI(searchUrl)) //
+					.GET() //
+					.build();
+
+			HttpResponse<String> response = HttpClient.newBuilder() //
+					.followRedirects(HttpClient.Redirect.NORMAL) // follow redirects
+					.build() //
+					.send(request, BodyHandlers.ofString());
+
+			if (response.statusCode() != 200) {
+				return Collections.emptyList();
+			}
+
+			// ex :
+			/*
+			 * { models: [ { name: "qwen2:latest", model: "qwen2:latest", modified_at:
+			 * "2024-08-20T18:56:28.9319459+02:00", size: 4431400262, digest:
+			 * "e0d4e1163c585612b5419eee0a0d87fe0cac5fa6844001392e78d0cdf57c8138", details:
+			 * { parent_model: "", format: "gguf", family: "qwen2", families: [ "qwen2" ],
+			 * parameter_size: "7.6B", quantization_level: "Q4_0" } } ] }
+			 */
+			String result = response.body();
+			OllamaModelsResult r = new GsonBuilder() //
+					.create()//
+					.fromJson(new StringReader(result), OllamaModelsResult.class);
+			if (r != null && r.getModels() != null) {
+				return r.getModels();
+			}
+
+		} catch (Exception e) {
+			LOGGER.log(Level.SEVERE, "Could not connect to ollama '" + searchUrl + "': " + e.getMessage());
+		}
+		return Collections.emptyList();
+	}
+}

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/extensions/ollama/client/OllamaModel.java
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/extensions/ollama/client/OllamaModel.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.extensions.ollama.client;
+
+/**
+ * Ollama model.
+ */
+public class OllamaModel {
+
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+}

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/extensions/ollama/client/OllamaModelsResult.java
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/java/com/redhat/quarkus/extensions/ollama/client/OllamaModelsResult.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.quarkus.extensions.ollama.client;
+
+import java.util.List;
+
+/**
+ * Bean class which maps the HTTP response of http://localhost:11434/v1/models
+ * 
+ * Example: <code>
+ * {
+		models: [
+			{
+				name: "qwen2:latest",
+				model: "qwen2:latest",
+				modified_at: "2024-08-20T18:56:28.9319459+02:00",
+				size: 4431400262,
+				digest: "e0d4e1163c585612b5419eee0a0d87fe0cac5fa6844001392e78d0cdf57c8138",
+				details: {
+					parent_model: "",
+					format: "gguf",
+					family: "qwen2",
+					families: [
+						"qwen2"
+					],
+					parameter_size: "7.6B",
+					quantization_level: "Q4_0"
+				}
+			}
+		]
+}
+ * </code>
+ */
+public class OllamaModelsResult {
+
+	private List<OllamaModel> models;
+
+	public List<OllamaModel> getModels() {
+		return models;
+	}
+
+	public void setModels(List<OllamaModel> models) {
+		this.models = models;
+	}
+}

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/resources/META-INF/services/org.eclipse.lsp4mp.extensions.ItemMetadataProviderFactory
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/resources/META-INF/services/org.eclipse.lsp4mp.extensions.ItemMetadataProviderFactory
@@ -1,0 +1,1 @@
+com.redhat.quarkus.extensions.ollama.OllamaItemMetadataProviderFactory

--- a/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/resources/META-INF/services/org.eclipse.lsp4mp.services.properties.extensions.IPropertiesFileExtension
+++ b/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/resources/META-INF/services/org.eclipse.lsp4mp.services.properties.extensions.IPropertiesFileExtension
@@ -1,0 +1,1 @@
+com.redhat.quarkus.extensions.ollama.OllamaExtension


### PR DESCRIPTION
feat: Available Ollama models support for `quarkus.langchain4j.ollama.chat-model.model-id` property value

This PR requires https://github.com/eclipse/lsp4mp/pull/460

Those models are retrieved by consuming the Ollama API `${base-url}/v1/models` where base-url equals to:

 * the value coming from declared `quarkus.langchain4j.ollama.base-url` property in the application.properties.
 * http://localhost:11434 otherwise

Here the result in vscode with completion:

![image](https://github.com/user-attachments/assets/9841a8f2-6a29-445e-ac9c-50bec1634f54)

Here the result with validtaion:

![image](https://github.com/user-attachments/assets/6b0282c6-c020-49c8-805f-7e85457fd75f)


As the error message is generic, it is not very good, LSP4MP must be improved to contribute with custom error validation message.

The Ollama models are cached, so if you add a new model in Ollama, you need to close the file and reopen it to refresh the cache (not tested but I think it should work).