### PR TITLE
TemplateExtension match any support

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/QuteProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/QuteProject.java
@@ -1118,11 +1118,19 @@ public class QuteProject {
 		}
 		List<MethodValueResolver> resolvers = getResolversFor(baseType);
 		for (MethodValueResolver resolver : resolvers) {
-			if (isMatchMethod(resolver, property)) {
+			if (isMatchMethod(resolver, property) || isMatchMethodResolver(resolver, property)) {
 				return resolver;
 			}
 		}
 		return null;
+	}
+
+	private boolean isMatchMethodResolver(MethodValueResolver resolver, String property) {
+		String matchName = resolver.getMatchName();
+		if (matchName == null) {
+			return false;
+		}
+		return ValueResolver.MATCH_NAME_ANY.equals(matchName) || matchName.equals(property);
 	}
 
 	public List<MethodValueResolver> getResolversFor(ResolvedJavaTypeInfo javaType) {

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/BaseQuteProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/BaseQuteProject.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.project;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.redhat.qute.commons.InvalidMethodReason;
+import com.redhat.qute.commons.JavaTypeInfo;
+import com.redhat.qute.commons.JavaTypeKind;
+import com.redhat.qute.commons.ProjectInfo;
+import com.redhat.qute.commons.ResolvedJavaTypeInfo;
+
+/**
+ * Base class for project which initializes JDK resolved Java types.
+ */
+public abstract class BaseQuteProject extends MockQuteProject {
+
+	public BaseQuteProject(ProjectInfo projectInfo, QuteProjectRegistry projectRegistry) {
+		super(projectInfo, projectRegistry);
+	}
+
+	@Override
+	protected void fillJavaTypes(List<JavaTypeInfo> cache) {
+		createJavaTypeInfo("java.util.List<E>", JavaTypeKind.Interface, cache);
+		createJavaTypeInfo("java.util.Map<K,V>", JavaTypeKind.Interface, cache);
+	}
+
+	@Override
+	protected void fillResolvedJavaTypes(List<ResolvedJavaTypeInfo> resolvedJavaTypes) {
+		createBinaryTypes(resolvedJavaTypes);
+	}
+
+	private void createBinaryTypes(List<ResolvedJavaTypeInfo> cache) {
+		// Java type primitives
+		createResolvedJavaTypeInfo("java.lang.Object", cache, true);
+		createResolvedJavaTypeInfo("java.lang.Boolean", cache, true);
+		createResolvedJavaTypeInfo("java.lang.Integer", cache, true);
+		createResolvedJavaTypeInfo("java.lang.Double", cache, true);
+		createResolvedJavaTypeInfo("java.lang.Long", cache, true);
+		createResolvedJavaTypeInfo("java.lang.Float", cache, true);
+		createResolvedJavaTypeInfo("java.math.BigDecimal", cache, true);
+
+		// String
+		ResolvedJavaTypeInfo string = createResolvedJavaTypeInfo("java.lang.String", cache, true);
+		registerField("UTF16 : byte", string);
+		registerMethod("isEmpty() : boolean", string);
+		registerMethod("codePointCount(beginIndex : int,endIndex : int) : int", string);
+		string.setInvalidMethod("getChars", InvalidMethodReason.VoidReturn); // void getChars(int srcBegin, int srcEnd,
+																				// char dst[], int dstBegin)
+		registerMethod("charAt(index : int) : char", string);
+		registerMethod("getBytes(charsetName : java.lang.String) : byte[]", string);
+		registerMethod("getBytes() : byte[]", string);
+
+		// BigInteger
+		ResolvedJavaTypeInfo bigInteger = createResolvedJavaTypeInfo("java.math.BigInteger", cache, true);
+		registerMethod("divide(val : java.math.BigInteger) : java.math.BigInteger", bigInteger);
+
+		// Iterator
+		ResolvedJavaTypeInfo iterator = createResolvedJavaTypeInfo("java.util.Iterator<E>", cache, true);
+		registerMethod("hasNext() : boolean", iterator);
+		registerMethod("next() : E", iterator);
+
+		// Iterable
+		ResolvedJavaTypeInfo iterable = createResolvedJavaTypeInfo("java.lang.Iterable<T>", cache, true);
+		registerMethod("iterator() : java.util.Iterator<T>", iterable);
+
+		// Collection
+		ResolvedJavaTypeInfo collection = createResolvedJavaTypeInfo("java.util.Collection<E>", cache, true);
+		collection.setExtendedTypes(Arrays.asList("java.lang.Iterable<E>"));
+
+		// List
+		ResolvedJavaTypeInfo list = createResolvedJavaTypeInfo("java.util.List<E>", cache, true);
+		list.setExtendedTypes(Arrays.asList("java.util.Collection<E>"));
+		registerMethod("size() : int", list);
+		registerMethod("get(index : int) : E", list);
+		registerMethod("subList(fromIndex : int, toIndex: int) : java.util.List<E>", list);
+
+		// Set
+		ResolvedJavaTypeInfo set = createResolvedJavaTypeInfo("java.util.Set<E>", cache, true);
+		set.setExtendedTypes(Arrays.asList("java.lang.Iterable<E>"));
+
+		// Map
+		ResolvedJavaTypeInfo map = createResolvedJavaTypeInfo("java.util.Map<K,V>", cache, true);
+		registerMethod("keySet() : java.util.Set<K>", map);
+		registerMethod("values() : java.util.Collection<V>", map);
+		registerMethod("entrySet() : java.util.Set<java.util.Map$Entry<K,V>>", map);
+		registerMethod("get(key : K) : V", map);
+
+		// Map.Entry
+		ResolvedJavaTypeInfo mapEntry = createResolvedJavaTypeInfo("java.util.Map$Entry<K,V>", cache, true);
+		registerMethod("getKey() : K", mapEntry);
+		registerMethod("getValue() : V", mapEntry);
+
+		// AbstractMap
+		ResolvedJavaTypeInfo abstractMap = createResolvedJavaTypeInfo("java.util.AbstractMap<K,V>", cache, true);
+		abstractMap.setExtendedTypes(Arrays.asList("java.util.Map<K,V>"));
+
+		// HashMap
+		ResolvedJavaTypeInfo hashMap = createResolvedJavaTypeInfo("java.util.HashMap<K,V>", cache, true);
+		hashMap.setExtendedTypes(Arrays.asList("java.util.AbstractMap<K,V>", "java.util.Map<K,V>"));
+
+		// https://quarkus.io/guides/qute-reference#evaluation-of-completionstage-and-uni-objects
+		createResolvedJavaTypeInfo("java.util.concurrent.CompletionStage<T>", cache, true);
+		ResolvedJavaTypeInfo completableFuture = createResolvedJavaTypeInfo("java.util.concurrent.CompletableFuture<T>",
+				cache, true);
+		completableFuture.setExtendedTypes(Arrays.asList("java.util.concurrent.CompletionStage<T>"));
+		createResolvedJavaTypeInfo("io.smallrye.mutiny.Uni<T>", cache, true);
+		ResolvedJavaTypeInfo asyncResultUni = createResolvedJavaTypeInfo("io.smallrye.mutiny.vertx.AsyncResultUni<T>",
+				cache, true);
+		asyncResultUni.setExtendedTypes(Arrays.asList("io.smallrye.mutiny.Uni<T>"));
+
+		// RawString for raw and safe resolver tests
+		ResolvedJavaTypeInfo rawString = createResolvedJavaTypeInfo("io.quarkus.qute.RawString", cache, true);
+		registerMethod("getValue() : java.lang.String", rawString);
+		registerMethod("toString() : java.lang.String", rawString);
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/MockQuteProjectRegistry.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/MockQuteProjectRegistry.java
@@ -37,6 +37,7 @@ import com.redhat.qute.commons.usertags.QuteUserTagParams;
 import com.redhat.qute.commons.usertags.UserTagInfo;
 import com.redhat.qute.project.multiple.QuteProjectA;
 import com.redhat.qute.project.multiple.QuteProjectB;
+import com.redhat.qute.project.roq.RoqProject;
 
 public class MockQuteProjectRegistry extends QuteProjectRegistry {
 
@@ -63,6 +64,9 @@ public class MockQuteProjectRegistry extends QuteProjectRegistry {
 		}
 		if (QuteProjectB.PROJECT_URI.equals(projectInfo.getUri())) {
 			return new QuteProjectB(this);
+		}
+		if (RoqProject.PROJECT_URI.equals(projectInfo.getUri())) {
+			return new RoqProject(projectInfo, this);
 		}
 		return super.createProject(projectInfo);
 	}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/QuteQuickStartProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/QuteQuickStartProject.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import com.redhat.qute.commons.InvalidMethodReason;
 import com.redhat.qute.commons.JavaMemberInfo;
 import com.redhat.qute.commons.JavaMethodInfo;
-import com.redhat.qute.commons.JavaTypeInfo;
 import com.redhat.qute.commons.JavaTypeKind;
 import com.redhat.qute.commons.ProjectInfo;
 import com.redhat.qute.commons.ResolvedJavaTypeInfo;
@@ -42,7 +41,7 @@ import com.redhat.qute.commons.jaxrs.RestParam;
  * @author Angelo ZERR
  *
  */
-public class QuteQuickStartProject extends MockQuteProject {
+public class QuteQuickStartProject extends BaseQuteProject {
 
 	public final static String PROJECT_URI = "qute-quickstart";
 
@@ -56,95 +55,9 @@ public class QuteQuickStartProject extends MockQuteProject {
 
 	@Override
 	protected void fillResolvedJavaTypes(List<ResolvedJavaTypeInfo> cache) {
-		createBinaryTypes(cache);
+		super.fillResolvedJavaTypes(cache);
 		createSourceTypes(cache);
 	}
-
-	private void createBinaryTypes(List<ResolvedJavaTypeInfo> cache) {
-		// Java type primitives
-		createResolvedJavaTypeInfo("java.lang.Object", cache, true);
-		createResolvedJavaTypeInfo("java.lang.Boolean", cache, true);
-		createResolvedJavaTypeInfo("java.lang.Integer", cache, true);
-		createResolvedJavaTypeInfo("java.lang.Double", cache, true);
-		createResolvedJavaTypeInfo("java.lang.Long", cache, true);
-		createResolvedJavaTypeInfo("java.lang.Float", cache, true);
-		createResolvedJavaTypeInfo("java.math.BigDecimal", cache, true);
-
-		// String
-		ResolvedJavaTypeInfo string = createResolvedJavaTypeInfo("java.lang.String", cache, true);
-		registerField("UTF16 : byte", string);
-		registerMethod("isEmpty() : boolean", string);
-		registerMethod("codePointCount(beginIndex : int,endIndex : int) : int", string);
-		string.setInvalidMethod("getChars", InvalidMethodReason.VoidReturn); // void getChars(int srcBegin, int srcEnd,
-																				// char dst[], int dstBegin)
-		registerMethod("charAt(index : int) : char", string);
-		registerMethod("getBytes(charsetName : java.lang.String) : byte[]", string);
-		registerMethod("getBytes() : byte[]", string);
-
-		// BigInteger
-		ResolvedJavaTypeInfo bigInteger = createResolvedJavaTypeInfo("java.math.BigInteger", cache, true);
-		registerMethod("divide(val : java.math.BigInteger) : java.math.BigInteger", bigInteger);
-
-		// Iterator
-		ResolvedJavaTypeInfo iterator = createResolvedJavaTypeInfo("java.util.Iterator<E>", cache, true);
-		registerMethod("hasNext() : boolean", iterator);
-		registerMethod("next() : E", iterator);
-
-		// Iterable
-		ResolvedJavaTypeInfo iterable = createResolvedJavaTypeInfo("java.lang.Iterable<T>", cache, true);
-		registerMethod("iterator() : java.util.Iterator<T>", iterable);
-
-		// Collection
-		ResolvedJavaTypeInfo collection = createResolvedJavaTypeInfo("java.util.Collection<E>", cache, true);
-		collection.setExtendedTypes(Arrays.asList("java.lang.Iterable<E>"));
-
-		// List
-		ResolvedJavaTypeInfo list = createResolvedJavaTypeInfo("java.util.List<E>", cache, true);
-		list.setExtendedTypes(Arrays.asList("java.util.Collection<E>"));
-		registerMethod("size() : int", list);
-		registerMethod("get(index : int) : E", list);
-		registerMethod("subList(fromIndex : int, toIndex: int) : java.util.List<E>", list);
-
-		// Set
-		ResolvedJavaTypeInfo set = createResolvedJavaTypeInfo("java.util.Set<E>", cache, true);
-		set.setExtendedTypes(Arrays.asList("java.lang.Iterable<E>"));
-
-		// Map
-		ResolvedJavaTypeInfo map = createResolvedJavaTypeInfo("java.util.Map<K,V>", cache, true);
-		registerMethod("keySet() : java.util.Set<K>", map);
-		registerMethod("values() : java.util.Collection<V>", map);
-		registerMethod("entrySet() : java.util.Set<java.util.Map$Entry<K,V>>", map);
-		registerMethod("get(key : K) : V", map);
-
-		// Map.Entry
-		ResolvedJavaTypeInfo mapEntry = createResolvedJavaTypeInfo("java.util.Map$Entry<K,V>", cache, true);
-		registerMethod("getKey() : K", mapEntry);
-		registerMethod("getValue() : V", mapEntry);
-
-		// AbstractMap
-		ResolvedJavaTypeInfo abstractMap = createResolvedJavaTypeInfo("java.util.AbstractMap<K,V>", cache, true);
-		abstractMap.setExtendedTypes(Arrays.asList("java.util.Map<K,V>"));
-
-		// HashMap
-		ResolvedJavaTypeInfo hashMap = createResolvedJavaTypeInfo("java.util.HashMap<K,V>", cache, true);
-		hashMap.setExtendedTypes(Arrays.asList("java.util.AbstractMap<K,V>", "java.util.Map<K,V>"));
-
-		// https://quarkus.io/guides/qute-reference#evaluation-of-completionstage-and-uni-objects
-		createResolvedJavaTypeInfo("java.util.concurrent.CompletionStage<T>", cache, true);
-		ResolvedJavaTypeInfo completableFuture = createResolvedJavaTypeInfo("java.util.concurrent.CompletableFuture<T>",
-				cache, true);
-		completableFuture.setExtendedTypes(Arrays.asList("java.util.concurrent.CompletionStage<T>"));
-		createResolvedJavaTypeInfo("io.smallrye.mutiny.Uni<T>", cache, true);
-		ResolvedJavaTypeInfo asyncResultUni = createResolvedJavaTypeInfo("io.smallrye.mutiny.vertx.AsyncResultUni<T>",
-				cache, true);
-		asyncResultUni.setExtendedTypes(Arrays.asList("io.smallrye.mutiny.Uni<T>"));
-
-		// RawString for raw and safe resolver tests
-		ResolvedJavaTypeInfo rawString = createResolvedJavaTypeInfo("io.quarkus.qute.RawString", cache, true);
-		registerMethod("getValue() : java.lang.String", rawString);
-		registerMethod("toString() : java.lang.String", rawString);
-	}
-
 	private void createSourceTypes(List<ResolvedJavaTypeInfo> cache) {
 		createResolvedJavaTypeInfo("org.acme", cache, true).setJavaTypeKind(JavaTypeKind.Package);
 
@@ -339,7 +252,7 @@ public class QuteQuickStartProject extends MockQuteProject {
 
 		// void method
 		registerMethod("timeoutGame() : void", renardeLogin);
-		
+
 		// https://quarkus.io/guides/qute-reference#evaluation-of-completionstage-and-uni-objects
 		ResolvedJavaTypeInfo completionStagePOJO = createResolvedJavaTypeInfo("org.acme.CompletionStagePOJO", cache,
 				false);
@@ -527,12 +440,6 @@ public class QuteQuickStartProject extends MockQuteProject {
 		hello.setData(helloData);
 		resolvers.add(hello);
 
-	}
-
-	@Override
-	protected void fillJavaTypes(List<JavaTypeInfo> cache) {
-		createJavaTypeInfo("java.util.List<E>", JavaTypeKind.Interface, cache);
-		createJavaTypeInfo("java.util.Map<K,V>", JavaTypeKind.Interface, cache);
 	}
 
 	@Override

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/roq/DocumentPage.json
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/roq/DocumentPage.json
@@ -1,0 +1,31 @@
+{
+	"signature": "io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage",
+	"extendedTypes": [
+		"java.lang.Record",
+		"io.quarkiverse.roq.frontmatter.runtime.model.Page"
+	],
+	"fields": [
+		{
+			"signature": "collection : java.lang.String"
+		},
+		{
+			"signature": "url : io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl"
+		},
+		{
+			"signature": "info : io.quarkiverse.roq.frontmatter.runtime.model.PageInfo"
+		},
+		{
+			"signature": "data : io.vertx.core.json.JsonObject"
+		},
+		{
+			"signature": "hidden : boolean"
+		}
+	],
+	"methods": [],
+	"binary": false,
+	"templateDataAnnotations": [
+		{}
+	],
+	"typeKind": 0,
+	"invalidMethods": {}
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/roq/Paginator.json
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/roq/Paginator.json
@@ -1,0 +1,55 @@
+{
+	"signature": "io.quarkiverse.roq.frontmatter.runtime.model.Paginator",
+	"extendedTypes": [
+		"java.lang.Record"
+	],
+	"fields": [
+		{
+			"signature": "collection : java.lang.String"
+		},
+		{
+			"signature": "collectionSize : int"
+		},
+		{
+			"signature": "limit : int"
+		},
+		{
+			"signature": "total : int"
+		},
+		{
+			"signature": "currentIndex : int"
+		},
+		{
+			"signature": "previousIndex : java.lang.Integer"
+		},
+		{
+			"signature": "previous : io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl"
+		},
+		{
+			"signature": "nextIndex : java.lang.Integer"
+		},
+		{
+			"signature": "next : io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl"
+		}
+	],
+	"methods": [
+		{
+			"signature": "prevIndex() : java.lang.Integer"
+		},
+		{
+			"signature": "prev() : io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl"
+		},
+		{
+			"signature": "isFirst() : boolean"
+		},
+		{
+			"signature": "isSecond() : boolean"
+		}
+	],
+	"binary": false,
+	"templateDataAnnotations": [
+		{}
+	],
+	"typeKind": 0,
+	"invalidMethods": {}
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/roq/RoqCollection.json
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/roq/RoqCollection.json
@@ -1,0 +1,33 @@
+{
+	"signature": "io.quarkiverse.roq.frontmatter.runtime.model.RoqCollection",
+	"extendedTypes": [
+		"java.util.ArrayList<io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage>"
+	],
+	"fields": [],
+	"methods": [
+		{
+			"signature": "resolveNextPage(page : io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage) : io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage"
+		},
+		{
+			"signature": "resolvePreviousPage(page : io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage) : io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage"
+		},
+		{
+			"signature": "resolvePrevPage(page : io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage) : io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage"
+		},
+		{
+			"signature": "paginated(paginator : io.quarkiverse.roq.frontmatter.runtime.model.Paginator) : java.util.List<io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage>"
+		},
+		{
+			"signature": "by(keys : java.lang.String...) : java.util.List<java.lang.Object>"
+		},
+		{
+			"signature": "group(keys : java.lang.String...) : java.util.Map<java.lang.Object,java.util.List<io.quarkiverse.roq.frontmatter.runtime.model.Page>>"
+		}
+	],
+	"binary": true,
+	"templateDataAnnotations": [
+		{}
+	],
+	"typeKind": 2,
+	"invalidMethods": {}
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/roq/RoqCollections.json
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/roq/RoqCollections.json
@@ -1,0 +1,46 @@
+{
+	"signature": "io.quarkiverse.roq.frontmatter.runtime.model.RoqCollections",
+	"extendedTypes": [
+		"java.lang.Record"
+	],
+	"fields": [
+		{
+			"signature": "collections : java.util.Map<java.lang.String,io.quarkiverse.roq.frontmatter.runtime.model.RoqCollection>"
+		}
+	],
+	"methods": [
+		{
+			"signature": "get(name : java.lang.String) : io.quarkiverse.roq.frontmatter.runtime.model.RoqCollection"
+		},
+		{
+			"signature": "resolveNextPage(page : io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage) : io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage"
+		},
+		{
+			"signature": "resolvePreviousPage(page : io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage) : io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage"
+		},
+		{
+			"signature": "resolveCollection(page : io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage) : io.quarkiverse.roq.frontmatter.runtime.model.RoqCollection"
+		},
+		{
+			"signature": "resolvePrevPage(page : io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage) : io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage"
+		},
+		{
+			"signature": "toString() : java.lang.String"
+		},
+		{
+			"signature": "hashCode() : int"
+		},
+		{
+			"signature": "equals(o : java.lang.Object) : boolean"
+		},
+		{
+			"signature": "collections() : java.util.Map<java.lang.String,io.quarkiverse.roq.frontmatter.runtime.model.RoqCollection>"
+		}
+	],
+	"binary": true,
+	"templateDataAnnotations": [
+		{}
+	],
+	"typeKind": 0,
+	"invalidMethods": {}
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/roq/RoqDataModel.json
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/roq/RoqDataModel.json
@@ -1,0 +1,461 @@
+{
+	"templates": [],
+	"namespaceResolverInfos": {
+		"inject": {
+			"namespaces": [
+				"inject",
+				"cdi"
+			],
+			"description": "A CDI bean annotated with `@Named` can be referenced in any template through `cdi` and/or `inject` namespaces.",
+			"url": "https://quarkus.io/guides/qute-reference#injecting-beans-directly-in-templates"
+		}
+	},
+	"valueResolvers": [
+		{
+			"namespace": "fm",
+			"signature": "pageNumber(arg0 : int, arg1 : int) : java.lang.String",
+			"sourceType": "io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterMessages",
+			"kind": 7,
+			"data": {
+				"locale": "en",
+				"message": "Page {index} of {total}"
+			}
+		},
+		{
+			"signature": "numberOfWords(text : java.lang.String) : long",
+			"sourceType": "io.quarkiverse.roq.frontmatter.runtime.RoqTemplateExtension",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"matchName": "*",
+			"signature": "collection(collections : io.quarkiverse.roq.frontmatter.runtime.model.RoqCollections, key : java.lang.String) : io.quarkiverse.roq.frontmatter.runtime.model.RoqCollection",
+			"sourceType": "io.quarkiverse.roq.frontmatter.runtime.RoqTemplateExtension",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "readTime(page : io.quarkiverse.roq.frontmatter.runtime.model.Page) : java.lang.Object",
+			"sourceType": "io.quarkiverse.roq.frontmatter.runtime.RoqTemplateExtension",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "slugify(text : java.lang.String) : java.lang.String",
+			"sourceType": "io.quarkiverse.roq.frontmatter.runtime.RoqTemplateExtension",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "asStrings(o : java.lang.Object) : java.util.List<java.lang.String>",
+			"sourceType": "io.quarkiverse.roq.frontmatter.runtime.RoqTemplateExtension",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"matchName": "*",
+			"signature": "collection(collections : io.quarkiverse.roq.frontmatter.runtime.model.RoqCollections, key : java.lang.String) : io.quarkiverse.roq.frontmatter.runtime.model.RoqCollection",
+			"sourceType": "io.quarkiverse.roq.frontmatter.runtime.RoqTemplateExtension",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"signature": "now : java.time.LocalDateTime",
+			"sourceType": "io.quarkiverse.roq.frontmatter.runtime.RoqTemplateGlobal",
+			"kind": 5,
+			"globalVariable": true
+		},
+		{
+			"signature": "roqVersion : java.lang.String",
+			"sourceType": "io.quarkiverse.roq.frontmatter.runtime.RoqTemplateGlobal",
+			"kind": 5,
+			"globalVariable": true
+		},
+		{
+			"signature": "locale : java.lang.String",
+			"sourceType": "io.quarkiverse.roq.frontmatter.runtime.RoqTemplateGlobal",
+			"kind": 5,
+			"globalVariable": true
+		},
+		{
+			"namespace": "io_quarkiverse_roq_frontmatter_runtime_model_Page",
+			"signature": "getImgFromData(data : io.vertx.core.json.JsonObject) : java.lang.String",
+			"sourceType": "io.quarkiverse.roq.frontmatter.runtime.model.Page",
+			"kind": 1
+		},
+		{
+			"namespace": "io_quarkiverse_roq_frontmatter_runtime_model_Page",
+			"signature": "resolveImgUrl(rootUrl : io.quarkiverse.roq.frontmatter.runtime.model.RootUrl, data : io.vertx.core.json.JsonObject) : io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl",
+			"sourceType": "io.quarkiverse.roq.frontmatter.runtime.model.Page",
+			"kind": 1
+		},
+		{
+			"namespace": "io_quarkiverse_roq_frontmatter_runtime_model_PageInfo",
+			"signature": "HTML_OUTPUT_EXTENSIONS : java.util.Set<java.lang.String>",
+			"sourceType": "io.quarkiverse.roq.frontmatter.runtime.model.PageInfo",
+			"kind": 1
+		},
+		{
+			"namespace": "io_quarkiverse_roq_frontmatter_runtime_model_PageInfo",
+			"signature": "create(id : java.lang.String, draft : boolean, imagesRootPath : java.lang.String, dateString : java.lang.String, rawContent : java.lang.String, sourcePath : java.lang.String, quteTemplatePath : java.lang.String) : io.quarkiverse.roq.frontmatter.runtime.model.PageInfo",
+			"sourceType": "io.quarkiverse.roq.frontmatter.runtime.model.PageInfo",
+			"kind": 1
+		},
+		{
+			"namespace": "io_quarkiverse_roq_frontmatter_runtime_model_RoqUrl",
+			"signature": "isFullPath(path : java.lang.String) : boolean",
+			"sourceType": "io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl",
+			"kind": 1
+		},
+		{
+			"namespace": "io_quarkiverse_roq_frontmatter_runtime_model_RoqUrl",
+			"signature": "fromRoot(root : io.quarkiverse.roq.frontmatter.runtime.model.RootUrl, path : java.lang.String) : io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl",
+			"sourceType": "io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl",
+			"kind": 1
+		},
+		{
+			"signature": "get(list : java.util.List<T>, index : int) : T",
+			"sourceType": "io.quarkus.qute.runtime.extensions.CollectionTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "getByIndex(list : java.util.List<T>, index : java.lang.String) : T",
+			"sourceType": "io.quarkus.qute.runtime.extensions.CollectionTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "reversed(list : java.util.List<T>) : java.util.Iterator<T>",
+			"sourceType": "io.quarkus.qute.runtime.extensions.CollectionTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "take(list : java.util.List<T>, n : int) : java.util.List<T>",
+			"sourceType": "io.quarkus.qute.runtime.extensions.CollectionTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "takeLast(list : java.util.List<T>, n : int) : java.util.List<T>",
+			"sourceType": "io.quarkus.qute.runtime.extensions.CollectionTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "orEmpty(iterable : java.util.Collection<T>) : java.util.Collection<T>",
+			"sourceType": "io.quarkus.qute.runtime.extensions.CollectionTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "first(list : java.util.List<T>) : T",
+			"sourceType": "io.quarkus.qute.runtime.extensions.CollectionTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "last(list : java.util.List<T>) : T",
+			"sourceType": "io.quarkus.qute.runtime.extensions.CollectionTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "getByIndex(list : java.util.List<T>, index : java.lang.String) : T",
+			"sourceType": "io.quarkus.qute.runtime.extensions.CollectionTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"namespace": "config",
+			"matchName": "*",
+			"signature": "getConfigProperty(propertyName : java.lang.String) : java.lang.Object",
+			"sourceType": "io.quarkus.qute.runtime.extensions.ConfigTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"namespace": "config",
+			"signature": "property(propertyName : java.lang.String) : java.lang.Object",
+			"sourceType": "io.quarkus.qute.runtime.extensions.ConfigTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"namespace": "config",
+			"matchName": "boolean",
+			"signature": "booleanProperty(propertyName : java.lang.String) : java.lang.Object",
+			"sourceType": "io.quarkus.qute.runtime.extensions.ConfigTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"namespace": "config",
+			"matchName": "integer",
+			"signature": "integerProperty(propertyName : java.lang.String) : java.lang.Object",
+			"sourceType": "io.quarkus.qute.runtime.extensions.ConfigTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"matchName": "*",
+			"signature": "map(arg0 : java.util.Map, arg1 : java.lang.String) : java.lang.Object",
+			"sourceType": "io.quarkus.qute.runtime.extensions.MapTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "get(map : java.util.Map<?,V>, key : java.lang.Object) : V",
+			"sourceType": "io.quarkus.qute.runtime.extensions.MapTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "containsKey(map : java.util.Map<?,?>, key : java.lang.Object) : boolean",
+			"sourceType": "io.quarkus.qute.runtime.extensions.MapTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"matchName": "*",
+			"signature": "map(arg0 : java.util.Map, arg1 : java.lang.String) : java.lang.Object",
+			"sourceType": "io.quarkus.qute.runtime.extensions.MapTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"signature": "mod(number : java.lang.Integer, mod : java.lang.Integer) : java.lang.Integer",
+			"sourceType": "io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "addToInt(number : java.lang.Integer, name : java.lang.String, other : java.lang.Integer) : java.lang.Integer",
+			"sourceType": "io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "addToInt(number : java.lang.Integer, name : java.lang.String, other : java.lang.Long) : java.lang.Long",
+			"sourceType": "io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "addToLong(number : java.lang.Long, name : java.lang.String, other : java.lang.Integer) : java.lang.Long",
+			"sourceType": "io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "addToLong(number : java.lang.Long, name : java.lang.String, other : java.lang.Long) : java.lang.Long",
+			"sourceType": "io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "subtractFromInt(number : java.lang.Integer, name : java.lang.String, other : java.lang.Integer) : java.lang.Integer",
+			"sourceType": "io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "subtractFromInt(number : java.lang.Integer, name : java.lang.String, other : java.lang.Long) : java.lang.Long",
+			"sourceType": "io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "subtractFromLong(number : java.lang.Long, name : java.lang.String, other : java.lang.Integer) : java.lang.Long",
+			"sourceType": "io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "subtractFromLong(number : java.lang.Long, name : java.lang.String, other : java.lang.Long) : java.lang.Long",
+			"sourceType": "io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "addToInt(number : java.lang.Integer, name : java.lang.String, other : java.lang.Integer) : java.lang.Integer",
+			"sourceType": "io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"signature": "addToInt(number : java.lang.Integer, name : java.lang.String, other : java.lang.Long) : java.lang.Long",
+			"sourceType": "io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"signature": "addToLong(number : java.lang.Long, name : java.lang.String, other : java.lang.Integer) : java.lang.Long",
+			"sourceType": "io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"signature": "addToLong(number : java.lang.Long, name : java.lang.String, other : java.lang.Long) : java.lang.Long",
+			"sourceType": "io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"signature": "subtractFromInt(number : java.lang.Integer, name : java.lang.String, other : java.lang.Integer) : java.lang.Integer",
+			"sourceType": "io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"signature": "subtractFromInt(number : java.lang.Integer, name : java.lang.String, other : java.lang.Long) : java.lang.Long",
+			"sourceType": "io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"signature": "subtractFromLong(number : java.lang.Long, name : java.lang.String, other : java.lang.Integer) : java.lang.Long",
+			"sourceType": "io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"signature": "subtractFromLong(number : java.lang.Long, name : java.lang.String, other : java.lang.Long) : java.lang.Long",
+			"sourceType": "io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"signature": "or(value : T, other : T) : T",
+			"sourceType": "io.quarkus.qute.runtime.extensions.OrOperatorTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "fmtInstance(format : java.lang.String, ignoredPropertyName : java.lang.String, args : java.lang.Object...) : java.lang.String",
+			"sourceType": "io.quarkus.qute.runtime.extensions.StringTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"signature": "fmtInstance(format : java.lang.String, ignoredPropertyName : java.lang.String, locale : java.util.Locale, args : java.lang.Object...) : java.lang.String",
+			"sourceType": "io.quarkus.qute.runtime.extensions.StringTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"namespace": "str",
+			"signature": "fmt(ignoredPropertyName : java.lang.String, format : java.lang.String, args : java.lang.Object...) : java.lang.String",
+			"sourceType": "io.quarkus.qute.runtime.extensions.StringTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"namespace": "str",
+			"signature": "fmt(ignoredPropertyName : java.lang.String, locale : java.util.Locale, format : java.lang.String, args : java.lang.Object...) : java.lang.String",
+			"sourceType": "io.quarkus.qute.runtime.extensions.StringTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"matchName": "+",
+			"signature": "plus(str : java.lang.String, val : java.lang.Object) : java.lang.String",
+			"sourceType": "io.quarkus.qute.runtime.extensions.StringTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"signature": "format(temporal : java.time.temporal.TemporalAccessor, pattern : java.lang.String) : java.lang.String",
+			"sourceType": "io.quarkus.qute.runtime.extensions.TimeTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "format(temporal : java.time.temporal.TemporalAccessor, pattern : java.lang.String, locale : java.util.Locale) : java.lang.String",
+			"sourceType": "io.quarkus.qute.runtime.extensions.TimeTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "format(temporal : java.time.temporal.TemporalAccessor, pattern : java.lang.String, locale : java.util.Locale, timeZone : java.time.ZoneId) : java.lang.String",
+			"sourceType": "io.quarkus.qute.runtime.extensions.TimeTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"namespace": "time",
+			"signature": "format(dateTimeObject : java.lang.Object, pattern : java.lang.String) : java.lang.String",
+			"sourceType": "io.quarkus.qute.runtime.extensions.TimeTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"namespace": "time",
+			"signature": "format(dateTimeObject : java.lang.Object, pattern : java.lang.String, locale : java.util.Locale) : java.lang.String",
+			"sourceType": "io.quarkus.qute.runtime.extensions.TimeTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"namespace": "time",
+			"signature": "format(dateTimeObject : java.lang.Object, pattern : java.lang.String, locale : java.util.Locale, timeZone : java.time.ZoneId) : java.lang.String",
+			"sourceType": "io.quarkus.qute.runtime.extensions.TimeTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "getFormattableObject(value : java.lang.Object, timeZone : java.time.ZoneId) : java.time.temporal.TemporalAccessor",
+			"sourceType": "io.quarkus.qute.runtime.extensions.TimeTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"signature": "formatterForKey(key : io.quarkus.qute.runtime.extensions.TimeTemplateExtensions$Key) : java.time.format.DateTimeFormatter",
+			"sourceType": "io.quarkus.qute.runtime.extensions.TimeTemplateExtensions",
+			"binary": true,
+			"kind": 4
+		},
+		{
+			"namespace": "time",
+			"signature": "format(dateTimeObject : java.lang.Object, pattern : java.lang.String) : java.lang.String",
+			"sourceType": "io.quarkus.qute.runtime.extensions.TimeTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"namespace": "time",
+			"signature": "format(dateTimeObject : java.lang.Object, pattern : java.lang.String, locale : java.util.Locale) : java.lang.String",
+			"sourceType": "io.quarkus.qute.runtime.extensions.TimeTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"namespace": "time",
+			"signature": "format(dateTimeObject : java.lang.Object, pattern : java.lang.String, locale : java.util.Locale, timeZone : java.time.ZoneId) : java.lang.String",
+			"sourceType": "io.quarkus.qute.runtime.extensions.TimeTemplateExtensions",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"signature": "convertToMarkdown(text : java.lang.String, ignoredName : java.lang.String) : java.lang.String",
+			"sourceType": "io.quarkiverse.qute.web.markdown.runtime.MarkdownSectionHelperFactory",
+			"binary": true,
+			"kind": 3
+		},
+		{
+			"named": "bundle",
+			"namespace": "inject",
+			"signature": "io.quarkiverse.web.bundler.runtime.Bundle",
+			"sourceType": "io.quarkiverse.web.bundler.runtime.Bundle",
+			"kind": 6
+		},
+		{
+			"named": "vertxRequest",
+			"namespace": "inject",
+			"signature": "getCurrentRequest(rc : io.vertx.ext.web.RoutingContext) : io.vertx.core.http.HttpServerRequest",
+			"sourceType": "io.quarkus.vertx.http.runtime.CurrentRequestProducer",
+			"kind": 6
+		}
+	]
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/roq/RoqProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/roq/RoqProject.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.project.roq;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.GsonBuilder;
+import com.redhat.qute.commons.ProjectInfo;
+import com.redhat.qute.commons.ResolvedJavaTypeInfo;
+import com.redhat.qute.commons.datamodel.DataModelParameter;
+import com.redhat.qute.commons.datamodel.DataModelProject;
+import com.redhat.qute.commons.datamodel.DataModelTemplate;
+import com.redhat.qute.commons.datamodel.resolvers.NamespaceResolverInfo;
+import com.redhat.qute.commons.datamodel.resolvers.ValueResolverInfo;
+import com.redhat.qute.project.BaseQuteProject;
+import com.redhat.qute.project.QuteProjectRegistry;
+
+/**
+ * Roq project.
+ */
+public class RoqProject extends BaseQuteProject {
+
+	public static final String PROJECT_URI = "roq";
+	private DataModelProject<DataModelTemplate<?>> dataModel;
+
+	public RoqProject(ProjectInfo projectInfo, QuteProjectRegistry projectRegistry) {
+		super(projectInfo, projectRegistry);
+	}
+
+	private DataModelProject<DataModelTemplate<?>> loadDataModel(String fileName) {
+		InputStream in = this.getClass().getResourceAsStream(fileName);
+		return new GsonBuilder().create().fromJson(new InputStreamReader(in),
+				DataModelProject.class);
+	}
+
+	@Override
+	protected void fillResolvedJavaTypes(List<ResolvedJavaTypeInfo> resolvedJavaTypes) {
+		super.fillResolvedJavaTypes(resolvedJavaTypes);
+		loadResolvedJavaType("Site.json", resolvedJavaTypes);
+		loadResolvedJavaType("RoqCollection.json", resolvedJavaTypes);
+		loadResolvedJavaType("RoqCollections.json", resolvedJavaTypes);
+		loadResolvedJavaType("Paginator.json", resolvedJavaTypes);
+		loadResolvedJavaType("DocumentPage.json", resolvedJavaTypes);
+	}
+
+	private void loadResolvedJavaType(String fileName, List<ResolvedJavaTypeInfo> resolvedJavaTypes) {
+		InputStream in = this.getClass().getResourceAsStream(fileName);
+		ResolvedJavaTypeInfo resolvedJavaType = new GsonBuilder().create().fromJson(new InputStreamReader(in),
+				ResolvedJavaTypeInfo.class);
+		resolvedJavaTypes.add(resolvedJavaType);
+	}
+
+	@Override
+	protected void fillTemplates(List<DataModelTemplate<DataModelParameter>> templates) {
+
+	}
+
+	@Override
+	protected void fillValueResolvers(List<ValueResolverInfo> valueResolvers) {
+		valueResolvers.addAll(getDataModel().getValueResolvers());
+	}
+
+	private DataModelProject<DataModelTemplate<?>> getDataModel() {
+		if (dataModel == null) {
+			dataModel = loadDataModel("RoqDataModel.json");
+		}
+		return dataModel;
+	}
+
+	@Override
+	protected void fillNamespaceResolverInfos(Map<String, NamespaceResolverInfo> namespaces) {
+
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/roq/Site.json
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/roq/Site.json
@@ -1,0 +1,76 @@
+{
+	"signature": "io.quarkiverse.roq.frontmatter.runtime.model.Site",
+	"extendedTypes": [
+		"java.lang.Record"
+	],
+	"fields": [
+		{
+			"signature": "url : io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl"
+		},
+		{
+			"signature": "imagesUrl : io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl"
+		},
+		{
+			"signature": "data : io.vertx.core.json.JsonObject"
+		},
+		{
+			"signature": "pages : java.util.List<io.quarkiverse.roq.frontmatter.runtime.model.NormalPage>"
+		},
+		{
+			"signature": "collections : io.quarkiverse.roq.frontmatter.runtime.model.RoqCollections"
+		}
+	],
+	"methods": [
+		{
+			"signature": "title() : java.lang.String"
+		},
+		{
+			"signature": "description() : java.lang.String"
+		},
+		{
+			"signature": "img() : io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl"
+		},
+		{
+			"signature": "url(path : java.lang.Object) : io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl"
+		},
+		{
+			"signature": "url(path : java.lang.Object, others : java.lang.Object...) : io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl"
+		},
+		{
+			"signature": "page(id : java.lang.String) : io.quarkiverse.roq.frontmatter.runtime.model.NormalPage"
+		},
+		{
+			"signature": "document(id : java.lang.String) : io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage"
+		},
+		{
+			"signature": "toString() : java.lang.String"
+		},
+		{
+			"signature": "hashCode() : int"
+		},
+		{
+			"signature": "equals(o : java.lang.Object) : boolean"
+		},
+		{
+			"signature": "url() : io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl"
+		},
+		{
+			"signature": "imagesUrl() : io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl"
+		},
+		{
+			"signature": "data() : io.vertx.core.json.JsonObject"
+		},
+		{
+			"signature": "pages() : java.util.List<io.quarkiverse.roq.frontmatter.runtime.model.NormalPage>"
+		},
+		{
+			"signature": "collections() : io.quarkiverse.roq.frontmatter.runtime.model.RoqCollections"
+		}
+	],
+	"binary": true,
+	"templateDataAnnotations": [
+		{}
+	],
+	"typeKind": 0,
+	"invalidMethods": {}
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/roq/RoqCompletionsTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/roq/RoqCompletionsTest.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.completions.roq;
+
+import static com.redhat.qute.QuteAssert.c;
+import static com.redhat.qute.QuteAssert.r;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.QuteAssert;
+import com.redhat.qute.project.roq.RoqProject;
+
+/**
+ * Test completion with Roq Quarkus extension.
+ *
+ * @author Angelo ZERR
+ *
+ */
+public class RoqCompletionsTest {
+
+	@Test
+	public void site() throws Exception {
+		String template = "{@io.quarkiverse.roq.frontmatter.runtime.model.Site site}\r\n" + //
+				"{site.|}";
+		testCompletionFor(template, //
+				c("or(base : T, arg : Object) : T", "or(arg)", r(1, 6, 1, 6)), //
+				c("img() : RoqUrl", "img", r(1, 6, 1, 6)), //
+				c("toString() : String", "toString", r(1, 6, 1, 6)), //
+				c("hashCode() : int", "hashCode", r(1, 6, 1, 6)), //
+				c("imagesUrl : RoqUrl", "imagesUrl", r(1, 6, 1, 6)), //
+				c("url() : RoqUrl", "url", r(1, 6, 1, 6)), //
+				c("collections : RoqCollections", "collections", r(1, 6, 1, 6)), //
+				c("collections() : RoqCollections", "collections", r(1, 6, 1, 6)), //
+				c("document(id : String) : DocumentPage", "document(id)", r(1, 6, 1, 6)), //
+				c("pages : List<NormalPage>", "pages", r(1, 6, 1, 6)), //
+				c("pages() : List<NormalPage>", "pages", r(1, 6, 1, 6)), //
+				c("data() : JsonObject", "data", r(1, 6, 1, 6)), //
+				c("orEmpty(base : T) : List<T>", "orEmpty", r(1, 6, 1, 6)), //
+				c("page(id : String) : NormalPage", "page(id)", r(1, 6, 1, 6)), //
+				c("safe(base : Object) : RawString", "safe", r(1, 6, 1, 6)), //
+				c("title() : String", "title", r(1, 6, 1, 6)), //
+				c("url(path : Object, others : Object...) : RoqUrl", "url(path, others)", r(1, 6, 1, 6)), //
+				c("title() : String", "title", r(1, 6, 1, 6)));
+	}
+
+	@Test
+	public void site_collections() throws Exception {
+		String template = "{@io.quarkiverse.roq.frontmatter.runtime.model.Site site}\r\n" + //
+				"{site.collections.|}";
+		testCompletionFor(template, //
+				c("or(base : T, arg : Object) : T", "or(arg)", r(1, 18, 1, 18)), //
+				c("collections : Map<String,RoqCollection>", "collections", r(1, 18, 1, 18)), //
+				c("resolveCollection(page : DocumentPage) : RoqCollection", "resolveCollection(page)", r(1, 18, 1, 18)), //
+				c("hashCode() : int", "hashCode", r(1, 18, 1, 18)), //
+				c("get(name : String) : RoqCollection", "get(name)", r(1, 18, 1, 18)));
+	}
+
+	@Test
+	public void site_collections_get() throws Exception {
+		String template = "{@io.quarkiverse.roq.frontmatter.runtime.model.Site site}\r\n" + //
+				"{site.collections.get('posts').|}";
+		testCompletionFor(template, //
+				c("or(base : T, arg : Object) : T", "or(arg)", r(1, 31, 1, 31)), //
+				c("group(keys : String...) : Map<Object,List<Page>>", "group(keys)", r(1, 31, 1, 31)), //
+				c("resolvePreviousPage(page : DocumentPage) : DocumentPage", "resolvePreviousPage(page)",
+						r(1, 31, 1, 31)), //
+				c("paginated(paginator : Paginator) : List<DocumentPage>", "paginated(paginator)", r(1, 31, 1, 31)));
+	}
+
+	@Test
+	public void site_collections_get_useTemlateExtension() throws Exception {
+		String template = "{@io.quarkiverse.roq.frontmatter.runtime.model.Site site}\r\n" + //
+				"{site.collections.posts.|}";
+		testCompletionFor(template, //
+				c("or(base : T, arg : Object) : T", "or(arg)", r(1, 24, 1, 24)), //
+				c("group(keys : String...) : Map<Object,List<Page>>", "group(keys)", r(1, 24, 1, 24)), //
+				c("resolvePreviousPage(page : DocumentPage) : DocumentPage", "resolvePreviousPage(page)",
+						r(1, 24, 1, 24)), //
+				c("paginated(paginator : Paginator) : List<DocumentPage>", "paginated(paginator)", r(1, 24, 1, 24)));
+	}
+
+	@Test
+	public void paginated() throws Exception {
+		String template = "{@io.quarkiverse.roq.frontmatter.runtime.model.Site site}\r\n" + //
+				"{#for post in site.collections.posts.paginated(page.paginator)}\r\n" + //
+				"{#if post.|}";
+		testCompletionFor(template, //
+				c("info : PageInfo", "info", r(2, 10, 2, 10)), //
+				c("hidden : boolean", "hidden", r(2, 10, 2, 10)), //
+				c("url : RoqUrl", "url", r(2, 10, 2, 10)), //
+				c("data : JsonObject", "data", r(2, 10, 2, 10)));
+	}
+
+	public static void testCompletionFor(String value,
+			CompletionItem... expectedItems) throws Exception {
+		QuteAssert.testCompletionFor(value, false, QuteAssert.FILE_URI, null, RoqProject.PROJECT_URI,
+				QuteAssert.TEMPLATE_BASE_DIR,
+				null,
+				expectedItems);
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/roq/RoqDiagnosticsTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/roq/RoqDiagnosticsTest.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.diagnostics.roq;
+
+import org.eclipse.lsp4j.Diagnostic;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.QuteAssert;
+import com.redhat.qute.project.roq.RoqProject;
+
+/**
+ * Test diagnostics with Roq Quarkus extension.
+ *
+ * @author Angelo ZERR
+ *
+ */
+public class RoqDiagnosticsTest {
+
+	@Test
+	public void noError() throws Exception {
+		String template = "{@io.quarkiverse.roq.frontmatter.runtime.model.Site site}\r\n" + //
+				"{#for post in site.collections.posts.paginated(null)}\r\n" + //
+				"{#if post.hidden}\r\n" + //
+				"{/if}" + //
+				"{/for}";
+		testDiagnosticsFor(template);
+	}
+
+	private static void testDiagnosticsFor(String value, Diagnostic... expected) {
+		QuteAssert.testDiagnosticsFor(value, QuteAssert.FILE_URI, null, RoqProject.PROJECT_URI,
+				QuteAssert.TEMPLATE_BASE_DIR, true, null, expected);
+	}
+
+}


### PR DESCRIPTION
TemplateExtension match any support

The problem has been found by playing with roq.

If you see this code https://github.com/quarkiverse/quarkus-roq/blob/caa56a5bf839545eb58fd721b8f85d3ae3ee07fc/theme/default/src/main/resources/templates/layouts/roq-default/index.html#L14

`{#for post in site.collections.get('posts').paginated(page.paginator)}`

you can write without get

`{#for post in site.collections.posts.paginated(page.paginator)}`

It works because Roq uses matchName any https://github.com/quarkiverse/quarkus-roq/blob/caa56a5bf839545eb58fd721b8f85d3ae3ee07fc/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqTemplateExtension.java#L21

 ```
@TemplateExtension(matchName = "*", priority = QUTE_FALLBACK_PRIORITY)
    public static RoqCollection collection(RoqCollections collections, String key) {
        return collections.get(key);
    }
```

This PR manages this usecase and provide tests for Roq.