### PR TITLE
Qute expression escape support.

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionTest.java
@@ -684,4 +684,10 @@ public class QuteDiagnosticsInExpressionTest {
 				d(0, 1, 0, 6, QuteErrorCode.UndefinedObject, "`items` cannot be resolved to an object.",
 						DiagnosticSeverity.Warning));
 	}
+
+	@Test
+	public void escape() throws Exception {
+		String template = "function gtag()\\{dataLayer.push(arguments);\\}";
+		testDiagnosticsFor(template);
+	}
 }


### PR DESCRIPTION
Qute expression escape support.

Qute expression can be escaped with `\` and in this case we should not validate the exression like

![image](https://github.com/user-attachments/assets/0afbbeb6-508c-4933-bc35-3127dae2436c)

