### PR TITLE
Guard against IOOBE for Optional returning method of ConfigMapped type.

### DIFF
--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/core/properties/QuarkusConfigMappingProvider.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/core/properties/QuarkusConfigMappingProvider.java
@@ -147,7 +147,11 @@ public class QuarkusConfigMappingProvider extends AbstractAnnotationTypeReferenc
 					// it's an optional type
 					// Optional<List<String>> databases();
 					// extract the type List<String>
-					returnTypeSignature = org.eclipse.jdt.core.Signature.getTypeArguments(returnTypeSignature)[0];
+					String[] typeArguments = org.eclipse.jdt.core.Signature.getTypeArguments(returnTypeSignature);
+					if (typeArguments.length < 1) {
+						continue;
+					}
+					returnTypeSignature = typeArguments[0];
 					resolvedTypeSignature = JavaModelUtil.getResolvedTypeName(returnTypeSignature, configMappingType);
 				}
 
@@ -194,8 +198,12 @@ public class QuarkusConfigMappingProvider extends AbstractAnnotationTypeReferenc
 					} else if (isCollection(returnType, resolvedTypeSignature)) {
 						// List<String>, List<App>
 						propertyName += "[*]"; // Generate indexed property.
-						String genericTypeName = org.eclipse.jdt.core.Signature
-								.getTypeArguments(returnTypeSignature)[0];
+						String[] typeArguments = org.eclipse.jdt.core.Signature
+								.getTypeArguments(returnTypeSignature);
+						if (typeArguments.length < 1) {
+							continue;
+						}
+						String genericTypeName = typeArguments[0];
 						resolvedTypeSignature = JavaModelUtil.getResolvedTypeName(genericTypeName, configMappingType);
 						returnType = findType(method.getJavaProject(), resolvedTypeSignature);
 						simpleType = isSimpleType(resolvedTypeSignature, returnType);


### PR DESCRIPTION
- When a type uses the ConfigMapping annotation, we populate properties for its methods. For methods with an Optional<..> return type we attempt to determine the type parameter for the Optional. This may fail so we should guard against that

Haven't been able to reproduce, but this is just something I ran into randomly.

<details>
<summary>stacktrace</summary>

```
message: Apr 10, 2025 1:37:47 P.M. org.eclipse.lsp4mp.jdt.core.AbstractAnnotationTypeReferencePropertiesProvider collectProperties
    SEVERE: NativeConfig
    java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
    	at com.redhat.microprofile.jdt.internal.quarkus.core.properties.QuarkusConfigMappingProvider.populateConfigObject(QuarkusConfigMappingProvider.java:150)
    	at com.redhat.microprofile.jdt.internal.quarkus.core.properties.QuarkusConfigMappingProvider.populateConfigObject(QuarkusConfigMappingProvider.java:212)
    	at com.redhat.microprofile.jdt.internal.quarkus.core.properties.QuarkusConfigMappingProvider.processConfigMapping(QuarkusConfigMappingProvider.java:117)
    	at com.redhat.microprofile.jdt.internal.quarkus.core.properties.QuarkusConfigMappingProvider.processAnnotation(QuarkusConfigMappingProvider.java:86)
    	at org.eclipse.lsp4mp.jdt.core.AbstractAnnotationTypeReferencePropertiesProvider.processAnnotation(AbstractAnnotationTypeReferencePropertiesProvider.java:183)
    	at org.eclipse.lsp4mp.jdt.core.AbstractAnnotationTypeReferencePropertiesProvider.processAnnotation(AbstractAnnotationTypeReferencePropertiesProvider.java:159)
    	at org.eclipse.lsp4mp.jdt.core.AbstractAnnotationTypeReferencePropertiesProvider.collectProperties(AbstractAnnotationTypeReferencePropertiesProvider.java:115)
    	at org.eclipse.lsp4mp.jdt.core.PropertiesManager.collectProperties(PropertiesManager.java:261)
    	at org.eclipse.lsp4mp.jdt.core.PropertiesManager$1.acceptSearchMatch(PropertiesManager.java:237)
    	at org.eclipse.jdt.internal.core.search.matching.MatchLocator.report(MatchLocator.java:2218)
    	at org.eclipse.jdt.internal.core.search.matching.TypeReferenceLocator.matchReportReference(TypeReferenceLocator.java:541)
    	at org.eclipse.jdt.internal.core.search.matching.TypeReferenceLocator.matchReportReference(TypeReferenceLocator.java:370)
    	at org.eclipse.jdt.internal.core.search.matching.OrLocator.matchReportReference(OrLocator.java:296)
    	at org.eclipse.jdt.internal.core.search.matching.MatchLocator.reportMatching(MatchLocator.java:2724)
    	at org.eclipse.jdt.internal.core.search.matching.MatchLocator.reportMatching(MatchLocator.java:3183)
    	at org.eclipse.jdt.internal.core.search.matching.MatchLocator.reportMatching(MatchLocator.java:2890)
    	at org.eclipse.jdt.internal.core.search.matching.MatchLocator.process(MatchLocator.java:2073)
    	at org.eclipse.jdt.internal.core.search.matching.MatchLocator.locateMatchesDefaultImpl(MatchLocator.java:1366)
    	at org.eclipse.jdt.internal.core.search.matching.MatchLocator.locateMatches(MatchLocator.java:1285)
    	at org.eclipse.jdt.internal.core.search.matching.MatchLocator.locateMatches(MatchLocator.java:1403)
    	at org.eclipse.jdt.internal.core.search.matching.MatchLocator.locateMatches(MatchLocator.java:1524)
    	at org.eclipse.jdt.internal.core.search.JavaSearchParticipant.locateMatches(JavaSearchParticipant.java:143)
    	at org.eclipse.jdt.internal.core.search.BasicSearchEngine.findMatches(BasicSearchEngine.java:276)
    	at org.eclipse.jdt.internal.core.search.BasicSearchEngine.search(BasicSearchEngine.java:620)
    	at org.eclipse.jdt.core.search.SearchEngine.search(SearchEngine.java:677)
    	at org.eclipse.lsp4mp.jdt.core.PropertiesManager.scanJavaClasses(PropertiesManager.java:221)
    	at org.eclipse.lsp4mp.jdt.core.PropertiesManager.getMicroProfileProjectInfo(PropertiesManager.java:145)
    	at org.eclipse.lsp4mp.jdt.core.PropertiesManager.getMicroProfileProjectInfo(PropertiesManager.java:113)
    	at org.eclipse.lsp4mp.jdt.core.PropertiesManager.getMicroProfileProjectInfo(PropertiesManager.java:104)
    	at org.eclipse.lsp4mp.jdt.internal.core.ls.MicroProfileDelegateCommandHandler.lambda$0(MicroProfileDelegateCommandHandler.java:110)
    	at org.eclipse.core.runtime.jobs.Job$2.run(Job.java:187)
    	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
```
</details>