### PR TITLE
Improve the Target platform for JDT Extension components.

### DIFF
--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/pom.xml
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus.test/pom.xml
@@ -19,6 +19,14 @@
 	   <skipDeployToJBossOrg>false</skipDeployToJBossOrg>
 	</properties>
 
+	<repositories>
+		<repository>
+			<id>platform.p2</id>
+			<layout>p2</layout>
+			<url>https://download.eclipse.org/eclipse/updates/4.34-I-builds</url>
+		</repository>
+	</repositories>
+
 	<build>
 	   <pluginManagement>
 	       <plugins>

--- a/quarkus.jdt.ext/pom.xml
+++ b/quarkus.jdt.ext/pom.xml
@@ -14,7 +14,6 @@
     <tycho.extras.version>${tycho.version}</tycho.extras.version>
     <tycho.scmUrl>scm:git:https://github.com/redhat-developer/quarkus-ls</tycho.scmUrl>
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
-    <jdt.ls.version>1.41.0-SNAPSHOT</jdt.ls.version>
     <tycho.test.platformArgs />
     <tycho.test.jvmArgs>-Xmx4G -DDetectVMInstallationsJob.disabled=true ${tycho.test.platformArgs}</tycho.test.jvmArgs>
     <lsp4mp.p2.url>https://download.eclipse.org/lsp4mp/snapshots/0.12.0/repository/</lsp4mp.p2.url>
@@ -40,11 +39,6 @@
       <layout>p2</layout>
       <url>${lsp4mp.p2.url}</url>
     </repository>
-    <repository>
-      <id>jdt.ls.maven</id>
-      <!-- Used to resolve the jdt.ls TP -->
-      <url>https://repo.eclipse.org/content/repositories/jdtls-snapshots/</url>
-    </repository>
   </repositories>
   <build>
     <plugins>
@@ -59,14 +53,6 @@
         <artifactId>target-platform-configuration</artifactId>
         <version>${tycho.version}</version>
         <configuration>
-          <resolver>p2</resolver>
-          <target>
-            <artifact>
-              <groupId>org.eclipse.jdt.ls</groupId>
-              <artifactId>org.eclipse.jdt.ls.tp</artifactId>
-              <version>${jdt.ls.version}</version>
-            </artifact>
-          </target>
           <resolver>p2</resolver>
           <pomDependencies>consider</pomDependencies>
           <ignoreTychoRepositories>true</ignoreTychoRepositories>

--- a/qute.jdt/com.redhat.qute.jdt.test/pom.xml
+++ b/qute.jdt/com.redhat.qute.jdt.test/pom.xml
@@ -19,6 +19,14 @@
 		<skipDeployToJBossOrg>false</skipDeployToJBossOrg>
 	</properties>
 
+	<repositories>
+		<repository>
+			<id>platform.p2</id>
+			<layout>p2</layout>
+			<url>https://download.eclipse.org/eclipse/updates/4.34-I-builds</url>
+		</repository>
+	</repositories>
+
 	<build>
 		<pluginManagement>
 			<plugins>

--- a/qute.jdt/pom.xml
+++ b/qute.jdt/pom.xml
@@ -16,7 +16,6 @@
 		<tycho.extras.version>${tycho.version}</tycho.extras.version>
 		<tycho.scmUrl>scm:git:https://github.com/redhat-developer/quarkus-ls</tycho.scmUrl>
 		<tycho.generateSourceReferences>true</tycho.generateSourceReferences>
-		<jdt.ls.version>1.41.0-SNAPSHOT</jdt.ls.version>
 		<tycho.test.platformArgs />
 		<tycho.test.jvmArgs>-Xmx512m -DDetectVMInstallationsJob.disabled=true ${tycho.test.platformArgs}</tycho.test.jvmArgs>
 
@@ -36,10 +35,6 @@
 			<layout>p2</layout>
 			<url>https://download.eclipse.org/jdtls/snapshots/repository/latest/</url>
 		</repository>
-		<repository>
-			<id>jdt.ls.maven</id>
-			<url>https://repo.eclipse.org/content/repositories/jdtls-snapshots/</url>
-		</repository>
 	</repositories>
 
 	<build>
@@ -55,14 +50,6 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho.version}</version>
 				<configuration>
-					<resolver>p2</resolver>
-					<target>
-						<artifact>
-							<groupId>org.eclipse.jdt.ls</groupId>
-							<artifactId>org.eclipse.jdt.ls.tp</artifactId>
-							<version>${jdt.ls.version}</version>
-						</artifact>
-					</target>
 					<resolver>p2</resolver>
 					<pomDependencies>consider</pomDependencies>
 					<ignoreTychoRepositories>true</ignoreTychoRepositories>


### PR DESCRIPTION
- Use the JDT-LS repository, which now contains all dependencies to build the target platform
- Include o.e.platform.feature.group for the test runtime