### PR TITLE
fix: don't report false positive error when @TemplateContents is declared

### DIFF
--- a/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-record/src/main/java/org/acme/sample/HelloResource.java
+++ b/qute.jdt/com.redhat.qute.jdt.test/projects/maven/qute-record/src/main/java/org/acme/sample/HelloResource.java
@@ -7,7 +7,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-
+import io.quarkus.qute.TemplateContents;
 import io.quarkus.qute.TemplateInstance;
 
 @Path("hello")
@@ -21,6 +21,9 @@ public class HelloResource {
 
     @CheckedTemplate(basePath="Foo", defaultName=CheckedTemplate.HYPHENATED_ELEMENT_NAME)
     record HelloWorld(String name) implements TemplateInstance {}
+
+    @TemplateContents("Hello {name}!")
+    record HelloWithTemplateContents(String name) implements TemplateInstance {}
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/QuteJavaConstants.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/QuteJavaConstants.java
@@ -63,7 +63,7 @@ public class QuteJavaConstants {
 	public static final String TEMPLATE_EXTENSION_ANNOTATION_MATCH_NAME = "matchName";
 
 	public static final String TEMPLATE_EXTENSION_ANNOTATION_MATCH_NAMES = "matchNames";
-	
+
 	// @TemplateData
 
 	public static final String TEMPLATE_DATA_ANNOTATION = "io.quarkus.qute.TemplateData";
@@ -97,6 +97,10 @@ public class QuteJavaConstants {
 	public static final String REGISTER_FOR_REFLECTION_ANNOTATION_METHODS = "methods";
 
 	public static final String REGISTER_FOR_REFLECTION_ANNOTATION_TARGETS = "targets";
+
+	// @TemplateContents
+
+	public static final String TEMPLATE_CONTENTS_ANNOTATION = "io.quarkus.qute.TemplateContents";
 
 	// @Message
 	public static final String MESSAGE_BUNDLE_ANNOTATION = "io.quarkus.qute.i18n.MessageBundle";

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/java/AbstractQuteTemplateLinkCollector.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/java/AbstractQuteTemplateLinkCollector.java
@@ -19,6 +19,7 @@ import static com.redhat.qute.jdt.internal.QuteJavaConstants.CHECKED_TEMPLATE_AN
 import static com.redhat.qute.jdt.internal.QuteJavaConstants.CHECKED_TEMPLATE_ANNOTATION_IGNORE_FRAGMENTS;
 import static com.redhat.qute.jdt.internal.QuteJavaConstants.OLD_CHECKED_TEMPLATE_ANNOTATION;
 import static com.redhat.qute.jdt.internal.QuteJavaConstants.TEMPLATE_CLASS;
+import static com.redhat.qute.jdt.internal.QuteJavaConstants.TEMPLATE_CONTENTS_ANNOTATION;
 
 import java.util.List;
 import java.util.logging.Level;
@@ -210,7 +211,7 @@ public abstract class AbstractQuteTemplateLinkCollector extends ASTVisitor {
 	 */
 	@Override
 	public boolean visit(RecordDeclaration node) {
-		if (isImplementTemplateInstance(node)) {
+		if (isImplementTemplateInstance(node) && !isTemplateContents(node)) {
 			// public class HelloResource {
 			// record Hello(String name) implements TemplateInstance {}
 			String recordName = node.getName().getIdentifier();
@@ -244,6 +245,19 @@ public abstract class AbstractQuteTemplateLinkCollector extends ASTVisitor {
 		for (ITypeBinding current : interfaces) {
 			if (QuteJavaConstants.TEMPLATE_INSTANCE_INTERFACE.equals(current.getQualifiedName())) {
 				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean isTemplateContents(RecordDeclaration node) {
+		List modifiers = node.modifiers();
+		for (Object modifier : modifiers) {
+			if (modifier instanceof Annotation) {
+				Annotation annotation = (Annotation) modifier;
+				if (AnnotationUtils.isMatchAnnotation(annotation, TEMPLATE_CONTENTS_ANNOTATION)) {
+					return true;
+				}
 			}
 		}
 		return false;


### PR DESCRIPTION
fix: don't report false positive error when @TemplateContents is declared

![TemplateContentsDemo](https://github.com/user-attachments/assets/b7e9213c-85d1-42c2-abdf-2a1264ddd177)
