### PR TITLE
false positive error with section name which contains underscore

### DIFF
--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/scanner/TemplateScanner.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/scanner/TemplateScanner.java
@@ -34,7 +34,7 @@ public class TemplateScanner extends AbstractScanner<TokenType, ScannerState> {
 	private static final int[] RCURLY_QUOTE = new int[] { '}', '"', '\'', };
 
 	private static final Predicate<Integer> TAG_NAME_PREDICATE = ch -> {
-		return Character.isLetterOrDigit(ch);
+		return Character.isLetterOrDigit(ch) || ch == '_' || ch == '-';
 	};
 
 	public static Scanner<TokenType, ScannerState> createScanner(String input) {

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
@@ -115,11 +115,11 @@ public class QuteAssert {
 
 	public static final String FILE_URI = "test.qute";
 
-	public static final int USER_TAG_SIZE = 11 /*
+	public static final int USER_TAG_SIZE = 12 /*
 												 * #input, #bundleStyle, #form, #title, #simpleTitle, #user,
 												 * #formElement,
 												 * #inputRequired, #myTag, #tagWithArgs
-												 * #ga4
+												 * #ga4, #reunion-card
 												 */;
 
 	public static final int SECTION_SNIPPET_SIZE = 15 /* #each, #for, ... #fragment ... */ + USER_TAG_SIZE;

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionWithIncludeSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionWithIncludeSectionTest.java
@@ -36,7 +36,7 @@ public class QuteCompletionWithIncludeSectionTest {
 		// Without snippet
 		testCompletionFor(template, //
 				false, // no snippet support
-				17 /* all files from src/test/resources/templates */ - 1 /* README.md */ - USER_TAG_SIZE, //
+				18 /* all files from src/test/resources/templates */ - 1 /* README.md */ - USER_TAG_SIZE, //
 				c("base", "base", r(0, 10, 0, 10)),
 				c("test.json", "test.json", r(0, 10, 0, 10)),
 				c("test.html", "test.html", r(0, 10, 0, 10)),
@@ -55,7 +55,7 @@ public class QuteCompletionWithIncludeSectionTest {
 		testCompletionFor(template, //
 				"src/test/resources/templates/base.html",
 				false, // no snippet support
-				17 /* all files from src/test/resources/templates */ - 1 /* base.html */ - 1 /* README.md */
+				18 /* all files from src/test/resources/templates */ - 1 /* base.html */ - 1 /* README.md */
 						- USER_TAG_SIZE, //
 				// c("base", "base", r(0, 10, 0, 10)),
 				c("test.json", "test.json", r(0, 10, 0, 10)),

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionWithUserTagTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionWithUserTagTest.java
@@ -528,7 +528,7 @@ public class QuteCompletionWithUserTagTest {
 	}
 	
 	@Test
-	public void ga4() throws Exception {
+	public void number_in_section_name() throws Exception {
 		String template = "{#|";
 
 		// Without snippet
@@ -542,5 +542,22 @@ public class QuteCompletionWithUserTagTest {
 				true, // snippet support
 				SECTION_SNIPPET_SIZE, //
 				c("ga4", "{#ga4 /}$0", r(0, 0, 0, 2)));
+	}
+	
+	@Test
+	public void underscore_in_section_name() throws Exception {
+		String template = "{#|";
+
+		// Without snippet
+		testCompletionFor(template, //
+				false, // no snippet support
+				SECTION_SNIPPET_SIZE, //
+				c("reunion-card", "{#reunion-card /}", r(0, 0, 0, 2)));
+
+		// With snippet support
+		testCompletionFor(template, //
+				true, // snippet support
+				SECTION_SNIPPET_SIZE, //
+				c("reunion-card", "{#reunion-card /}$0", r(0, 0, 0, 2)));
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsWithUserTagTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsWithUserTagTest.java
@@ -58,8 +58,14 @@ public class QuteDiagnosticsWithUserTagTest {
 	}
 
 	@Test
-	public void ga4() {
+	public void number_in_section_name() {
 		String template = "{#ga4 /}";
+		testDiagnosticsFor(template);
+	}
+	
+	@Test
+	public void underscore_in_section_name() {
+		String template = "{#reunion-card /}";
 		testDiagnosticsFor(template);
 	}
 	


### PR DESCRIPTION
false positive error with section name which contains underscore

This PR fixes false positive error when user tags contains underscore:

![image](https://github.com/user-attachments/assets/b23e1cff-52eb-47b5-84b2-3777a10bf0e7)
