### PR TITLE
Data model template matcher support

### DIFF
--- a/qute.jdt/com.redhat.qute.jdt/plugin.xml
+++ b/qute.jdt/com.redhat.qute.jdt/plugin.xml
@@ -82,6 +82,7 @@
    <!-- =========== Roq extension =========== -->
    
    <extension point="com.redhat.qute.jdt.dataModelProviders">
+      <provider class="com.redhat.qute.jdt.internal.extensions.roq.RoqDataModelProvider" />
       <provider class="com.redhat.qute.jdt.internal.extensions.roq.DataMappingSupport" />
    </extension>
    

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/datamodel/DataModelProject.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/datamodel/DataModelProject.java
@@ -124,7 +124,12 @@ public class DataModelProject<T extends DataModelTemplate<?>> {
 
 	private T findDataModelTemplate(String templateUri, List<T> templates) {
 		Optional<T> dataModelForTemplate = templates.stream() //
-				.filter(t -> templateUri.endsWith(t.getTemplateUri())) //
+				.filter(t -> {
+					/*if (t instanceof ExtendedDataModelTemplate) {
+						return ((ExtendedDataModelTemplate) t).matches(templateUri);
+					}*/
+					return templateUri.endsWith(t.getTemplateUri());
+				}) //
 				.findFirst();
 		if (dataModelForTemplate.isPresent()) {
 			return dataModelForTemplate.get();

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/datamodel/DataModelTemplate.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/datamodel/DataModelTemplate.java
@@ -28,6 +28,8 @@ public class DataModelTemplate<T extends DataModelParameter> extends DataModelBa
 
 	private String templateUri;
 
+	private DataModelTemplateMatcher templateMatcher;
+
 	private String sourceField;
 
 	private List<DataModelFragment<T>> fragments;
@@ -48,6 +50,14 @@ public class DataModelTemplate<T extends DataModelParameter> extends DataModelBa
 	 */
 	public void setTemplateUri(String templateUri) {
 		this.templateUri = templateUri;
+	}
+
+	public DataModelTemplateMatcher getTemplateMatcher() {
+		return templateMatcher;
+	}
+
+	public void setTemplateMatcher(DataModelTemplateMatcher templateMatcher) {
+		this.templateMatcher = templateMatcher;
 	}
 
 	/**
@@ -131,6 +141,7 @@ public class DataModelTemplate<T extends DataModelParameter> extends DataModelBa
 	public String toString() {
 		ToStringBuilder b = new ToStringBuilder(this);
 		b.add("templateUri", this.templateUri);
+		b.add("templateMatcher", this.templateMatcher);
 		b.add("sourceType", this.getSourceType());
 		b.add("sourceMethod", this.getSourceMethod());
 		b.add("sourceField", this.sourceField);

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/datamodel/DataModelTemplateMatcher.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/datamodel/DataModelTemplateMatcher.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.commons.datamodel;
+
+import java.util.List;
+
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Data model template matcher used to inject data parameters with patterns.
+ */
+public class DataModelTemplateMatcher {
+
+	private List<String> includes;
+
+	public DataModelTemplateMatcher() {
+
+	}
+
+	public DataModelTemplateMatcher(List<String> includes) {
+		setIncludes(includes);
+	}
+
+	public List<String> getIncludes() {
+		return includes;
+	}
+
+	public void setIncludes(List<String> includes) {
+		this.includes = includes;
+	}
+
+	@Override
+	public String toString() {
+		ToStringBuilder b = new ToStringBuilder(this);
+		b.add("includes", this.includes);
+		return b.toString();
+	}
+}

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/roq/RoqDataModelProvider.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/roq/RoqDataModelProvider.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.jdt.internal.extensions.roq;
+
+import java.util.Arrays;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.search.SearchMatch;
+import org.eclipse.jdt.core.search.SearchPattern;
+
+import com.redhat.qute.commons.datamodel.DataModelParameter;
+import com.redhat.qute.commons.datamodel.DataModelTemplate;
+import com.redhat.qute.commons.datamodel.DataModelTemplateMatcher;
+import com.redhat.qute.jdt.template.datamodel.AbstractDataModelProvider;
+import com.redhat.qute.jdt.template.datamodel.SearchContext;
+import com.redhat.qute.jdt.utils.JDTTypeUtils;
+
+/**
+ * Inject 'site' and 'page' as data model parameters for all Qute templates
+ * which belong to a Roq application.
+ */
+public class RoqDataModelProvider extends AbstractDataModelProvider {
+
+	@Override
+	public void beginSearch(SearchContext context, IProgressMonitor monitor) {
+		if (JDTTypeUtils.findType(context.getJavaProject(), RoqJavaConstants.SITE_CLASS) == null) {
+			// It is not a Roq application, don't inject site and page.
+			return;
+		}
+
+		DataModelTemplate<DataModelParameter> roqTemplate = new DataModelTemplate<DataModelParameter>();
+		roqTemplate.setTemplateMatcher(new DataModelTemplateMatcher(Arrays.asList("**/**")));
+
+		// site
+		DataModelParameter site = new DataModelParameter();
+		site.setKey("site");
+		site.setSourceType("io.quarkiverse.roq.frontmatter.runtime.model.Site");
+		roqTemplate.addParameter(site);
+
+		// page
+		DataModelParameter page = new DataModelParameter();
+		page.setKey("page");
+		page.setSourceType("io.quarkiverse.roq.frontmatter.runtime.model.Page");
+		roqTemplate.addParameter(page);
+
+		context.getDataModelProject().getTemplates().add(roqTemplate);
+	}
+
+	@Override
+	public void collectDataModel(SearchMatch match, SearchContext context, IProgressMonitor monitor) {
+		// Do nothing
+	}
+
+	@Override
+	protected String[] getPatterns() {
+		return null;
+	}
+
+	@Override
+	protected SearchPattern createSearchPattern(String pattern) {
+		return null;
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/datamodel/DataModelProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/datamodel/DataModelProject.java
@@ -19,6 +19,7 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 import com.redhat.qute.commons.datamodel.resolvers.NamespaceResolverInfo;
 import com.redhat.qute.commons.datamodel.resolvers.ValueResolverInfo;
+import com.redhat.qute.project.datamodel.ExtendedDataModelTemplate;
 
 /**
  * Data model project hosts for a given Qute project:
@@ -124,7 +125,12 @@ public class DataModelProject<T extends DataModelTemplate<?>> {
 
 	private T findDataModelTemplate(String templateUri, List<T> templates) {
 		Optional<T> dataModelForTemplate = templates.stream() //
-				.filter(t -> templateUri.endsWith(t.getTemplateUri())) //
+				.filter(t -> {
+					if (t instanceof ExtendedDataModelTemplate) {
+						return ((ExtendedDataModelTemplate) t).matches(templateUri);
+					}
+					return templateUri.endsWith(t.getTemplateUri());
+				}) //
 				.findFirst();
 		if (dataModelForTemplate.isPresent()) {
 			return dataModelForTemplate.get();

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/datamodel/DataModelTemplate.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/datamodel/DataModelTemplate.java
@@ -28,6 +28,8 @@ public class DataModelTemplate<T extends DataModelParameter> extends DataModelBa
 
 	private String templateUri;
 
+	private DataModelTemplateMatcher templateMatcher;
+
 	private String sourceField;
 
 	private List<DataModelFragment<T>> fragments;
@@ -48,6 +50,14 @@ public class DataModelTemplate<T extends DataModelParameter> extends DataModelBa
 	 */
 	public void setTemplateUri(String templateUri) {
 		this.templateUri = templateUri;
+	}
+
+	public DataModelTemplateMatcher getTemplateMatcher() {
+		return templateMatcher;
+	}
+
+	public void setTemplateMatcher(DataModelTemplateMatcher templateMatcher) {
+		this.templateMatcher = templateMatcher;
 	}
 
 	/**
@@ -131,6 +141,7 @@ public class DataModelTemplate<T extends DataModelParameter> extends DataModelBa
 	public String toString() {
 		ToStringBuilder b = new ToStringBuilder(this);
 		b.add("templateUri", this.templateUri);
+		b.add("templateMatcher", this.templateMatcher);
 		b.add("sourceType", this.getSourceType());
 		b.add("sourceMethod", this.getSourceMethod());
 		b.add("sourceField", this.sourceField);

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/datamodel/DataModelTemplateMatcher.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/datamodel/DataModelTemplateMatcher.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.commons.datamodel;
+
+import java.util.List;
+
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Data model template matcher used to inject data parameters with patterns.
+ */
+public class DataModelTemplateMatcher {
+
+	private List<String> includes;
+
+	public DataModelTemplateMatcher() {
+
+	}
+
+	public DataModelTemplateMatcher(List<String> includes) {
+		setIncludes(includes);
+	}
+
+	public List<String> getIncludes() {
+		return includes;
+	}
+
+	public void setIncludes(List<String> includes) {
+		this.includes = includes;
+	}
+
+	@Override
+	public String toString() {
+		ToStringBuilder b = new ToStringBuilder(this);
+		b.add("includes", this.includes);
+		return b.toString();
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/ExtendedDataModelTemplate.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/ExtendedDataModelTemplate.java
@@ -23,8 +23,11 @@ import com.redhat.qute.commons.datamodel.DataModelTemplate;
 public class ExtendedDataModelTemplate extends DataModelTemplate<ExtendedDataModelParameter>
 		implements DataModelSourceProvider {
 
+	private ExtendedDataModelTemplateMatcher templateMatcher;
+
 	public ExtendedDataModelTemplate(DataModelTemplate<DataModelParameter> template) {
 		super.setTemplateUri(template.getTemplateUri());
+		super.setTemplateMatcher(template.getTemplateMatcher());
 		super.setSourceType(template.getSourceType());
 		super.setSourceMethod(template.getSourceMethod());
 		super.setSourceField(template.getSourceField());
@@ -63,5 +66,18 @@ public class ExtendedDataModelTemplate extends DataModelTemplate<ExtendedDataMod
 		params.setSourceField(sourceField);
 		params.setSourceMethod(sourceMethod);
 		return params;
+	}
+
+	public boolean matches(String templateUri) {
+		if (getTemplateUri() != null && templateUri.endsWith(getTemplateUri())) {
+			return true;
+		}
+		if (super.getTemplateMatcher() == null) {
+			return false;
+		}
+		if (templateMatcher == null) {
+			templateMatcher = new ExtendedDataModelTemplateMatcher(super.getTemplateMatcher().getIncludes());
+		}
+		return templateMatcher.matches(templateUri);
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/ExtendedDataModelTemplateMatcher.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/ExtendedDataModelTemplateMatcher.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.project.datamodel;
+
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.redhat.qute.commons.FileUtils;
+import com.redhat.qute.commons.datamodel.DataModelTemplateMatcher;
+import com.redhat.qute.settings.PathPatternMatcher;
+
+/**
+ * Data model template matcher extension.
+ */
+public class ExtendedDataModelTemplateMatcher extends DataModelTemplateMatcher {
+
+	private Boolean anyMatches;
+
+	private List<PathPatternMatcher> includes;
+
+	public ExtendedDataModelTemplateMatcher(List<String> includes) {
+		super(includes);
+	}
+
+	public boolean matches(String templateFileUri) {
+		if (super.getIncludes() == null) {
+			return false;
+		}
+		if (includes == null && anyMatches == null) {
+			// Compute anyMatches flag or path pattern matcher.
+			if (super.getIncludes().size() == 1
+					&& ("**".equals(super.getIncludes().get(0)) || "**/**".equals(super.getIncludes().get(0)))) {
+				// To avoid computing path pattern matcher, if pattern is '**' or '**/**'
+				// we consider that it is an any matches.
+				anyMatches = true;
+			} else {
+				includes = super.getIncludes() //
+						.stream() //
+						.map(p -> new PathPatternMatcher(p)) //
+						.collect(Collectors.toList());
+			}
+		}
+
+		if (anyMatches != null && anyMatches) {
+			// Pattern is '**' or '**/**'
+			return true;
+		}
+
+		// Checks if the template uri matches the includes which defines glob pattern
+		URI uri = FileUtils.createUri(templateFileUri);
+		for (PathPatternMatcher include : includes) {
+			if (include.matches(uri)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteCodeLens.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteCodeLens.java
@@ -91,7 +91,7 @@ class QuteCodeLens {
 
 	private static void collectDataModelCodeLenses(Range range, DataModelSourceProvider templateDataModel,
 			String projectUri, SharedSettings settings, List<CodeLens> lenses, CancelChecker cancelChecker) {
-		if (templateDataModel == null || templateDataModel.getSourceType() == null) {
+		if (templateDataModel == null) {
 			return;
 		}
 
@@ -99,21 +99,27 @@ class QuteCodeLens {
 
 		boolean canSupportJavaDefinition = settings.getCommandCapabilities()
 				.isCommandSupported(COMMAND_JAVA_DEFINITION);
+		boolean hasSourceType = templateDataModel.getSourceType() != null;
 
-		// Method/Field which is bound with the template
-		String title = createCheckedTemplateTitle(templateDataModel);
-		Command command = !canSupportJavaDefinition ? new Command(title, "")
-				: new Command(title, COMMAND_JAVA_DEFINITION,
-						Arrays.asList(templateDataModel.toJavaDefinitionParams(projectUri)));
-		CodeLens codeLens = new CodeLens(range, command, null);
-		lenses.add(codeLens);
+		if (hasSourceType) {
+			// Template with source type.
+
+			// Method/Field which is bound with the template
+			String title = createCheckedTemplateTitle(templateDataModel);
+			Command command = !canSupportJavaDefinition ? new Command(title, "")
+					: new Command(title, COMMAND_JAVA_DEFINITION,
+							Arrays.asList(templateDataModel.toJavaDefinitionParams(projectUri)));
+			CodeLens codeLens = new CodeLens(range, command, null);
+			lenses.add(codeLens);
+		}
 
 		// Parameters of the template
 		List<ExtendedDataModelParameter> parameters = templateDataModel.getParameters();
 		if (parameters != null) {
 			for (ExtendedDataModelParameter parameter : parameters) {
 				String parameterTitle = createParameterTitle(parameter);
-				Command parameterCommand = !canSupportJavaDefinition ? new Command(title, "")
+				Command parameterCommand = !(canSupportJavaDefinition && hasSourceType)
+						? new Command(parameterTitle, "")
 						: new Command(parameterTitle, COMMAND_JAVA_DEFINITION,
 								Arrays.asList(parameter.toJavaDefinitionParams(projectUri)));
 				CodeLens parameterCodeLens = new CodeLens(range, parameterCommand, null);

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteDefinition.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteDefinition.java
@@ -382,6 +382,9 @@ class QuteDefinition {
 					cancelChecker.checkCanceled();
 					// Try to find in parameter model
 					if (parameter != null) {
+						if (parameter.getSourceType() == null) {
+							return NO_DEFINITION;
+						}
 						QuteJavaDefinitionParams params = parameter.toJavaDefinitionParams(project.getUri());
 						return findJavaDefinition(params, project, cancelChecker,
 								() -> QutePositionUtility.createRange(part));

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
@@ -628,7 +628,7 @@ public class QuteAssert {
 		testCodeLensFor(value, fileUri, templateId, PROJECT_URI, TEMPLATE_BASE_DIR, expected);
 	}
 
-	private static void testCodeLensFor(String value, String fileUri, String templateId, String projectUri,
+	public static void testCodeLensFor(String value, String fileUri, String templateId, String projectUri,
 			String templateBaseDir, CodeLens... expected) throws Exception {
 		QuteProjectRegistry projectRegistry = new MockQuteProjectRegistry();
 		Template template = createTemplate(value, fileUri, projectUri, templateBaseDir, projectRegistry);

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/roq/RoqProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/roq/RoqProject.java
@@ -11,6 +11,7 @@
 *******************************************************************************/
 package com.redhat.qute.project.roq;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -19,6 +20,7 @@ import com.redhat.qute.commons.ResolvedJavaTypeInfo;
 import com.redhat.qute.commons.datamodel.DataModelParameter;
 import com.redhat.qute.commons.datamodel.DataModelProject;
 import com.redhat.qute.commons.datamodel.DataModelTemplate;
+import com.redhat.qute.commons.datamodel.DataModelTemplateMatcher;
 import com.redhat.qute.commons.datamodel.resolvers.NamespaceResolverInfo;
 import com.redhat.qute.commons.datamodel.resolvers.ValueResolverInfo;
 import com.redhat.qute.project.BaseQuteProject;
@@ -49,7 +51,23 @@ public class RoqProject extends BaseQuteProject {
 
 	@Override
 	protected void fillTemplates(List<DataModelTemplate<DataModelParameter>> templates) {
+		// Inject 'page' and 'site' for all Qute templates which belongs to a Roq application 
+		DataModelTemplate<DataModelParameter> roqTemplate = new DataModelTemplate<DataModelParameter>();
+		roqTemplate.setTemplateMatcher(new DataModelTemplateMatcher(Arrays.asList("**/**")));
 
+		// site
+		DataModelParameter site = new DataModelParameter();
+		site.setKey("site");
+		site.setSourceType("io.quarkiverse.roq.frontmatter.runtime.model.Site");
+		roqTemplate.addParameter(site);
+
+		// page
+		DataModelParameter page = new DataModelParameter();
+		page.setKey("page");
+		page.setSourceType("io.quarkiverse.roq.frontmatter.runtime.model.Page");
+		roqTemplate.addParameter(page);
+
+		templates.add(roqTemplate);
 	}
 
 	@Override

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codelens/roq/RoqCodeLensTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/codelens/roq/RoqCodeLensTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.codelens.roq;
+
+import static com.redhat.qute.QuteAssert.cl;
+import static com.redhat.qute.QuteAssert.r;
+
+import org.eclipse.lsp4j.CodeLens;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.QuteAssert;
+import com.redhat.qute.project.roq.RoqProject;
+
+/**
+ * Tests for Qute code lens and data model for template which belongs to a Roq
+ * application.
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class RoqCodeLensTest {
+
+	@Test
+	public void pageAndDocument() throws Exception {
+		String value = "";
+		testCodeLensFor(value, "src/main/resources/templates/ItemResource/XXXXXXXXXXX.qute.html", //
+				cl(r(0, 0, 0, 0), "site : Site", ""), //
+				cl(r(0, 0, 0, 0), "page : Page", ""));
+	}
+
+	public static void testCodeLensFor(String value, String fileUri, CodeLens... expected) throws Exception {
+		QuteAssert.testCodeLensFor(value, fileUri, null, RoqProject.PROJECT_URI, QuteAssert.TEMPLATE_BASE_DIR,
+				expected);
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/roq/RoqCompletionsTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/roq/RoqCompletionsTest.java
@@ -54,6 +54,30 @@ public class RoqCompletionsTest {
 	}
 
 	@Test
+	public void siteWithNoDeclaration() throws Exception {
+		String template = "{site.|}";
+		testCompletionFor(template, //
+				c("or(base : T, arg : Object) : T", "or(arg)", r(0, 6, 0, 6)), //
+				c("img() : RoqUrl", "img", r(0, 6, 0, 6)), //
+				c("toString() : String", "toString", r(0, 6, 0, 6)), //
+				c("hashCode() : int", "hashCode", r(0, 6, 0, 6)), //
+				c("imagesUrl : RoqUrl", "imagesUrl", r(0, 6, 0, 6)), //
+				c("url() : RoqUrl", "url", r(0, 6, 0, 6)), //
+				c("collections : RoqCollections", "collections", r(0, 6, 0, 6)), //
+				c("collections() : RoqCollections", "collections", r(0, 6, 0, 6)), //
+				c("document(id : String) : DocumentPage", "document(id)", r(0, 6, 0, 6)), //
+				c("pages : List<NormalPage>", "pages", r(0, 6, 0, 6)), //
+				c("pages() : List<NormalPage>", "pages", r(0, 6, 0, 6)), //
+				c("data() : JsonObject", "data", r(0, 6, 0, 6)), //
+				c("orEmpty(base : T) : List<T>", "orEmpty", r(0, 6, 0, 6)), //
+				c("page(id : String) : NormalPage", "page(id)", r(0, 6, 0, 6)), //
+				c("safe(base : Object) : RawString", "safe", r(0, 6, 0, 6)), //
+				c("title() : String", "title", r(0, 6, 0, 6)), //
+				c("url(path : Object, others : Object...) : RoqUrl", "url(path, others)", r(0, 6, 0, 6)), //
+				c("title() : String", "title", r(0, 6, 0, 6)));
+	}
+	
+	@Test
 	public void site_collections() throws Exception {
 		String template = "{@io.quarkiverse.roq.frontmatter.runtime.model.Site site}\r\n" + //
 				"{site.collections.|}";

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/roq/RoqDiagnosticsTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/roq/RoqDiagnosticsTest.java
@@ -44,6 +44,14 @@ public class RoqDiagnosticsTest {
 		testDiagnosticsFor(template);
 	}
 
+	@Test
+	public void pageWithNoDeclaration() {		
+		// As 'page' and 'site' are injected for all Qute templates for a Roq application
+		// no need to declare {@io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage page}
+		String template = "{page.date.format('yyyy, MMM dd')}";
+		testDiagnosticsFor(template);
+	}
+	
 	private static void testDiagnosticsFor(String value, Diagnostic... expected) {
 		QuteAssert.testDiagnosticsFor(value, QuteAssert.FILE_URI, null, RoqProject.PROJECT_URI,
 				QuteAssert.TEMPLATE_BASE_DIR, true, null, expected);


### PR DESCRIPTION
This PR provides the capability to inject data model parameter with pattern (instead of just template uri). This mechanims is used by roq extension to add site and page on each Qute template which are a roq application.

To test this PR,

 *  open https://github.com/quarkiverse/quarkus-roq/tree/main/blog
 *  create a foo.html file in https://github.com/quarkiverse/quarkus-roq/tree/main/blog/content you should see site and page as codelens:

![image](https://github.com/user-attachments/assets/1591a95b-2987-4ab1-9524-c54b3e277459)
 * create a Qute expression and open completion, you should see site and page

![image](https://github.com/user-attachments/assets/4a02cd8d-0292-4760-b371-94197e16bca5)

This auto injection  of data parameter is generic. Roq extension defines a template data model like this:

```
[Trace - 11:48:52 PM] Sending response 'qute/template/projectDataModel - (17)'. Processing request took 94877ms
Result: {
    "templates": [
        {
            "templateMatcher": {
                "includes": [
                    "**/**"
                ]
            },
            "parameters": [
                {
                    "key": "site",
                    "sourceType": "io.quarkiverse.roq.frontmatter.runtime.model.Site"
                },
                {
                    "key": "page",
                    "sourceType": "io.quarkiverse.roq.frontmatter.runtime.model.Page"
                }
            ]
        }
```

includes is set to **/** which means that any Qute template have siteand page parameters, but we can use a glob pattern to define some specific folders.