### PR TITLE
Support for Qute Integer Numbers

### DIFF
--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/JavaMethodInfo.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/JavaMethodInfo.java
@@ -311,12 +311,18 @@ public class JavaMethodInfo extends JavaMemberInfo {
 	}
 
 	/**
-	 * Returns the parameters length of the method.
+	 * Returns the applicable parameters of the method.
 	 * 
-	 * @return the parameters length of the method.
+	 * <p>
+	 * By default it returns the same list that getParameters(). This method is
+	 * override
+	 * for method value resolver to returns the applicable parameters.
+	 * </p>
+	 * 
+	 * @return the applicable parameters of the method.
 	 */
-	public int getParameterslength() {
-		return getParameters().size() - (isVirtual() ? 1 : 0);
+	public List<JavaParameterInfo> getApplicableParameters() {
+		return getParameters();
 	}
 
 	private static List<JavaParameterInfo> parseParameters(String signature) {

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/JavaMethodInfo.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/JavaMethodInfo.java
@@ -311,12 +311,18 @@ public class JavaMethodInfo extends JavaMemberInfo {
 	}
 
 	/**
-	 * Returns the parameters length of the method.
+	 * Returns the applicable parameters of the method.
 	 * 
-	 * @return the parameters length of the method.
+	 * <p>
+	 * By default it returns the same list that getParameters(). This method is
+	 * override
+	 * for method value resolver to returns the applicable parameters.
+	 * </p>
+	 * 
+	 * @return the applicable parameters of the method.
 	 */
-	public int getParameterslength() {
-		return getParameters().size() - (isVirtual() ? 1 : 0);
+	public List<JavaParameterInfo> getApplicableParameters() {
+		return getParameters();
 	}
 
 	private static List<JavaParameterInfo> parseParameters(String signature) {

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/JavaDataModelCache.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/JavaDataModelCache.java
@@ -58,12 +58,15 @@ public class JavaDataModelCache {
 
 	private static final Map<String, String> autoboxing;
 
+	private static final Map<String, String> bigNumber;
+
 	private static final Map<String, CompletableFuture<ResolvedJavaTypeInfo>> javaPrimitiveTypes;
 
 	static {
 		javaPrimitiveTypes = new HashMap<>();
 		autoboxing = new HashMap<>();
 		JavaTypeInfo.PRIMITIVE_TYPES.forEach(type -> registerPrimitiveType(type));
+		bigNumber = Map.of("java.math.BigInteger", "java.lang.Integer", "java.math.BigDouble", "java.lang.Double");
 	}
 
 	private static void registerPrimitiveType(String type) {
@@ -586,6 +589,10 @@ public class JavaDataModelCache {
 		if (primitiveType != null) {
 			// It's a Java primitive type
 			return primitiveType.equals(autoboxing.get(type2));
+		}
+		String bigNumberType = bigNumber.get(type1);
+		if (bigNumberType != null) {
+			return bigNumberType.equals(type2);
 		}
 		return false;
 	}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/JavaMemberResult.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/JavaMemberResult.java
@@ -12,6 +12,7 @@
 package com.redhat.qute.project;
 
 import com.redhat.qute.commons.JavaMemberInfo;
+import com.redhat.qute.project.datamodel.resolvers.MethodValueResolver;
 
 /**
  * The search result of Java member.
@@ -85,6 +86,14 @@ public class JavaMemberResult {
 	 */
 	public void setMatchVirtualMethod(boolean matchVirtualMethod) {
 		this.matchVirtualMethod = matchVirtualMethod;
+	}
+	
+	public boolean isMatchNameAny() {
+		if (member instanceof MethodValueResolver) {
+			MethodValueResolver method = (MethodValueResolver) member;
+			return method.isMatchNameAny();
+		}
+		return false;
 	}
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/ExtendedDataModelProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/ExtendedDataModelProject.java
@@ -65,10 +65,10 @@ public class ExtendedDataModelProject extends DataModelProject<ExtendedDataModel
 		methodValueResolvers = new ArrayList<MethodValueResolver>();
 		updateValueResolvers(typeValueResolvers, fieldValueResolvers, methodValueResolvers, project);
 		Collections.sort(methodValueResolvers, (r1, r2) -> {
-			if (r1.getMatchNames() != null && r1.getMatchNames().contains(MATCH_NAME_ANY)) {
+			if (r1.isMatchNameAny()) {
 				return 1;
 			}
-			if (r2.getMatchNames() != null && r2.getMatchNames().contains(MATCH_NAME_ANY)) {
+			if (r2.isMatchNameAny()) {
 				return -1;
 			}
 			return 0;

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteDiagnostics.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteDiagnostics.java
@@ -1136,7 +1136,6 @@ class QuteDiagnostics {
 
 		boolean matchVirtualMethod = result.isMatchVirtualMethod();
 		if (!matchVirtualMethod) {
-
 			Range range = QutePositionUtility.createRange(methodPart);
 			Diagnostic diagnostic = createDiagnostic(range, DiagnosticSeverity.Error,
 					QuteErrorCode.InvalidVirtualMethod, //
@@ -1146,8 +1145,9 @@ class QuteDiagnostics {
 			return null;
 		}
 
+		List<JavaParameterInfo> applicableParamters = method.getApplicableParameters();
 		if (methodPart.isInfixNotation()) {
-			int nbParameters = method.getParameters().size() - (method.isVirtual() ? 1 : 0);
+			int nbParameters = applicableParamters.size();
 			if (nbParameters != 1) {
 				// infix notation,
 				// ex: String#codePointCount cannot be used with infix notation
@@ -1166,15 +1166,11 @@ class QuteDiagnostics {
 			// The method codePointAt(int) in the type String is not applicable for the
 			// arguments ()
 			StringBuilder expectedSignature = new StringBuilder("(");
-			boolean ignoreParameter = method.isVirtual();
-			for (JavaParameterInfo parameter : method.getParameters()) {
-				if (!ignoreParameter) {
-					if (expectedSignature.length() > 1) {
-						expectedSignature.append(", ");
-					}
-					expectedSignature.append(parameter.getJavaElementSimpleType());
+			for (JavaParameterInfo parameter : applicableParamters) {
+				if (expectedSignature.length() > 1) {
+					expectedSignature.append(", ");
 				}
-				ignoreParameter = false;
+				expectedSignature.append(parameter.getJavaElementSimpleType());
 			}
 			expectedSignature.append(")");
 			expectedSignature.insert(0, method.getName());

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/completions/QuteCompletionsForExpression.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/completions/QuteCompletionsForExpression.java
@@ -544,8 +544,7 @@ public class QuteCompletionsForExpression {
 		if (!infixNotation) {
 			return true;
 		}
-		int nbParameters = method.getParameterslength();
-		return nbParameters == 1;
+		return method.getApplicableParameters().size() == 1;
 	}
 
 	private static void fillCompletionMethod(JavaMethodInfo method, JavaTypeAccessibiltyRule javaTypeAccessibility,
@@ -604,24 +603,20 @@ public class QuteCompletionsForExpression {
 		} else {
 			snippet.append(methodName);
 			if (method.hasParameters()) {
-				int start = 0;
-				if (method.isVirtual() && ((ValueResolver) method).getNamespace() == null) {
-					start++;
-				}
-
 				if (!infixNotation) {
 					snippet.append('(');
 				} else {
 					snippet.append(' ');
 				}
 				int end = getRequiredParametersSize(method);
-				for (int i = start; i < end; i++) {
-					if (i > start) {
+				List<JavaParameterInfo> applicableParameters = method.getApplicableParameters();
+				for (int i = 0; i < end; i++) {
+					if (i > 0) {
 						snippet.append(", ");
 					}
-					JavaParameterInfo parameter = method.getParameterAt(i);
+					JavaParameterInfo parameter = applicableParameters.get(i);
 					if (snippetsSupported) {
-						SnippetsBuilder.placeholders(i - start + 1, parameter.getName(), snippet);
+						SnippetsBuilder.placeholders(i + 1, parameter.getName(), snippet);
 					} else {
 						snippet.append(parameter.getName());
 					}
@@ -638,7 +633,7 @@ public class QuteCompletionsForExpression {
 	}
 
 	private static int getRequiredParametersSize(JavaMethodInfo method) {
-		int nbParameters = method.getParameters().size();
+		int nbParameters = method.getApplicableParameters().size();
 		if (method.getJaxRsMethodKind() != null) {
 			// Renarde parameters, only @ResPath (required parameters) must be shown in the
 			// completion

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/QuteQuickStartProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/QuteQuickStartProject.java
@@ -42,7 +42,7 @@ import com.redhat.qute.commons.jaxrs.RestParam;
  *
  */
 public class QuteQuickStartProject extends BaseQuteProject {
- 
+
 	public final static String PROJECT_URI = "qute-quickstart";
 
 	public static final String ITEMRESOURCE_ITEMS_TEMPLATE_URI = "src/main/resources/templates/ItemResource/items";
@@ -360,7 +360,23 @@ public class QuteQuickStartProject extends BaseQuteProject {
 
 	@Override
 	protected void fillValueResolvers(List<ValueResolverInfo> resolvers) {
-
+		// io.quarkus.qute.runtime.extensions.NumberTemplateExtensions
+		resolvers.add(createValueResolver(null, null, (String) null,
+				"io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+				"mod(number : java.lang.Integer, mod : java.lang.Integer) : java.lang.Integer",
+				ValueResolverKind.TemplateExtensionOnMethod,
+				false, true));
+		resolvers.add(createValueResolver(null, null, List.of("plus", "+"),
+				"io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+				"addToInt(number : java.lang.Integer, name : java.lang.String, other : java.lang.Integer) : java.lang.Integer",
+				ValueResolverKind.TemplateExtensionOnMethod,
+				false, true));
+		resolvers.add(createValueResolver(null, null, List.of("minus", "-"),
+				"io.quarkus.qute.runtime.extensions.NumberTemplateExtensions",
+				"subtractFromInt(number : java.lang.Integer, name : java.lang.String, other : java.lang.Integer) : java.lang.Integer",
+				ValueResolverKind.TemplateExtensionOnMethod,
+				false, true));
+		
 		// Type value resolvers
 		resolvers.add(createValueResolver("inject", "plexux", (String) null,
 				"org.eclipse.aether.internal.transport.wagon.PlexusWagonConfigurator",

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInInfixNotationTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/QuteCompletionInInfixNotationTest.java
@@ -85,7 +85,7 @@ public class QuteCompletionInInfixNotationTest {
 
 		// Infix notation : only methods with one parameter of String class
 		testCompletionFor(template, //
-				RESOLVERS_SIZE + 1, //, //
+				RESOLVERS_SIZE + 1, // , //
 				c("item", "item", r(1, 14, 1, 14)), //
 				c("inject:bean", "inject:bean", r(1, 14, 1, 14)), //
 				c("inject:plexux", "inject:plexux", r(1, 14, 1, 14)), //
@@ -95,7 +95,7 @@ public class QuteCompletionInInfixNotationTest {
 				c("GLOBAL", "GLOBAL", r(1, 14, 1, 14)), //
 				c("VARCHAR_SIZE", "VARCHAR_SIZE", r(1, 14, 1, 14)), //
 				c("uri:Login", "uri:Login", r(1, 14, 1, 14)), //
-				c("msg:hello_name(name : String) : String", "msg:hello_name(${1:name})$0", r(1, 14, 1, 14)),//
+				c("msg:hello_name(name : String) : String", "msg:hello_name(${1:name})$0", r(1, 14, 1, 14)), //
 				c("msg2:hello() : String", "msg2:hello", r(1, 14, 1, 14)), //
 				c("bundle", "bundle", r(1, 14, 1, 14)));
 
@@ -114,9 +114,28 @@ public class QuteCompletionInInfixNotationTest {
 				c("GLOBAL", "GLOBAL", r(1, 25, 1, 25)), //
 				c("VARCHAR_SIZE", "VARCHAR_SIZE", r(1, 25, 1, 25)), //
 				c("uri:Login", "uri:Login", r(1, 25, 1, 25)), //
-				c("msg:hello_name(name : String) : String", "msg:hello_name(${1:name})$0", r(1, 25, 1, 25)),//
+				c("msg:hello_name(name : String) : String", "msg:hello_name(${1:name})$0", r(1, 25, 1, 25)), //
 				c("msg2:hello() : String", "msg2:hello", r(1, 25, 1, 25)), //
 				c("bundle", "bundle", r(1, 25, 1, 25)));
+	}
+
+	@Test
+	public void infixNotationWithNumbers() throws Exception {
+		String template = "{@int foo}\r\n" + //
+				"{foo + |}";
+
+		// Infix notation : only methods with one parameter of String class
+		testCompletionFor(template, //
+				5,
+				// - resolvers
+				c("ifTruthy(base : T, arg : Object) : T", "ifTruthy ${1:arg}$0", r(1, 7, 1, 7)),
+				c("or(base : T, arg : Object) : T", "or ${1:arg}$0", r(1, 7, 1, 7)),
+				// Numbers resolvers
+				c("plus(number : Integer, name : String, other : Integer) : Integer", "plus ${1:other}$0",
+						r(1, 7, 1, 7)),
+				c("minus(number : Integer, name : String, other : Integer) : Integer", "minus ${1:other}$0",
+						r(1, 7, 1, 7)),
+				c("mod(number : Integer, mod : Integer) : Integer", "mod ${1:mod}$0", r(1, 7, 1, 7)));
 	}
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionTest.java
@@ -121,6 +121,77 @@ public class QuteDiagnosticsInExpressionTest {
 				ca(d, te(0, 5, 0, 5, "??")));
 	}
 
+	/**
+	 * See https://quarkus.io/guides/qute-reference#integer-numbers
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void integerNumbersMod() throws Exception {
+		String template = "{@java.lang.Integer counter}\r\n" + //
+				"\r\n" + //
+				"{#if counter.mod(5) == 0}\r\n" + //
+				"{/}";
+		testDiagnosticsFor(template);
+
+		template = "{@int counter}\r\n" + //
+				"\r\n" + //
+				"{#if counter.mod(5) == 0}\r\n" + //
+				"{/}";
+		testDiagnosticsFor(template);
+
+	}
+
+	/**
+	 * See https://quarkus.io/guides/qute-reference#integer-numbers
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void integerNumbersAddition() throws Exception {
+		String template = "{@java.lang.Integer counter}\r\n" + //
+				"{@java.lang.Integer age}\r\n" + //
+				"\r\n" + //
+				"{counter + 1}\r\n" + //
+				"{age plus 10}\r\n" + //
+				"{age.plus(10)}";
+		testDiagnosticsFor(template);
+	}
+
+	/**
+	 * See https://quarkus.io/guides/qute-reference#integer-numbers
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void integerNumbersSubstraction() throws Exception {
+		String template = "{@java.lang.Integer counter}\r\n" + //
+				"{@java.lang.Integer age}\r\n" + //
+				"\r\n" + //
+				"{counter - 1}\r\n" + //
+				"{age minus 10}\r\n" + //
+				"{age.minus(10)}";
+		testDiagnosticsFor(template);
+	}
+
+	/**
+	 * See https://quarkus.io/guides/qute-reference#integer-numbers
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void integerNumbersInFor() throws Exception {
+		String template = "{@java.lang.Integer[] ints}\r\n" + //
+				"\r\n" + //
+				"{#for item in ints}\r\n" + //
+				"  {item_count + 1}\r\n" + //
+				"  {item_count + 1 + 2 plus 3 - 5 minus 6}\r\n" + //
+				"  {item_count + ints.0 - 6}\r\n" + //
+				"  {item_count + ints.get(0) - 6}\r\n" + //
+				"{/for}";
+		testDiagnosticsFor(template);
+	}
+
 	@Test
 	public void longLiteral() throws Exception {
 		String template = "{123L}";
@@ -690,11 +761,11 @@ public class QuteDiagnosticsInExpressionTest {
 		String template = "function gtag()\\{dataLayer.push(arguments);\\}";
 		testDiagnosticsFor(template);
 	}
-	
+
 	@Test
 	public void configNamepscaeWithString() throws Exception {
 		String template = "{config:\"quarkus.application.name\"}";
 		testDiagnosticsFor(template);
 	}
-	
+
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithEachSectionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithEachSectionTest.java
@@ -1,6 +1,5 @@
 package com.redhat.qute.services.diagnostics;
 
-import static com.redhat.qute.QuteAssert.c;
 import static com.redhat.qute.QuteAssert.ca;
 import static com.redhat.qute.QuteAssert.d;
 import static com.redhat.qute.QuteAssert.te;
@@ -10,9 +9,6 @@ import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.jupiter.api.Test;
-
-import com.redhat.qute.ls.commons.client.ConfigurationItemEditType;
-import com.redhat.qute.services.commands.QuteClientCommandConstants;
 
 public class QuteDiagnosticsInExpressionWithEachSectionTest {
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithNamespaceTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInExpressionWithNamespaceTest.java
@@ -11,8 +11,6 @@
 *******************************************************************************/
 package com.redhat.qute.services.diagnostics;
 
-import static com.redhat.qute.QuteAssert.c;
-import static com.redhat.qute.QuteAssert.ca;
 import static com.redhat.qute.QuteAssert.d;
 import static com.redhat.qute.QuteAssert.testCodeActionsFor;
 import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
@@ -20,9 +18,6 @@ import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.jupiter.api.Test;
-
-import com.redhat.qute.ls.commons.client.ConfigurationItemEditType;
-import com.redhat.qute.services.commands.QuteClientCommandConstants;
 
 /**
  * Test with expressions.
@@ -117,19 +112,21 @@ public class QuteDiagnosticsInExpressionWithNamespaceTest {
 		template = "{cdi:bean.isEmpty()}";
 		testDiagnosticsFor(template);
 	}
-	
+
 	@Test
 	public void notOperatorWithNamespacePart() {
 		String template = "{#if !cdi:bean}NOK{#else}OK{/if}";
 		testDiagnosticsFor(template);
 
 		template = "{#if !cdi:foo}NOK{#else}OK{/if}";
-		testDiagnosticsFor(template, d(0, 10, 0, 13, QuteErrorCode.UndefinedObject, "`foo` cannot be resolved to an object.",
-				DiagnosticSeverity.Warning));
-		
+		testDiagnosticsFor(template,
+				d(0, 10, 0, 13, QuteErrorCode.UndefinedObject, "`foo` cannot be resolved to an object.",
+						DiagnosticSeverity.Warning));
+
 		template = "{#if !foo:bar}NOK{#else}OK{/if}";
-		testDiagnosticsFor(template, d(0, 6, 0, 9, QuteErrorCode.UndefinedNamespace, "No namespace resolver found for: `foo`.",
-				DiagnosticSeverity.Warning));
+		testDiagnosticsFor(template,
+				d(0, 6, 0, 9, QuteErrorCode.UndefinedNamespace, "No namespace resolver found for: `foo`.",
+						DiagnosticSeverity.Warning));
 	}
 
 	@Test

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInNativeModeTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsInNativeModeTest.java
@@ -32,27 +32,60 @@ public class QuteDiagnosticsInNativeModeTest {
 
 	@Test
 	public void templateDataField() {
+		boolean nativeMode = false;
 		// public class Item
 		String template = // "{@org.acme.Review review}\r\n" + //
 				"{review.name}";
 		testDiagnosticsFor(template, //
+				nativeMode);
+
+		template = "{@org.acme.Review review}\r\n" + //
+				"{review.name}";
+		testDiagnosticsFor(template, nativeMode);
+
+		// @TemplateData
+		// public class ItemWithTemplateData
+		template = // "{@org.acme.ItemWithTemplateData itemWithTemplateData}\r\n" + //
+				"{itemWithTemplateData.name}";
+		testDiagnosticsFor(template, nativeMode);
+
+		template = // "{@org.acme.ItemWithTemplateData itemWithTemplateData}\r\n" + //
+				"{itemWithTemplateData.price.divide(0)}";
+		testDiagnosticsFor(template, //
+				nativeMode);
+
+		template = // "{@org.acme.ItemWithTemplateData itemWithTemplateData}\r\n" + //
+				"{itemWithTemplateData.name.isEmpty()}";
+		testDiagnosticsFor(template, //
+				nativeMode);
+	}
+
+	@Test
+	public void templateDataFieldInNativeMode() {
+		boolean nativeMode = true;
+		// public class Item
+		String template = // "{@org.acme.Review review}\r\n" + //
+				"{review.name}";
+		testDiagnosticsFor(template, //
+				nativeMode,
 				d(0, 8, 0, 12, QuteErrorCode.PropertyNotSupportedInNativeMode,
 						"Property `name` of `org.acme.Review` Java type cannot be used in native image mode.",
 						DiagnosticSeverity.Error));
 
 		template = "{@org.acme.Review review}\r\n" + //
 				"{review.name}";
-		testDiagnosticsFor(template);
+		testDiagnosticsFor(template, nativeMode);
 
 		// @TemplateData
 		// public class ItemWithTemplateData
 		template = // "{@org.acme.ItemWithTemplateData itemWithTemplateData}\r\n" + //
 				"{itemWithTemplateData.name}";
-		testDiagnosticsFor(template);
+		testDiagnosticsFor(template, nativeMode);
 
 		template = // "{@org.acme.ItemWithTemplateData itemWithTemplateData}\r\n" + //
 				"{itemWithTemplateData.price.divide(0)}";
 		testDiagnosticsFor(template, //
+				nativeMode,
 				d(0, 28, 0, 34, QuteErrorCode.MethodNotSupportedInNativeMode,
 						"Method `divide` of `java.math.BigInteger` Java type cannot be used in native image mode.",
 						DiagnosticSeverity.Error));
@@ -60,6 +93,7 @@ public class QuteDiagnosticsInNativeModeTest {
 		template = // "{@org.acme.ItemWithTemplateData itemWithTemplateData}\r\n" + //
 				"{itemWithTemplateData.name.isEmpty()}";
 		testDiagnosticsFor(template, //
+				nativeMode,
 				d(0, 27, 0, 34, QuteErrorCode.MethodNotSupportedInNativeMode,
 						"Method `isEmpty` of `java.lang.String` Java type cannot be used in native image mode.",
 						DiagnosticSeverity.Error));
@@ -67,22 +101,52 @@ public class QuteDiagnosticsInNativeModeTest {
 
 	@Test
 	public void templateDataFieldWithTarget() {
+		boolean nativeMode = false;
 		// @TemplateData
 		// @TemplateData(target = String.class)
 		// public class ItemWithTemplateDataWithTarget
 		String template = "{@org.acme.ItemWithTemplateDataWithTarget itemWithTemplateDataWithTarget}\r\n" + //
 				"{itemWithTemplateDataWithTarget.name}";
-		testDiagnosticsFor(template);
+		testDiagnosticsFor(template, nativeMode);
 
 		template = // "{@org.acme.ItemWithTemplateDataWithTarget
 					// itemWithTemplateDataWithTarget}\r\n" + //
 				"{itemWithTemplateDataWithTarget.name.isEmpty()}";
-		testDiagnosticsFor(template);
+		testDiagnosticsFor(template, nativeMode);
+
+		template = // "{@org.acme.ItemWithTemplateDataWithTarget
+					// itemWithTemplateDataWithTarget}\r\n" + //
+				"{itemWithTemplateDataWithTarget.price.divide(0)}";
+		testDiagnosticsFor(template, nativeMode);
+
+		// here java.lang.String#isEmpty is supported in native mode because
+		// ItemWithTemplateDataWithTarget defines @TemplateData(target = String.class)
+		template = // "{@org.acme.ItemWithTemplateDataWithTarget
+					// itemWithTemplateDataWithTarget}\r\n" + //
+				"{itemWithTemplateDataWithTarget.name.isEmpty()}";
+		testDiagnosticsFor(template, nativeMode);
+	}
+
+	@Test
+	public void templateDataFieldWithTargetInNativeMode() {
+		boolean nativeMode = true;
+		// @TemplateData
+		// @TemplateData(target = String.class)
+		// public class ItemWithTemplateDataWithTarget
+		String template = "{@org.acme.ItemWithTemplateDataWithTarget itemWithTemplateDataWithTarget}\r\n" + //
+				"{itemWithTemplateDataWithTarget.name}";
+		testDiagnosticsFor(template, nativeMode);
+
+		template = // "{@org.acme.ItemWithTemplateDataWithTarget
+					// itemWithTemplateDataWithTarget}\r\n" + //
+				"{itemWithTemplateDataWithTarget.name.isEmpty()}";
+		testDiagnosticsFor(template, nativeMode);
 
 		template = // "{@org.acme.ItemWithTemplateDataWithTarget
 					// itemWithTemplateDataWithTarget}\r\n" + //
 				"{itemWithTemplateDataWithTarget.price.divide(0)}";
 		testDiagnosticsFor(template, //
+				nativeMode,
 				d(0, 38, 0, 44, QuteErrorCode.MethodNotSupportedInNativeMode,
 						"Method `divide` of `java.math.BigInteger` Java type cannot be used in native image mode.",
 						DiagnosticSeverity.Error));
@@ -92,11 +156,12 @@ public class QuteDiagnosticsInNativeModeTest {
 		template = // "{@org.acme.ItemWithTemplateDataWithTarget
 					// itemWithTemplateDataWithTarget}\r\n" + //
 				"{itemWithTemplateDataWithTarget.name.isEmpty()}";
-		testDiagnosticsFor(template);
+		testDiagnosticsFor(template, nativeMode);
 	}
 
 	@Test
 	public void templateDataFieldIgnoreSubClasses() {
+		boolean nativeMode = false;
 		// @TemplateData(ignoreSubClasses = true)
 		// public class ItemWithTemplateDataIgnoreSubClasses
 		String template = // "{@org.acme.ItemWithTemplateDataIgnoreSubClasses
@@ -106,6 +171,22 @@ public class QuteDiagnosticsInNativeModeTest {
 						"{itemWithTemplateDataIgnoreSubClasses.base}"; // <-- error because base comes from super class
 																		// BaseItem
 		testDiagnosticsFor(template, //
+				nativeMode);
+	}
+
+	@Test
+	public void templateDataFieldIgnoreSubClassesInNativeMode() {
+		boolean nativeMode = true;
+		// @TemplateData(ignoreSubClasses = true)
+		// public class ItemWithTemplateDataIgnoreSubClasses
+		String template = // "{@org.acme.ItemWithTemplateDataIgnoreSubClasses
+							// itemWithTemplateDataIgnoreSubClasses}\r\n" + //
+				"{itemWithTemplateDataIgnoreSubClasses.price}\r\n" + // <-- no error because price comes from
+																		// ItemWithTemplateDataIgnoreSubClasses
+						"{itemWithTemplateDataIgnoreSubClasses.base}"; // <-- error because base comes from super class
+																		// BaseItem
+		testDiagnosticsFor(template, //
+				nativeMode,
 				d(1, 38, 1, 42, QuteErrorCode.InheritedPropertyNotSupportedInNativeMode,
 						"Inherited property `base` of `org.acme.ItemWithTemplateDataIgnoreSubClasses` Java type cannot be used in native image mode because Java type is annotated with `@TemplateData(ignoreSuperclasses = true)`.",
 						DiagnosticSeverity.Error));
@@ -113,11 +194,28 @@ public class QuteDiagnosticsInNativeModeTest {
 
 	@Test
 	public void templateDataMethod() {
-
+		boolean nativeMode = false;
 		// public class Item
 		String template = // "{@org.acme.Review review}\r\n" + //
 				"{review.getReviews()}";
 		testDiagnosticsFor(template, //
+				nativeMode);
+
+		// @TemplateData
+		// public class ItemWithTemplateData
+		template = // "{@org.acme.ItemWithTemplateData itemWithTemplateData}\r\n" + //
+				"iItemWithTemplateData.getReview2()}";
+		testDiagnosticsFor(template, nativeMode);
+	}
+
+	@Test
+	public void templateDataMethodInNativeMode() {
+		boolean nativeMode = true;
+		// public class Item
+		String template = // "{@org.acme.Review review}\r\n" + //
+				"{review.getReviews()}";
+		testDiagnosticsFor(template, //
+				nativeMode,
 				d(0, 8, 0, 18, QuteErrorCode.MethodNotSupportedInNativeMode,
 						"Method `getReviews` of `org.acme.Review` Java type cannot be used in native image mode.",
 						DiagnosticSeverity.Error));
@@ -126,11 +224,12 @@ public class QuteDiagnosticsInNativeModeTest {
 		// public class ItemWithTemplateData
 		template = // "{@org.acme.ItemWithTemplateData itemWithTemplateData}\r\n" + //
 				"iItemWithTemplateData.getReview2()}";
-		testDiagnosticsFor(template);
+		testDiagnosticsFor(template, nativeMode);
 	}
 
 	@Test
 	public void templateDataMethodIgnoreSubClasses() {
+		boolean nativeMode = false;
 		// @TemplateData(ignoreSubClasses = true)
 		// public class ItemWithTemplateDataIgnoreSubClasses
 		String template = // "{@org.acme.ItemWithTemplateDataIgnoreSubClasses
@@ -142,6 +241,24 @@ public class QuteDiagnosticsInNativeModeTest {
 																				// from super
 																				// class BaseItem
 		testDiagnosticsFor(template, //
+				nativeMode);
+	}
+
+	@Test
+	public void templateDataMethodIgnoreSubClassesInNativeMode() {
+		boolean nativeMode = true;
+		// @TemplateData(ignoreSubClasses = true)
+		// public class ItemWithTemplateDataIgnoreSubClasses
+		String template = // "{@org.acme.ItemWithTemplateDataIgnoreSubClasses
+							// itemWithTemplateDataIgnoreSubClasses}\r\n" + //
+				"{itemWithTemplateDataIgnoreSubClasses.getSubClasses()}\r\n" + // <-- no error because getSubClasses
+																				// comes from
+				// ItemWithTemplateDataIgnoreSubClasses
+						"{itemWithTemplateDataIgnoreSubClasses.getReviews()}"; // <-- error because getReviews comes
+																				// from super
+																				// class BaseItem
+		testDiagnosticsFor(template, //
+				nativeMode,
 				d(1, 38, 1, 48, QuteErrorCode.InheritedMethodNotSupportedInNativeMode,
 						"Inherited method `getReviews` of `org.acme.ItemWithTemplateDataIgnoreSubClasses` Java type cannot be used in native image mode because Java type is annotated with `@TemplateData(ignoreSuperclasses = true)`.",
 						DiagnosticSeverity.Error));
@@ -149,10 +266,29 @@ public class QuteDiagnosticsInNativeModeTest {
 
 	@Test
 	public void registerForReflectionField() {
+		boolean nativeMode = false;
 		// public class Item
 		String template = // "{@org.acme.Review review}\r\n" + //
 				"{review.name}";
 		testDiagnosticsFor(template, //
+				nativeMode);
+
+		// @RegisterForReflection
+		// public class ItemWithRegisterForReflection
+		template = // "{@org.acme.ItemWithRegisterForReflection itemWithRegisterForReflection}\r\n"
+					// + //
+				"{itemWithRegisterForReflection.name}";
+		testDiagnosticsFor(template, nativeMode);
+	}
+
+	@Test
+	public void registerForReflectionFieldInNativeMode() {
+		boolean nativeMode = true;
+		// public class Item
+		String template = // "{@org.acme.Review review}\r\n" + //
+				"{review.name}";
+		testDiagnosticsFor(template, //
+				nativeMode,
 				d(0, 8, 0, 12, QuteErrorCode.PropertyNotSupportedInNativeMode,
 						"Property `name` of `org.acme.Review` Java type cannot be used in native image mode.",
 						DiagnosticSeverity.Error));
@@ -162,12 +298,12 @@ public class QuteDiagnosticsInNativeModeTest {
 		template = // "{@org.acme.ItemWithRegisterForReflection itemWithRegisterForReflection}\r\n"
 					// + //
 				"{itemWithRegisterForReflection.name}";
-		testDiagnosticsFor(template);
+		testDiagnosticsFor(template, nativeMode);
 	}
 
 	@Test
 	public void registerForReflectionNoFields() {
-
+		boolean nativeMode = false;
 		// @RegisterForReflection(fields = false)
 		// public class ItemWithRegisterForReflectionNoFields
 		String template = // "{@org.acme.ItemWithRegisterForReflectionNoFields
@@ -175,6 +311,20 @@ public class QuteDiagnosticsInNativeModeTest {
 				"{itemWithRegisterForReflectionNoFields.getReview2()}\r\n" + // <-- no error because it's a method
 						"{itemWithRegisterForReflectionNoFields.base}"; // <-- error because fields are ignored
 		testDiagnosticsFor(template, //
+				nativeMode);
+	}
+
+	@Test
+	public void registerForReflectionNoFieldsInNativeMode() {
+		boolean nativeMode = true;
+		// @RegisterForReflection(fields = false)
+		// public class ItemWithRegisterForReflectionNoFields
+		String template = // "{@org.acme.ItemWithRegisterForReflectionNoFields
+							// itemWithRegisterForReflectionNoFields}\r\n" + //
+				"{itemWithRegisterForReflectionNoFields.getReview2()}\r\n" + // <-- no error because it's a method
+						"{itemWithRegisterForReflectionNoFields.base}"; // <-- error because fields are ignored
+		testDiagnosticsFor(template, //
+				nativeMode,
 				d(1, 39, 1, 43, QuteErrorCode.ForbiddenByRegisterForReflectionFields,
 						"The field `base` of `org.acme.ItemWithRegisterForReflectionNoFields` Java type cannot be used in native image mode because Java type is annotated with `@RegisterForReflection(fields = false)`.",
 						DiagnosticSeverity.Error));
@@ -182,7 +332,7 @@ public class QuteDiagnosticsInNativeModeTest {
 
 	@Test
 	public void registerForReflectionNoMethods() {
-
+		boolean nativeMode = false;
 		// @RegisterForReflection(methods = false)
 		// public class ItemWithRegisterForReflectionNoMethods
 		String template = // "{@org.acme.ItemWithRegisterForReflectionNoMethods
@@ -190,33 +340,66 @@ public class QuteDiagnosticsInNativeModeTest {
 				"{itemWithRegisterForReflectionNoMethods.getReview2()}\r\n" + // <-- error because methods are ignored
 						"{itemWithRegisterForReflectionNoMethods.base}"; // <-- no error because it's a field
 		testDiagnosticsFor(template, //
+				nativeMode);
+	}
+
+	@Test
+	public void registerForReflectionNoMethodsInNativeMode() {
+		boolean nativeMode = true;
+		// @RegisterForReflection(methods = false)
+		// public class ItemWithRegisterForReflectionNoMethods
+		String template = // "{@org.acme.ItemWithRegisterForReflectionNoMethods
+							// itemWithRegisterForReflectionNoMethods}\r\n" + //
+				"{itemWithRegisterForReflectionNoMethods.getReview2()}\r\n" + // <-- error because methods are ignored
+						"{itemWithRegisterForReflectionNoMethods.base}"; // <-- no error because it's a field
+		testDiagnosticsFor(template, //
+				nativeMode,
 				d(0, 40, 0, 50, QuteErrorCode.ForbiddenByRegisterForReflectionMethods,
 						"The method `getReview2` of `org.acme.ItemWithRegisterForReflectionNoMethods` Java type cannot be used in native image mode because Java type is annotated with `@RegisterForReflection(methods = false)`.",
 						DiagnosticSeverity.Error));
 	}
-
 	@Test
 	public void registerForReflectionMethod() {
+		boolean nativeMode = false;
 		// public class Item
-		String template = //"{@org.acme.Review review}\r\n" + //
+		String template = // "{@org.acme.Review review}\r\n" + //
 				"{review.getReviews()}";
 		testDiagnosticsFor(template, //
+				nativeMode);
+
+		// @RegisterForReflection
+		// public class ItemWithRegisterForReflection
+		template = // "{@org.acme.ItemWithRegisterForReflection itemWithRegisterForReflection}\r\n"
+					// + //
+				"{itemWithRegisterForReflection.getReview2()}";
+		testDiagnosticsFor(template, nativeMode);
+	}
+	
+	@Test
+	public void registerForReflectionMethodInNativeMode() {
+		boolean nativeMode = true;
+		// public class Item
+		String template = // "{@org.acme.Review review}\r\n" + //
+				"{review.getReviews()}";
+		testDiagnosticsFor(template, //
+				nativeMode,
 				d(0, 8, 0, 18, QuteErrorCode.MethodNotSupportedInNativeMode,
 						"Method `getReviews` of `org.acme.Review` Java type cannot be used in native image mode.",
 						DiagnosticSeverity.Error));
 
 		// @RegisterForReflection
 		// public class ItemWithRegisterForReflection
-		template = // "{@org.acme.ItemWithRegisterForReflection itemWithRegisterForReflection}\r\n" + //
+		template = // "{@org.acme.ItemWithRegisterForReflection itemWithRegisterForReflection}\r\n"
+					// + //
 				"{itemWithRegisterForReflection.getReview2()}";
-		testDiagnosticsFor(template);
+		testDiagnosticsFor(template, nativeMode);
 	}
 
-	private static void testDiagnosticsFor(String value, Diagnostic... expected) {
+	private static void testDiagnosticsFor(String value, boolean nativeMode, Diagnostic... expected) {
 		String templateUri = QuteQuickStartProject.NATIVEITEMRESOURCE_ITEMS_TEMPLATE_URI;
 
 		QuteNativeSettings nativeImagesSettings = new QuteNativeSettings();
-		nativeImagesSettings.setEnabled(true);
+		nativeImagesSettings.setEnabled(nativeMode);
 
 		QuteValidationSettings validationSettings = new QuteValidationSettings();
 

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsWithArraysTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/QuteDiagnosticsWithArraysTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+* Copyright (c) 2025 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.diagnostics;
+
+import static com.redhat.qute.QuteAssert.testDiagnosticsFor;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test with arrays.
+ *
+ * @author Angelo ZERR
+ * @see https://quarkus.io/guides/qute-reference#arrays
+ */
+public class QuteDiagnosticsWithArraysTest {
+
+	@Test
+	public void arrays() throws Exception {
+		String template = "{@java.lang.String[] myArray}\r\n"
+				+ "<h1>Array of length: {myArray.length}</h1> \r\n"
+				+ "<ul>\r\n"
+				+ "  <li>First: {myArray.0}</li> \r\n"
+				+ "  <li>Second: {myArray[1]}</li> \r\n"
+				+ "  <li>Third: {myArray.get(2)}</li> \r\n"
+				+ "</ul>\r\n"
+				+ "<ol>\r\n"
+				+ " {#for element in myArray}\r\n"
+				+ " <li>{element}</li>\r\n"
+				+ " {/for}\r\n"
+				+ "</ol>\r\n"
+				+ "First two elements: {#each myArray.take(2)}{it}{/each}";
+		testDiagnosticsFor(template);
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/sandbox/TestItCountQute.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/sandbox/TestItCountQute.java
@@ -1,0 +1,47 @@
+package sandbox;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+
+import io.quarkus.qute.Engine;
+import io.quarkus.qute.ReflectionValueResolver;
+import io.quarkus.qute.Template;
+
+public class TestItCountQute {
+
+	public static void main(String[] args) {
+
+		List<Item> items=new ArrayList<>();
+		for (int i = 0; i < 5; i++) {
+			Item item = new Item(i);
+			items.add(item);
+			for (int j = 0; j <7; j++) {
+				item.addReview(new Review(j));
+			}
+		}
+		
+		
+		Map<String, Object> data = new HashMap<>();
+		data.put("items", items);
+		data.put("foo", 1);
+		
+		Engine engine = Engine.builder().addDefaults().addValueResolver(new ReflectionValueResolver()).build();
+		
+		Template template = engine.parse(convertStreamToString(TestItCountQute.class.getResourceAsStream("it_count.qute.html")));
+		String s = template.data(data).render();
+
+		System.err.println(s);
+
+	}
+
+	private static String convertStreamToString(InputStream is) {
+		try (Scanner s = new java.util.Scanner(is)) {
+			s.useDelimiter("\\A");
+			return s.hasNext() ? s.next() : "";
+		}
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/sandbox/it_count.qute.html
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/sandbox/it_count.qute.html
@@ -1,0 +1,3 @@
+{#each items}
+    {foo - foo}
+{/each}


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-quarkus/issues/974

Here a sample which doesn't report false positive error:

```
{@int foo}
{@int[] bar}

{foo mod 10 + 58 + foo.mod(10) - 9999 minus 7}

{bar.0 + 10 - 7}

{#for item in bar}
  {item + 7 + item_count - 7 minus 88}
{/for}
```

The fix is done to support correctly matchNames used in TemplateExtension.

This `+` is managed with https://github.com/quarkusio/quarkus/blob/91c8a5b95d900917039190985e9ed84e1af75eba/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/extensions/NumberTemplateExtensions.java#L17

By fixing matchName support it allows to support features like diagnostic, completion, hover, definition, etc

Here a demo

![QuteNumebrSupport](https://github.com/user-attachments/assets/a3560ac5-0a2a-4147-a588-ba1321eae6bd)
