### PR TITLE
fix: Message: Request qute/java/documentLink failed with message: Cannot invoke "org.eclipse.jdt.core.dom.ITypeBinding.getQualifiedName()"

### DIFF
--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/java/AbstractQuteTemplateLinkCollector.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/java/AbstractQuteTemplateLinkCollector.java
@@ -456,6 +456,11 @@ public abstract class AbstractQuteTemplateLinkCollector extends ASTVisitor {
 		if (type == null || !type.isSimpleType()) {
 			return false;
 		}
-		return (TEMPLATE_CLASS.equals(((SimpleType) type).resolveBinding().getQualifiedName().toString()));
+		ITypeBinding binding = ((SimpleType) type).resolveBinding();
+		if (binding == null) {
+			// ex : when type=Integer
+			return false;
+		}
+		return TEMPLATE_CLASS.equals(binding.getQualifiedName());
 	}
 }

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/java/QuteJavaDiagnosticsCollector.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/java/QuteJavaDiagnosticsCollector.java
@@ -80,9 +80,12 @@ public class QuteJavaDiagnosticsCollector extends AbstractQuteTemplateLinkCollec
 		}
 		case NoMatchingTemplate: {			
 			ITypeBinding binding = type.resolveBinding();
-			String fullQualifiedName = ((IType) binding.getJavaElement()).getFullyQualifiedName();
-			Diagnostic diagnostic = createDiagnostic(range, DiagnosticSeverity.Error, error, path, fullQualifiedName);
-			this.diagnostics.add(diagnostic);
+			if (binding != null) {
+				String fullQualifiedName = ((IType) binding.getJavaElement()).getFullyQualifiedName();
+				Diagnostic diagnostic = createDiagnostic(range, DiagnosticSeverity.Error, error, path,
+						fullQualifiedName);
+				this.diagnostics.add(diagnostic);
+			}
 			break;
 		}
 		}


### PR DESCRIPTION
[invoke "org.eclipse.jdt.core.dom.ITypeBinding.getQualifiedName()"](fix: Message: Request qute/java/documentLink failed with message: Cannot invoke "org.eclipse.jdt.core.dom.ITypeBinding.getQualifiedName()")

See https://github.com/redhat-developer/vscode-quarkus/issues/839

To test this PR::

 * open https://github.com/burrsutter/ai-rubric/blob/main/src/main/java/com/burrsutter/RESTResource.java#L15
 * declare an Integer field like

```
public class RESTResource {
    public Integer foo;
...
}
```

In this case the Integer resolveBinding returns null.