### PR TITLE
Disable getMethodJavadocCyclic test by waiting for https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4672

### DIFF
--- a/qute.jdt/com.redhat.qute.jdt.test/src/main/java/com/redhat/qute/jdt/template/TemplateGetJavadocTest.java
+++ b/qute.jdt/com.redhat.qute.jdt.test/src/main/java/com/redhat/qute/jdt/template/TemplateGetJavadocTest.java
@@ -94,7 +94,8 @@ public class TemplateGetJavadocTest {
 		assertEquals(expected, actual);
 	}
 	
-	@Test
+	// @Test
+	// Re-enable test when https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4672 will be fixed.
 	public void getMethodJavadocCyclic() throws Exception {
 		loadMavenProject(QuteMavenProjectName.qute_quickstart);
 


### PR DESCRIPTION
Disable getMethodJavadocCyclic test by waiting for https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4672