### PR TITLE
false positive error with section name which contains number

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/scanner/TemplateScanner.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/scanner/TemplateScanner.java
@@ -34,7 +34,7 @@ public class TemplateScanner extends AbstractScanner<TokenType, ScannerState> {
 	private static final int[] RCURLY_QUOTE = new int[] { '}', '"', '\'', };
 
 	private static final Predicate<Integer> TAG_NAME_PREDICATE = ch -> {
-		return Character.isLetter(ch);
+		return Character.isLetterOrDigit(ch);
 	};
 
 	public static Scanner<TokenType, ScannerState> createScanner(String input) {

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
@@ -115,10 +115,11 @@ public class QuteAssert {
 
 	public static final String FILE_URI = "test.qute";
 
-	public static final int USER_TAG_SIZE = 10 /*
+	public static final int USER_TAG_SIZE = 11 /*
 												 * #input, #bundleStyle, #form, #title, #simpleTitle, #user,
 												 * #formElement,
 												 * #inputRequired, #myTag, #tagWithArgs
+												 * #ga4
 												 */;
 
 	public static final int SECTION_SNIPPET_SIZE = 15 /* #each, #for, ... #fragment ... */ + USER_TAG_SIZE;

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionWithIncludeSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionWithIncludeSectionTest.java
@@ -36,7 +36,7 @@ public class QuteCompletionWithIncludeSectionTest {
 		// Without snippet
 		testCompletionFor(template, //
 				false, // no snippet support
-				16 /* all files from src/test/resources/templates */ - 1 /* README.md */ - USER_TAG_SIZE, //
+				17 /* all files from src/test/resources/templates */ - 1 /* README.md */ - USER_TAG_SIZE, //
 				c("base", "base", r(0, 10, 0, 10)),
 				c("test.json", "test.json", r(0, 10, 0, 10)),
 				c("test.html", "test.html", r(0, 10, 0, 10)),
@@ -55,7 +55,7 @@ public class QuteCompletionWithIncludeSectionTest {
 		testCompletionFor(template, //
 				"src/test/resources/templates/base.html",
 				false, // no snippet support
-				16 /* all files from src/test/resources/templates */ - 1 /* base.html */ - 1 /* README.md */
+				17 /* all files from src/test/resources/templates */ - 1 /* base.html */ - 1 /* README.md */
 						- USER_TAG_SIZE, //
 				// c("base", "base", r(0, 10, 0, 10)),
 				c("test.json", "test.json", r(0, 10, 0, 10)),

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionWithUserTagTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionWithUserTagTest.java
@@ -69,6 +69,7 @@ public class QuteCompletionWithUserTagTest {
 						"name=\"${1:main.css}\"$0", //
 						r(0, 14, 0, 14)));
 	}
+
 	@Test
 	public void input() throws Exception {
 		String template = "{#|";
@@ -524,5 +525,22 @@ public class QuteCompletionWithUserTagTest {
 				true, // snippet support
 				1, //
 				c("foo", "foo=\"${1:foo}\"$0", r(0, 14, 0, 14)));
+	}
+	
+	@Test
+	public void ga4() throws Exception {
+		String template = "{#|";
+
+		// Without snippet
+		testCompletionFor(template, //
+				false, // no snippet support
+				SECTION_SNIPPET_SIZE, //
+				c("ga4", "{#ga4 /}", r(0, 0, 0, 2)));
+
+		// With snippet support
+		testCompletionFor(template, //
+				true, // snippet support
+				SECTION_SNIPPET_SIZE, //
+				c("ga4", "{#ga4 /}$0", r(0, 0, 0, 2)));
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsWithUserTagTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsWithUserTagTest.java
@@ -58,6 +58,12 @@ public class QuteDiagnosticsWithUserTagTest {
 	}
 
 	@Test
+	public void ga4() {
+		String template = "{#ga4 /}";
+		testDiagnosticsFor(template);
+	}
+	
+	@Test
 	public void definedAllParameterNamesWithoutAssignment() {
 		String template = "{@java.lang.String name}\n" + //
 				"{@java.lang.String id}\n" + //


### PR DESCRIPTION
false positive error with section name which contains number

Open https://github.com/quarkiverse/quarkus-roq/blob/90048f75d54a8e1396245c94f39aa87950194f94/theme/default/src/main/resources/templates/partials/roq-default/head.html#L5

There is a false positive error:

![image](https://github.com/user-attachments/assets/598effa4-c06c-48cb-8451-6a193f7bc15a)

It is because the fault toerant Qute parser doesn't support number in section name.

//cc @ia3andy 