### PR TITLE
Support for Roq Data files

### DIFF
--- a/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/core/properties/QuarkusConfigMappingProvider.java
+++ b/quarkus.jdt.ext/com.redhat.microprofile.jdt.quarkus/src/main/java/com/redhat/microprofile/jdt/internal/quarkus/core/properties/QuarkusConfigMappingProvider.java
@@ -173,8 +173,9 @@ public class QuarkusConfigMappingProvider extends AbstractAnnotationTypeReferenc
 		for (IJavaElement child : elements) {
 			if (child.getElementType() == IJavaElement.METHOD) {
 				IMethod method = (IMethod) child;
-				if (Flags.isDefaultMethod(method.getFlags()) || method.getNumberOfParameters() > 0
-						|| "void".equals(method.getReturnType()) || "<clinit>".equals(method.getElementName())) {
+				if (Flags.isDefaultMethod(method.getFlags()) || Flags.isStatic(method.getFlags())
+						|| method.getNumberOfParameters() > 0 || "void".equals(method.getReturnType())
+						|| "<clinit>".equals(method.getElementName())) {
 					continue;
 				}
 

--- a/qute.jdt/com.redhat.qute.jdt/META-INF/MANIFEST.MF
+++ b/qute.jdt/com.redhat.qute.jdt/META-INF/MANIFEST.MF
@@ -30,5 +30,6 @@ Export-Package: com.redhat.qute.commons,
  com.redhat.qute.jdt.internal.ls;x-friends:="com.redhat.qute.jdt.test",
  com.redhat.qute.jdt.internal.template;x-friends:="com.redhat.qute.jdt.test",
  com.redhat.qute.jdt.template.datamodel,
+ com.redhat.qute.jdt.template.project,
  com.redhat.qute.jdt.utils
 Bundle-Activator: com.redhat.qute.jdt.QutePlugin

--- a/qute.jdt/com.redhat.qute.jdt/plugin.properties
+++ b/qute.jdt/com.redhat.qute.jdt/plugin.properties
@@ -13,6 +13,7 @@
 pluginName=JDT Qute Extension
 providerName=Red Hat
 
+projectFeatureProviders.name=Project Features
 templateRootPathProviders.name=Template Root Path Providers
 dataModelProviders.name=Data model providers
 resolvedJavaTypeFactoriesName=Resolved Java Type Factories

--- a/qute.jdt/com.redhat.qute.jdt/plugin.xml
+++ b/qute.jdt/com.redhat.qute.jdt/plugin.xml
@@ -2,6 +2,9 @@
 <?eclipse version="3.5"?>
 <plugin>
 
+   <extension-point id="projectFeatureProviders"
+					name="%projectFeatureProviders.name"
+					schema="schema/projectFeatureProviders.exsd" />
    <extension-point id="templateRootPathProviders"
 					name="%templateRootPathProviders.name"
 					schema="schema/templateRootPathProviders.exsd" />
@@ -76,15 +79,16 @@
 
    <!-- =========== Renarde extension =========== -->
 
+   <extension point="com.redhat.qute.jdt.projectFeatureProviders">
+      <provider class="com.redhat.qute.jdt.internal.extensions.renarde.RenardeProjectFeatureProvider" />
+   </extension>
+
    <!-- Data model providers for Quarkus Renarde -->
    <extension point="com.redhat.qute.jdt.dataModelProviders">
       <provider namespaces="uri,uriabs"
                 description="In order to generate the URI to an endpoint, in a Qute view, you can use the `uri` and `uriabs` namespace with a call to the endpoint you want to point to."
                 url="https://github.com/quarkiverse/quarkus-renarde/blob/main/docs/modules/ROOT/pages/index.adoc#obtaining-a-uri-in-qute-views"
                 class="com.redhat.qute.jdt.internal.extensions.renarde.UriNamespaceResolverSupport" />
-   </extension>
-
-   <extension point="com.redhat.qute.jdt.dataModelProviders">
       <provider namespaces="m"
                 description="Localisation / Internationalisation."
                 url="https://docs.quarkiverse.io/quarkus-renarde/dev/advanced.html#localisation"
@@ -97,7 +101,11 @@
    </extension>
 
    <!-- =========== Roq extension =========== -->
-   
+
+   <extension point="com.redhat.qute.jdt.projectFeatureProviders">
+      <provider class="com.redhat.qute.jdt.internal.extensions.roq.RoqProjectFeatureProvider" />
+   </extension>
+
    <extension point="com.redhat.qute.jdt.dataModelProviders">
       <provider class="com.redhat.qute.jdt.internal.extensions.roq.RoqDataModelProvider" />
       <provider class="com.redhat.qute.jdt.internal.extensions.roq.DataMappingSupport" />

--- a/qute.jdt/com.redhat.qute.jdt/schema/projectFeatureProviders.exsd
+++ b/qute.jdt/com.redhat.qute.jdt/schema/projectFeatureProviders.exsd
@@ -1,0 +1,89 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="com.redhat.qute.jdt" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="com.redhat.qute.jdt" id="projectFeatureProviders" name="Project Feature Providers"/>
+      </appinfo>
+      <documentation>
+         This extension point allows adding a project feature provider.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="provider"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="provider">
+      <annotation>
+         <documentation>
+            Project feature provider
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Name of a class that implements IProjectFeatureProvider
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":com.redhat.qute.jdt.template.project.IProjectFeatureProvider"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         The following is an example of a project feature providers extension:
+
+&lt;pre&gt;
+  &lt;extension point=&quot;com.redhat.qute.jdt.projectFeatureProviders&quot;&gt;
+    &lt;provider class=&quot;com.redhat.qute.jdt.internal.extensions.renarde.RenardeProjectFeatureProvider&quot; /&gt;
+  &lt;/extension&gt;
+&lt;/pre&gt;
+      </documentation>
+   </annotation>
+
+
+
+
+</schema>

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/FileUtils.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/FileUtils.java
@@ -77,9 +77,13 @@ public class FileUtils {
 			return null;
 		}
 		if (fileURi.isAbsolute()) {
+			// Real usecase
+			// ex: uriString = file://C/Users/XXX/renarde/src/main/resources
 			return new File(fileURi).toPath();
 		}
-		return new File(uriString).toPath();
+		// Usecase coming from Tests
+		// ex: uriString = src/test/resources/projects/renarde/src/main/resources
+		return new File(uriString).toPath().toAbsolutePath().normalize();
 	}
 
 	public static String toUri(Path path) {

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/JavaElementInfo.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/JavaElementInfo.java
@@ -25,6 +25,8 @@ public abstract class JavaElementInfo {
 
 	private String documentation;
 
+	private transient ResolvedJavaTypeInfo resolvedType;
+
 	/**
 	 * Returns the Java element signature.
 	 *
@@ -41,6 +43,25 @@ public abstract class JavaElementInfo {
 	 */
 	public void setSignature(String signature) {
 		this.signature = signature;
+	}
+
+	/**
+	 * Determines whether the Javadoc must be loaded for this Java element.
+	 * <p>
+	 * The Javadoc should be loaded only if:
+	 * <ul>
+	 * <li>the Java element type has not been resolved yet</li>
+	 * <li>and no documentation is currently available</li>
+	 * </ul>
+	 * </p>
+	 *
+	 * @return {@code true} if the Javadoc must be loaded, {@code false} otherwise.
+	 */
+	public boolean shouldLoadDocumentation() {
+		if (isTypeResolved()) {
+			return false;
+		}
+		return getDocumentation() == null;
 	}
 
 	/**
@@ -118,7 +139,7 @@ public abstract class JavaElementInfo {
 		StringBuilder result = new StringBuilder();
 		for (int i = 0; i < type.length(); i++) {
 			char c = type.charAt(i);
-			switch(c) {
+			switch (c) {
 			case '.':
 				lastIndex = i;
 				break;
@@ -127,7 +148,7 @@ public abstract class JavaElementInfo {
 				result.append(type.substring(lastIndex + 1, i + 1));
 				lastIndex = i;
 				break;
-			}			
+			}
 		}
 		if (lastIndex != type.length()) {
 			result.append(type.substring(lastIndex + 1, type.length()));
@@ -135,4 +156,38 @@ public abstract class JavaElementInfo {
 		return result.toString();
 	}
 
+	/**
+	 * Indicates whether the Java element type has been resolved.
+	 *
+	 * @return {@code true} if the Java element type is resolved, {@code false}
+	 *         otherwise.
+	 */
+	public final boolean isTypeResolved() {
+		return resolvedType != null;
+	}
+
+	/**
+	 * Returns the resolved Java type information for this element.
+	 *
+	 * @return the resolved Java type information, or {@code null} if the type has
+	 *         not been resolved yet.
+	 */
+	public final ResolvedJavaTypeInfo getResolvedType() {
+		return resolvedType;
+	}
+
+	/**
+	 * Sets the resolved Java type information for this element.
+	 * <p>
+	 * Once the type is resolved, the element is considered fully typed and
+	 * additional metadata (such as documentation) does not need to be loaded lazily
+	 * anymore.
+	 * </p>
+	 *
+	 * @param resolvedType the resolved Java type information to associate with this
+	 *                     element, or {@code null} to clear the resolved state
+	 */
+	public void setResolvedType(ResolvedJavaTypeInfo resolvedType) {
+		this.resolvedType = resolvedType;
+	}
 }

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/JavaElementKind.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/JavaElementKind.java
@@ -22,5 +22,6 @@ public enum JavaElementKind {
 	TYPE, //
 	FIELD, //
 	METHOD, //
-	PARAMETER;
+	PARAMETER, //
+	CUSTOM;
 }

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/JavaTypeInfo.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/JavaTypeInfo.java
@@ -142,7 +142,7 @@ public class JavaTypeInfo extends JavaElementInfo {
 	public void setInvalidMethods(Map<String /* method name */, InvalidMethodReason> invalidMethods) {
 		this.invalidMethods = invalidMethods;
 	}
-	
+
 	public Map<String, InvalidMethodReason> getInvalidMethods() {
 		return invalidMethods;
 	}
@@ -161,8 +161,11 @@ public class JavaTypeInfo extends JavaElementInfo {
 	 * @return the java type parameters.
 	 */
 	public List<JavaParameterInfo> getTypeParameters() {
+		String signature = super.getSignature();
+		if (signature == null && isTypeResolved()) {
+			return Collections.emptyList();
+		}
 		if (parameters == null) {
-			String signature = super.getSignature();
 			int index = signature.indexOf('<');
 			if (index == -1) {
 				name = signature;
@@ -224,6 +227,9 @@ public class JavaTypeInfo extends JavaElementInfo {
 	 * @return true if the java type is a generic type and false otherwise.
 	 */
 	public boolean isGenericType() {
+		if (isTypeResolved()) {
+			return false;
+		}
 		if (isSingleGenericType()) {
 			return true;
 		}
@@ -280,7 +286,8 @@ public class JavaTypeInfo extends JavaElementInfo {
 	 *         otherwise.
 	 */
 	public boolean isArray() {
-		return getName().endsWith("[]");
+		String name = getName();
+		return name != null && name.endsWith("[]");
 	}
 
 	/**

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/ProjectFeature.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/ProjectFeature.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.qute.commons;
+
+/**
+ * Enum representing a project feature supported by the Qute Language Server.
+ * 
+ * <p>This enum is used to indicate which features or frameworks a Qute project
+ * has enabled or is compatible with. Examples of features include:
+ * <ul>
+ *     <li>{@link #Renarde} - Support for Renarde templates</li>
+ *     <li>{@link #Roq} - Support for Roq templates</li>
+ * </ul>
+ * 
+ * <p>Features are typically used in {@link com.redhat.qute.commons.ProjectInfo}
+ * to describe the capabilities of a Qute project.
+ * 
+ * <p>Example usage:
+ * <pre>{@code
+ * Set<ProjectFeature> features = EnumSet.of(ProjectFeature.Renarde, ProjectFeature.Roq);
+ * projectInfo.setFeatures(features);
+ * }</pre>
+ * 
+ * <p>Note: if integer values are used via {@link #getValue()} and {@link #forValue(int)},
+ * they can be used for serialization or compact representation.
+ * 
+ * @author Angelo ZERR
+ */
+public enum ProjectFeature {
+
+    /** Support for Renarde templates. */
+    Renarde(0),
+
+    /** Support for Roq templates. */
+    Roq(1);
+
+    /** Integer value of the feature, useful for serialization. */
+    private final int value;
+
+    /**
+     * Constructor for the enum.
+     * 
+     * @param value integer value associated with the feature
+     */
+    ProjectFeature(int value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the integer value of this feature.
+     * 
+     * @return integer value of the feature
+     */
+    public int getValue() {
+        return value;
+    }
+
+    /**
+     * Returns the {@link ProjectFeature} corresponding to a given integer value.
+     * 
+     * @param value integer value of the feature (starting at 0)
+     * @return corresponding ProjectFeature
+     * @throws IllegalArgumentException if the value does not correspond to any feature
+     */
+    public static ProjectFeature forValue(int value) {
+        ProjectFeature[] allValues = ProjectFeature.values();
+        for (ProjectFeature f : allValues) {
+            if (f.getValue() == value) {
+                return f;
+            }
+        }
+        throw new IllegalArgumentException("Illegal enum value: " + value);
+    }
+}

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/ProjectInfo.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/ProjectInfo.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
-* Copyright (c) 2021 Red Hat Inc. and others.
-* All rights reserved. This program and the accompanying materials
-* which accompanies this distribution, and is available at
-* http://www.eclipse.org/legal/epl-v20.html
-*
-* SPDX-License-Identifier: EPL-2.0
-*
-* Contributors:
-*     Red Hat Inc. - initial API and implementation
-*******************************************************************************/
+ * Copyright (c) 2021 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
 package com.redhat.qute.commons;
 
 import java.util.List;
@@ -17,103 +17,184 @@ import java.util.Set;
 /**
  * Project information where a Qute template belongs to.
  * 
- * @author Angelo ZERR
- *
+ * This class contains metadata about a Qute project, including its location,
+ * template roots, source folders, project dependencies, and supported features.
+ * 
+ * Example of features: renarde, roq, renarde-qrcode
  */
 public class ProjectInfo {
 
+	/**
+	 * The project URI (typically a file URI like file:///C:/path/to/project).
+	 */
 	private String uri;
 
+	/**
+	 * Absolute project folder URI (full path) like:
+	 * file:///C:/Users/foo/workspace/my-project
+	 */
+	private String projectFolder;
+
+	/**
+	 * List of template root paths supported by the Qute project.
+	 */
 	private List<TemplateRootPath> templateRootPaths;
 
+	/**
+	 * Set of source folders (full path) like:
+	 * file:///C:/Users/foo/project/src/main/java
+	 * file:///C:/Users/foo/project/src/main/resources
+	 */
 	private Set<String> sourceFolders;
 
+	/**
+	 * List of project dependency URIs (for multi-module projects).
+	 */
 	private List<String> projectDependencyUris;
 
+	/**
+	 * Set of detected project features. Examples: renarde, roq, renarde-qrcode
+	 */
+	private Set<ProjectFeature> features;
+
+	/**
+	 * Default constructor.
+	 */
 	public ProjectInfo() {
 	}
 
-	public ProjectInfo(String projectUri, List<String> projectDependencies, List<TemplateRootPath> templateRootPaths,
-			Set<String> sourceFolders) {
+	/**
+	 * Full constructor.
+	 *
+	 * @param projectUri          the project URI like file:///C:/path/to/project
+	 * @param projectFolder       absolute project folder URI like file:///...
+	 * @param projectDependencies list of project dependency URIs
+	 * @param templateRootPaths   list of template root paths
+	 * @param sourceFolders       set of source folders (full path) like file:///...
+	 * @param features            set of project features
+	 */
+	public ProjectInfo(String projectUri, String projectFolder, List<String> projectDependencies,
+			List<TemplateRootPath> templateRootPaths, Set<String> sourceFolders, Set<ProjectFeature> features) {
 		setUri(projectUri);
+		setProjectFolder(projectFolder);
 		setProjectDependencyUris(projectDependencies);
 		setTemplateRootPaths(templateRootPaths);
 		setSourceFolders(sourceFolders);
+		setFeatures(features);
 	}
 
+	// ------------------- Getters & Setters -------------------
+
 	/**
-	 * Returns the project Uri.
+	 * Returns the project URI.
 	 * 
-	 * @return the project Uri.
+	 * @return the project URI like file:///C:/path/to/project
 	 */
 	public String getUri() {
 		return uri;
 	}
 
 	/**
-	 * Set the project Uri.
+	 * Sets the project URI.
 	 * 
-	 * @param uri the project Uri.
+	 * @param uri the project URI like file:///C:/path/to/project
 	 */
 	public void setUri(String uri) {
 		this.uri = uri;
 	}
 
 	/**
-	 * Returns the project dependency Uris.
+	 * Returns the absolute project folder URI.
 	 * 
-	 * @return the project dependency Uris.
+	 * @return the project folder URI like file:///C:/Users/foo/workspace/my-project
 	 */
-	public List<String> getProjectDependencyUris() {
-		return projectDependencyUris;
+	public String getProjectFolder() {
+		return projectFolder;
 	}
 
 	/**
-	 * Set the project dependency Uris.
+	 * Sets the absolute project folder URI.
 	 * 
-	 * @param projectDependencyUris the project dependency Uris.
+	 * @param projectFolder the project folder URI like
+	 *                      file:///C:/Users/foo/workspace/my-project
 	 */
-	public void setProjectDependencyUris(List<String> projectDependencyUris) {
-		this.projectDependencyUris = projectDependencyUris;
+	public void setProjectFolder(String projectFolder) {
+		this.projectFolder = projectFolder;
 	}
 
 	/**
-	 * Returns the list of the template root path supported by the Qute project.
+	 * Returns the list of template root paths supported by the Qute project.
 	 * 
-	 * @return the list of the template root path supported by the Qute project.
+	 * @return the list of template root paths
 	 */
 	public List<TemplateRootPath> getTemplateRootPaths() {
 		return templateRootPaths;
 	}
 
 	/**
-	 * Set the list of the template root path supported by the Qute project.
+	 * Sets the list of template root paths supported by the Qute project.
 	 * 
-	 * @param templateRootPaths the list of the template root path.
+	 * @param templateRootPaths the list of template root paths
 	 */
 	public void setTemplateRootPaths(List<TemplateRootPath> templateRootPaths) {
 		this.templateRootPaths = templateRootPaths;
 	}
 
 	/**
-	 * Returns the list of source folders (full path) like
+	 * Returns the set of source folders (full paths) like:
+	 * file:///C:/Users/foo/project/src/main/java
 	 * file:///C:/Users/foo/project/src/main/resources
 	 * 
-	 * @return the list of source folders (full path) like
-	 *         file:///C:/Users/foo/project/src/main/resources
+	 * @return the set of source folders
 	 */
 	public Set<String> getSourceFolders() {
 		return sourceFolders;
 	}
 
 	/**
-	 * Set the list of source folders (full path) like
+	 * Sets the set of source folders (full paths) like:
+	 * file:///C:/Users/foo/project/src/main/java
 	 * file:///C:/Users/foo/project/src/main/resources
 	 * 
-	 * @param sourceFolders the list of source folders (full path) like
-	 *                      file:///C:/Users/foo/project/src/main/resources
+	 * @param sourceFolders the set of source folders
 	 */
 	public void setSourceFolders(Set<String> sourceFolders) {
 		this.sourceFolders = sourceFolders;
+	}
+
+	/**
+	 * Returns the list of project dependency URIs.
+	 * 
+	 * @return the project dependency URIs
+	 */
+	public List<String> getProjectDependencyUris() {
+		return projectDependencyUris;
+	}
+
+	/**
+	 * Sets the list of project dependency URIs.
+	 * 
+	 * @param projectDependencyUris the project dependency URIs
+	 */
+	public void setProjectDependencyUris(List<String> projectDependencyUris) {
+		this.projectDependencyUris = projectDependencyUris;
+	}
+
+	/**
+	 * Returns the set of detected project features.
+	 * 
+	 * @return the set of features like renarde, roq, renarde-qrcode
+	 */
+	public Set<ProjectFeature> getFeatures() {
+		return features;
+	}
+
+	/**
+	 * Sets the set of detected project features.
+	 * 
+	 * @param features the set of features like renarde, roq, renarde-qrcode
+	 */
+	public void setFeatures(Set<ProjectFeature> features) {
+		this.features = features;
 	}
 }

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/QuteTelemetryConstants.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/QuteTelemetryConstants.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.qute.commons;
+
+/**
+ * telemetry events emitted for various Qute events
+ */
+public class QuteTelemetryConstants {
+
+	/**
+	 * telemetry event to emit when a Qute template file is opened
+	 */
+	public static final String FILE_OPENED = "qute.file.opened";
+
+}

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/ResolvedJavaTypeInfo.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/ResolvedJavaTypeInfo.java
@@ -155,12 +155,12 @@ public class ResolvedJavaTypeInfo extends JavaTypeInfo {
 
 	/**
 	 * Returns true if the Java type is / or implements
-	 * "java.util.concurrent.CompletionStage"
-	 * or "io.smallrye.mutiny.Uni" and false otherwise.
+	 * "java.util.concurrent.CompletionStage" or "io.smallrye.mutiny.Uni" and false
+	 * otherwise.
 	 * 
 	 * @return true if the Java type is / or implements
-	 *         "java.util.concurrent.CompletionStage"
-	 *         or "io.smallrye.mutiny.Uni" and false otherwise.
+	 *         "java.util.concurrent.CompletionStage" or "io.smallrye.mutiny.Uni"
+	 *         and false otherwise.
 	 */
 	public boolean isWrapperType() {
 		if (isWrapperType != null) {

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/TelemetryEvent.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/commons/TelemetryEvent.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+* Copyright (c) 2023 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.commons;
+
+public class TelemetryEvent {
+    private String name;
+    private Object properties;
+
+    public TelemetryEvent(String name, Object properties) {
+        this.name = name;
+        this.properties = properties;
+    }
+
+    /**
+     * @return the name for the telemetry action performed
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return the optional properties associated with this event
+     */
+    public Object getProperties() {
+        return properties;
+    }
+}

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/QuteSupportForTemplate.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/QuteSupportForTemplate.java
@@ -116,7 +116,7 @@ public class QuteSupportForTemplate {
 			IJavaProject javaProject = getJavaProject(project);
 			if (isQuteProject(javaProject)) {
 				// It is a Qute project
-				quteProjects.add(JDTQuteProjectUtils.getProjectInfo(javaProject));
+				quteProjects.add(JDTQuteProjectUtils.getProjectInfo(javaProject, monitor));
 			}
 		}
 		return quteProjects;
@@ -136,7 +136,7 @@ public class QuteSupportForTemplate {
 		if (javaProject == null) {
 			return null;
 		}
-		return JDTQuteProjectUtils.getProjectInfo(javaProject);
+		return JDTQuteProjectUtils.getProjectInfo(javaProject, monitor);
 	}
 
 	/**

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/renarde/MNamespaceResolverSupport.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/renarde/MNamespaceResolverSupport.java
@@ -11,16 +11,14 @@
 *******************************************************************************/
 package com.redhat.qute.jdt.internal.extensions.renarde;
 
-import static com.redhat.qute.jdt.internal.extensions.renarde.RenardeJavaConstants.RENARDE_CONTROLLER_TYPE;
+import static com.redhat.qute.jdt.internal.extensions.renarde.RenardeUtils.isRenardeProject;
 
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.search.SearchMatch;
 import org.eclipse.jdt.core.search.SearchPattern;
 
 import com.redhat.qute.jdt.template.datamodel.AbstractDataModelProvider;
 import com.redhat.qute.jdt.template.datamodel.SearchContext;
-import com.redhat.qute.jdt.utils.JDTTypeUtils;
 
 /**
  * m renarde support.
@@ -37,8 +35,7 @@ public class MNamespaceResolverSupport extends AbstractDataModelProvider {
 	@Override
 	protected boolean isNamespaceAvailable(String namespace, SearchContext context, IProgressMonitor monitor) {
 		// m namespace is available only for renarde project
-		IJavaProject javaProject = context.getJavaProject();
-		return JDTTypeUtils.findType(javaProject, RENARDE_CONTROLLER_TYPE) != null;
+		return isRenardeProject(context.getJavaProject());
 	}
 
 	@Override

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/renarde/RenardeProjectFeatureProvider.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/renarde/RenardeProjectFeatureProvider.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.jdt.internal.extensions.renarde;
+
+import static com.redhat.qute.jdt.internal.extensions.renarde.RenardeUtils.isRenardeProject;
+
+import java.util.Set;
+
+import org.eclipse.jdt.core.IJavaProject;
+
+import com.redhat.qute.commons.ProjectFeature;
+import com.redhat.qute.jdt.template.project.IProjectFeatureProvider;
+
+/**
+ * Renarde project feature.
+ */
+public class RenardeProjectFeatureProvider implements IProjectFeatureProvider {
+
+	@Override
+	public void collectProjectFeatures(IJavaProject javaProject, Set<ProjectFeature> projectFeatures) {
+		if (isRenardeProject(javaProject)) {
+			projectFeatures.add(ProjectFeature.Renarde);
+		}
+
+	}
+
+}

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/renarde/RenardeUtils.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/renarde/RenardeUtils.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.jdt.internal.extensions.renarde;
+
+import org.eclipse.jdt.core.IJavaProject;
+
+import com.redhat.qute.jdt.utils.JDTTypeUtils;
+
+/**
+ * Renarde project utilities.
+ */
+public class RenardeUtils {
+
+	public static boolean isRenardeProject(IJavaProject javaProject) {
+		return JDTTypeUtils.findType(javaProject, RenardeJavaConstants.RENARDE_CONTROLLER_TYPE) != null;
+	}
+}

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/renarde/UriNamespaceResolverSupport.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/renarde/UriNamespaceResolverSupport.java
@@ -13,6 +13,7 @@ package com.redhat.qute.jdt.internal.extensions.renarde;
 
 import static com.redhat.qute.jdt.internal.QuteJavaConstants.JAVA_LANG_OBJECT_TYPE;
 import static com.redhat.qute.jdt.internal.extensions.renarde.RenardeJavaConstants.RENARDE_CONTROLLER_TYPE;
+import static com.redhat.qute.jdt.internal.extensions.renarde.RenardeUtils.isRenardeProject;
 
 import java.util.List;
 import java.util.logging.Level;
@@ -123,8 +124,7 @@ public class UriNamespaceResolverSupport extends AbstractDataModelProvider {
 	@Override
 	protected boolean isNamespaceAvailable(String namespace, SearchContext context, IProgressMonitor monitor) {
 		// uri, and uriabs are available only for renarde project
-		IJavaProject javaProject = context.getJavaProject();
-		return JDTTypeUtils.findType(javaProject, RENARDE_CONTROLLER_TYPE) != null;
+		return isRenardeProject(context.getJavaProject());
 	}
 
 	@Override

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/roq/RoqDataModelProvider.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/roq/RoqDataModelProvider.java
@@ -11,6 +11,8 @@
 *******************************************************************************/
 package com.redhat.qute.jdt.internal.extensions.roq;
 
+import static com.redhat.qute.jdt.internal.extensions.roq.RoqUtils.isRoqProject;
+
 import java.util.Arrays;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -22,7 +24,6 @@ import com.redhat.qute.commons.datamodel.DataModelTemplate;
 import com.redhat.qute.commons.datamodel.DataModelTemplateMatcher;
 import com.redhat.qute.jdt.template.datamodel.AbstractDataModelProvider;
 import com.redhat.qute.jdt.template.datamodel.SearchContext;
-import com.redhat.qute.jdt.utils.JDTTypeUtils;
 
 /**
  * Inject 'site' and 'page' as data model parameters for all Qute templates
@@ -32,7 +33,7 @@ public class RoqDataModelProvider extends AbstractDataModelProvider {
 
 	@Override
 	public void beginSearch(SearchContext context, IProgressMonitor monitor) {
-		if (JDTTypeUtils.findType(context.getJavaProject(), RoqJavaConstants.SITE_CLASS) == null) {
+		if (!isRoqProject(context.getJavaProject())) {
 			// It is not a Roq application, don't inject site and page.
 			return;
 		}

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/roq/RoqProjectFeatureProvider.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/roq/RoqProjectFeatureProvider.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.jdt.internal.extensions.roq;
+
+import static com.redhat.qute.jdt.internal.extensions.roq.RoqUtils.isRoqProject;
+
+import java.util.Set;
+
+import org.eclipse.jdt.core.IJavaProject;
+
+import com.redhat.qute.commons.ProjectFeature;
+import com.redhat.qute.jdt.template.project.IProjectFeatureProvider;
+
+/**
+ * Roq project feature.
+ */
+public class RoqProjectFeatureProvider implements IProjectFeatureProvider {
+
+	@Override
+	public void collectProjectFeatures(IJavaProject javaProject, Set<ProjectFeature> projectFeatures) {
+		if (isRoqProject(javaProject)) {
+			projectFeatures.add(ProjectFeature.Roq);
+		}
+	}
+
+}

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/roq/RoqTemplateRootPathProvider.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/roq/RoqTemplateRootPathProvider.java
@@ -13,6 +13,8 @@
 *******************************************************************************/
 package com.redhat.qute.jdt.internal.extensions.roq;
 
+import static com.redhat.qute.jdt.internal.extensions.roq.RoqUtils.isRoqProject;
+
 import java.util.List;
 
 import org.eclipse.core.resources.IProject;
@@ -20,7 +22,6 @@ import org.eclipse.jdt.core.IJavaProject;
 
 import com.redhat.qute.commons.TemplateRootPath;
 import com.redhat.qute.jdt.template.rootpath.ITemplateRootPathProvider;
-import com.redhat.qute.jdt.utils.JDTTypeUtils;
 
 /**
  * Roq template root path provider for Roq project.
@@ -29,11 +30,13 @@ public class RoqTemplateRootPathProvider implements ITemplateRootPathProvider {
 
 	private static final String ORIGIN = "roq";
 
-	private static final String[] TEMPLATES_BASE_DIRS = { "templates/", "content/", "src/main/resources/content/" };
+	private static final String[] TEMPLATES_BASE_DIRS = { "templates/", //
+			"content/", //
+			"src/main/resources/content/" };
 
 	@Override
 	public boolean isApplicable(IJavaProject javaProject) {
-		return JDTTypeUtils.findType(javaProject, RoqJavaConstants.SITE_CLASS) != null;
+		return isRoqProject(javaProject);
 	}
 
 	@Override

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/roq/RoqUtils.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/internal/extensions/roq/RoqUtils.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.jdt.internal.extensions.roq;
+
+import org.eclipse.jdt.core.IJavaProject;
+
+import com.redhat.qute.jdt.utils.JDTTypeUtils;
+
+/**
+ * Roq project utilities.
+ */
+public class RoqUtils {
+
+	public static boolean isRoqProject(IJavaProject javaProject) {
+		return JDTTypeUtils.findType(javaProject, RoqJavaConstants.SITE_CLASS) != null;
+	}
+}

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/template/project/IProjectFeatureProvider.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/template/project/IProjectFeatureProvider.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.jdt.template.project;
+
+import java.util.Set;
+
+import org.eclipse.jdt.core.IJavaProject;
+
+import com.redhat.qute.commons.ProjectFeature;
+
+/**
+ * Project feature provider API.
+ *
+ * @author Angelo ZERR
+ *
+ */
+public interface IProjectFeatureProvider {
+
+	/**
+	 * Collect project feature for the given Java project.
+	 * 
+	 * @param javaProject the Java project.
+	 */
+	void collectProjectFeatures(IJavaProject javaProject, Set<ProjectFeature> projectFeatures);
+}

--- a/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/template/project/ProjectFeatureProviderRegistry.java
+++ b/qute.jdt/com.redhat.qute.jdt/src/main/java/com/redhat/qute/jdt/template/project/ProjectFeatureProviderRegistry.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.jdt.template.project;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
+
+import com.redhat.qute.commons.ProjectFeature;
+import com.redhat.qute.jdt.internal.AbstractQuteExtensionPointRegistry;
+
+/**
+ * Registry to handle instances of {@link IProjectFeatureProvider}
+ *
+ * @author Angelo ZERR
+ */
+public class ProjectFeatureProviderRegistry extends AbstractQuteExtensionPointRegistry<IProjectFeatureProvider> {
+
+	private static final Logger LOGGER = Logger.getLogger(ProjectFeatureProviderRegistry.class.getName());
+
+	private static final String PROJECT_FEATURE_PROVIDERS_EXTENSION_POINT_ID = "projectFeatureProviders";
+	private static final ProjectFeatureProviderRegistry INSTANCE = new ProjectFeatureProviderRegistry();
+
+	private ProjectFeatureProviderRegistry() {
+		super();
+	}
+
+	public static ProjectFeatureProviderRegistry getInstance() {
+		return INSTANCE;
+	}
+
+	@Override
+	public String getProviderExtensionId() {
+		return PROJECT_FEATURE_PROVIDERS_EXTENSION_POINT_ID;
+	}
+
+	/**
+	 * Returns the project feature list for the given java project.
+	 * 
+	 * @param javaProject the java project.
+	 * @param monitor     the progress monitor.
+	 * 
+	 * @return the project feature list for the given java project.
+	 * 
+	 * @throws CoreException
+	 */
+	public Set<ProjectFeature> getProjectFeatures(IJavaProject javaProject, IProgressMonitor monitor) {
+		Set<ProjectFeature> projectFeatures = new HashSet<>();
+		for (IProjectFeatureProvider provider : super.getProviders()) {
+			try {
+				provider.collectProjectFeatures(javaProject, projectFeatures);
+			} catch (Exception e) {
+				LOGGER.log(Level.SEVERE, "Error while collecting project feature with the provider '"
+						+ provider.getClass().getName() + "'.", e);
+			}
+		}
+		return projectFeatures;
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/pom.xml
+++ b/qute.ls/com.redhat.qute.ls/pom.xml
@@ -41,6 +41,7 @@
 		<lsp4j.version>0.14.0</lsp4j.version>
 		<qute.version>3.30.1</qute.version>
 		<junit.version>5.6.1</junit.version>
+		<jackson-dataformat-yaml.version>2.18.2</jackson-dataformat-yaml.version>
 	</properties>
 
 	<build>
@@ -184,6 +185,12 @@
 			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<!-- Yaml parser ro support Roq Data file -->
+		<dependency>
+		    <groupId>com.fasterxml.jackson.dataformat</groupId>
+		    <artifactId>jackson-dataformat-yaml</artifactId>
+		    <version>${jackson-dataformat-yaml.version}</version>
+		</dependency>		
 	</dependencies>
 
     <distributionManagement>

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/JavaElementInfo.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/JavaElementInfo.java
@@ -25,6 +25,8 @@ public abstract class JavaElementInfo {
 
 	private String documentation;
 
+	private transient ResolvedJavaTypeInfo resolvedType;
+
 	/**
 	 * Returns the Java element signature.
 	 *
@@ -41,6 +43,25 @@ public abstract class JavaElementInfo {
 	 */
 	public void setSignature(String signature) {
 		this.signature = signature;
+	}
+
+	/**
+	 * Determines whether the Javadoc must be loaded for this Java element.
+	 * <p>
+	 * The Javadoc should be loaded only if:
+	 * <ul>
+	 * <li>the Java element type has not been resolved yet</li>
+	 * <li>and no documentation is currently available</li>
+	 * </ul>
+	 * </p>
+	 *
+	 * @return {@code true} if the Javadoc must be loaded, {@code false} otherwise.
+	 */
+	public boolean shouldLoadDocumentation() {
+		if (isTypeResolved()) {
+			return false;
+		}
+		return getDocumentation() == null;
 	}
 
 	/**
@@ -118,7 +139,7 @@ public abstract class JavaElementInfo {
 		StringBuilder result = new StringBuilder();
 		for (int i = 0; i < type.length(); i++) {
 			char c = type.charAt(i);
-			switch(c) {
+			switch (c) {
 			case '.':
 				lastIndex = i;
 				break;
@@ -127,7 +148,7 @@ public abstract class JavaElementInfo {
 				result.append(type.substring(lastIndex + 1, i + 1));
 				lastIndex = i;
 				break;
-			}			
+			}
 		}
 		if (lastIndex != type.length()) {
 			result.append(type.substring(lastIndex + 1, type.length()));
@@ -135,4 +156,38 @@ public abstract class JavaElementInfo {
 		return result.toString();
 	}
 
+	/**
+	 * Indicates whether the Java element type has been resolved.
+	 *
+	 * @return {@code true} if the Java element type is resolved, {@code false}
+	 *         otherwise.
+	 */
+	public final boolean isTypeResolved() {
+		return resolvedType != null;
+	}
+
+	/**
+	 * Returns the resolved Java type information for this element.
+	 *
+	 * @return the resolved Java type information, or {@code null} if the type has
+	 *         not been resolved yet.
+	 */
+	public final ResolvedJavaTypeInfo getResolvedType() {
+		return resolvedType;
+	}
+
+	/**
+	 * Sets the resolved Java type information for this element.
+	 * <p>
+	 * Once the type is resolved, the element is considered fully typed and
+	 * additional metadata (such as documentation) does not need to be loaded lazily
+	 * anymore.
+	 * </p>
+	 *
+	 * @param resolvedType the resolved Java type information to associate with this
+	 *                     element, or {@code null} to clear the resolved state
+	 */
+	public void setResolvedType(ResolvedJavaTypeInfo resolvedType) {
+		this.resolvedType = resolvedType;
+	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/JavaElementKind.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/JavaElementKind.java
@@ -22,5 +22,6 @@ public enum JavaElementKind {
 	TYPE, //
 	FIELD, //
 	METHOD, //
-	PARAMETER;
+	PARAMETER, //
+	CUSTOM;
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/JavaTypeInfo.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/JavaTypeInfo.java
@@ -142,7 +142,7 @@ public class JavaTypeInfo extends JavaElementInfo {
 	public void setInvalidMethods(Map<String /* method name */, InvalidMethodReason> invalidMethods) {
 		this.invalidMethods = invalidMethods;
 	}
-	
+
 	public Map<String, InvalidMethodReason> getInvalidMethods() {
 		return invalidMethods;
 	}
@@ -161,8 +161,11 @@ public class JavaTypeInfo extends JavaElementInfo {
 	 * @return the java type parameters.
 	 */
 	public List<JavaParameterInfo> getTypeParameters() {
+		String signature = super.getSignature();
+		if (signature == null && isTypeResolved()) {
+			return Collections.emptyList();
+		}
 		if (parameters == null) {
-			String signature = super.getSignature();
 			int index = signature.indexOf('<');
 			if (index == -1) {
 				name = signature;
@@ -224,6 +227,9 @@ public class JavaTypeInfo extends JavaElementInfo {
 	 * @return true if the java type is a generic type and false otherwise.
 	 */
 	public boolean isGenericType() {
+		if (isTypeResolved()) {
+			return false;
+		}
 		if (isSingleGenericType()) {
 			return true;
 		}
@@ -280,7 +286,8 @@ public class JavaTypeInfo extends JavaElementInfo {
 	 *         otherwise.
 	 */
 	public boolean isArray() {
-		return getName().endsWith("[]");
+		String name = getName();
+		return name != null && name.endsWith("[]");
 	}
 
 	/**

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/ProjectFeature.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/ProjectFeature.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.qute.commons;
+
+/**
+ * Enum representing a project feature supported by the Qute Language Server.
+ * 
+ * <p>This enum is used to indicate which features or frameworks a Qute project
+ * has enabled or is compatible with. Examples of features include:
+ * <ul>
+ *     <li>{@link #Renarde} - Support for Renarde templates</li>
+ *     <li>{@link #Roq} - Support for Roq templates</li>
+ * </ul>
+ * 
+ * <p>Features are typically used in {@link com.redhat.qute.commons.ProjectInfo}
+ * to describe the capabilities of a Qute project.
+ * 
+ * <p>Example usage:
+ * <pre>{@code
+ * Set<ProjectFeature> features = EnumSet.of(ProjectFeature.Renarde, ProjectFeature.Roq);
+ * projectInfo.setFeatures(features);
+ * }</pre>
+ * 
+ * <p>Note: if integer values are used via {@link #getValue()} and {@link #forValue(int)},
+ * they can be used for serialization or compact representation.
+ * 
+ * @author Angelo ZERR
+ */
+public enum ProjectFeature {
+
+    /** Support for Renarde templates. */
+    Renarde(0),
+
+    /** Support for Roq templates. */
+    Roq(1);
+
+    /** Integer value of the feature, useful for serialization. */
+    private final int value;
+
+    /**
+     * Constructor for the enum.
+     * 
+     * @param value integer value associated with the feature
+     */
+    ProjectFeature(int value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the integer value of this feature.
+     * 
+     * @return integer value of the feature
+     */
+    public int getValue() {
+        return value;
+    }
+
+    /**
+     * Returns the {@link ProjectFeature} corresponding to a given integer value.
+     * 
+     * @param value integer value of the feature (starting at 0)
+     * @return corresponding ProjectFeature
+     * @throws IllegalArgumentException if the value does not correspond to any feature
+     */
+    public static ProjectFeature forValue(int value) {
+        ProjectFeature[] allValues = ProjectFeature.values();
+        for (ProjectFeature f : allValues) {
+            if (f.getValue() == value) {
+                return f;
+            }
+        }
+        throw new IllegalArgumentException("Illegal enum value: " + value);
+    }
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/ProjectInfo.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/ProjectInfo.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
-* Copyright (c) 2021 Red Hat Inc. and others.
-* All rights reserved. This program and the accompanying materials
-* which accompanies this distribution, and is available at
-* http://www.eclipse.org/legal/epl-v20.html
-*
-* SPDX-License-Identifier: EPL-2.0
-*
-* Contributors:
-*     Red Hat Inc. - initial API and implementation
-*******************************************************************************/
+ * Copyright (c) 2021 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
 package com.redhat.qute.commons;
 
 import java.util.List;
@@ -17,103 +17,184 @@ import java.util.Set;
 /**
  * Project information where a Qute template belongs to.
  * 
- * @author Angelo ZERR
- *
+ * This class contains metadata about a Qute project, including its location,
+ * template roots, source folders, project dependencies, and supported features.
+ * 
+ * Example of features: renarde, roq, renarde-qrcode
  */
 public class ProjectInfo {
 
+	/**
+	 * The project URI (typically a file URI like file:///C:/path/to/project).
+	 */
 	private String uri;
 
+	/**
+	 * Absolute project folder URI (full path) like:
+	 * file:///C:/Users/foo/workspace/my-project
+	 */
+	private String projectFolder;
+
+	/**
+	 * List of template root paths supported by the Qute project.
+	 */
 	private List<TemplateRootPath> templateRootPaths;
 
+	/**
+	 * Set of source folders (full path) like:
+	 * file:///C:/Users/foo/project/src/main/java
+	 * file:///C:/Users/foo/project/src/main/resources
+	 */
 	private Set<String> sourceFolders;
 
+	/**
+	 * List of project dependency URIs (for multi-module projects).
+	 */
 	private List<String> projectDependencyUris;
 
+	/**
+	 * Set of detected project features. Examples: renarde, roq, renarde-qrcode
+	 */
+	private Set<ProjectFeature> features;
+
+	/**
+	 * Default constructor.
+	 */
 	public ProjectInfo() {
 	}
 
-	public ProjectInfo(String projectUri, List<String> projectDependencies, List<TemplateRootPath> templateRootPaths,
-			Set<String> sourceFolders) {
+	/**
+	 * Full constructor.
+	 *
+	 * @param projectUri          the project URI like file:///C:/path/to/project
+	 * @param projectFolder       absolute project folder URI like file:///...
+	 * @param projectDependencies list of project dependency URIs
+	 * @param templateRootPaths   list of template root paths
+	 * @param sourceFolders       set of source folders (full path) like file:///...
+	 * @param features            set of project features
+	 */
+	public ProjectInfo(String projectUri, String projectFolder, List<String> projectDependencies,
+			List<TemplateRootPath> templateRootPaths, Set<String> sourceFolders, Set<ProjectFeature> features) {
 		setUri(projectUri);
+		setProjectFolder(projectFolder);
 		setProjectDependencyUris(projectDependencies);
 		setTemplateRootPaths(templateRootPaths);
 		setSourceFolders(sourceFolders);
+		setFeatures(features);
 	}
 
+	// ------------------- Getters & Setters -------------------
+
 	/**
-	 * Returns the project Uri.
+	 * Returns the project URI.
 	 * 
-	 * @return the project Uri.
+	 * @return the project URI like file:///C:/path/to/project
 	 */
 	public String getUri() {
 		return uri;
 	}
 
 	/**
-	 * Set the project Uri.
+	 * Sets the project URI.
 	 * 
-	 * @param uri the project Uri.
+	 * @param uri the project URI like file:///C:/path/to/project
 	 */
 	public void setUri(String uri) {
 		this.uri = uri;
 	}
 
 	/**
-	 * Returns the project dependency Uris.
+	 * Returns the absolute project folder URI.
 	 * 
-	 * @return the project dependency Uris.
+	 * @return the project folder URI like file:///C:/Users/foo/workspace/my-project
 	 */
-	public List<String> getProjectDependencyUris() {
-		return projectDependencyUris;
+	public String getProjectFolder() {
+		return projectFolder;
 	}
 
 	/**
-	 * Set the project dependency Uris.
+	 * Sets the absolute project folder URI.
 	 * 
-	 * @param projectDependencyUris the project dependency Uris.
+	 * @param projectFolder the project folder URI like
+	 *                      file:///C:/Users/foo/workspace/my-project
 	 */
-	public void setProjectDependencyUris(List<String> projectDependencyUris) {
-		this.projectDependencyUris = projectDependencyUris;
+	public void setProjectFolder(String projectFolder) {
+		this.projectFolder = projectFolder;
 	}
 
 	/**
-	 * Returns the list of the template root path supported by the Qute project.
+	 * Returns the list of template root paths supported by the Qute project.
 	 * 
-	 * @return the list of the template root path supported by the Qute project.
+	 * @return the list of template root paths
 	 */
 	public List<TemplateRootPath> getTemplateRootPaths() {
 		return templateRootPaths;
 	}
 
 	/**
-	 * Set the list of the template root path supported by the Qute project.
+	 * Sets the list of template root paths supported by the Qute project.
 	 * 
-	 * @param templateRootPaths the list of the template root path.
+	 * @param templateRootPaths the list of template root paths
 	 */
 	public void setTemplateRootPaths(List<TemplateRootPath> templateRootPaths) {
 		this.templateRootPaths = templateRootPaths;
 	}
 
 	/**
-	 * Returns the list of source folders (full path) like
+	 * Returns the set of source folders (full paths) like:
+	 * file:///C:/Users/foo/project/src/main/java
 	 * file:///C:/Users/foo/project/src/main/resources
 	 * 
-	 * @return the list of source folders (full path) like
-	 *         file:///C:/Users/foo/project/src/main/resources
+	 * @return the set of source folders
 	 */
 	public Set<String> getSourceFolders() {
 		return sourceFolders;
 	}
 
 	/**
-	 * Set the list of source folders (full path) like
+	 * Sets the set of source folders (full paths) like:
+	 * file:///C:/Users/foo/project/src/main/java
 	 * file:///C:/Users/foo/project/src/main/resources
 	 * 
-	 * @param sourceFolders the list of source folders (full path) like
-	 *                      file:///C:/Users/foo/project/src/main/resources
+	 * @param sourceFolders the set of source folders
 	 */
 	public void setSourceFolders(Set<String> sourceFolders) {
 		this.sourceFolders = sourceFolders;
+	}
+
+	/**
+	 * Returns the list of project dependency URIs.
+	 * 
+	 * @return the project dependency URIs
+	 */
+	public List<String> getProjectDependencyUris() {
+		return projectDependencyUris;
+	}
+
+	/**
+	 * Sets the list of project dependency URIs.
+	 * 
+	 * @param projectDependencyUris the project dependency URIs
+	 */
+	public void setProjectDependencyUris(List<String> projectDependencyUris) {
+		this.projectDependencyUris = projectDependencyUris;
+	}
+
+	/**
+	 * Returns the set of detected project features.
+	 * 
+	 * @return the set of features like renarde, roq, renarde-qrcode
+	 */
+	public Set<ProjectFeature> getFeatures() {
+		return features;
+	}
+
+	/**
+	 * Sets the set of detected project features.
+	 * 
+	 * @param features the set of features like renarde, roq, renarde-qrcode
+	 */
+	public void setFeatures(Set<ProjectFeature> features) {
+		this.features = features;
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/ResolvedJavaTypeInfo.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/ResolvedJavaTypeInfo.java
@@ -155,12 +155,12 @@ public class ResolvedJavaTypeInfo extends JavaTypeInfo {
 
 	/**
 	 * Returns true if the Java type is / or implements
-	 * "java.util.concurrent.CompletionStage"
-	 * or "io.smallrye.mutiny.Uni" and false otherwise.
+	 * "java.util.concurrent.CompletionStage" or "io.smallrye.mutiny.Uni" and false
+	 * otherwise.
 	 * 
 	 * @return true if the Java type is / or implements
-	 *         "java.util.concurrent.CompletionStage"
-	 *         or "io.smallrye.mutiny.Uni" and false otherwise.
+	 *         "java.util.concurrent.CompletionStage" or "io.smallrye.mutiny.Uni"
+	 *         and false otherwise.
 	 */
 	public boolean isWrapperType() {
 		if (isWrapperType != null) {

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/datamodel/resolvers/ValueResolverKind.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/commons/datamodel/resolvers/ValueResolverKind.java
@@ -24,7 +24,8 @@ public enum ValueResolverKind {
 	TemplateGlobal(5), //
 	InjectedBean(6), //
 	Message(7), //
-	Renarde(8);
+	Renarde(8), //
+	File(9);
 
 	private final int value;
 

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/template/TemplateFileTextDocumentService.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/ls/template/TemplateFileTextDocumentService.java
@@ -67,6 +67,7 @@ import com.redhat.qute.ls.api.QuteProjectInfoProvider;
 import com.redhat.qute.ls.api.QuteTemplateProvider;
 import com.redhat.qute.ls.commons.ModelTextDocument;
 import com.redhat.qute.ls.commons.ValidatorDelayer;
+import com.redhat.qute.parser.injection.InjectionDetector;
 import com.redhat.qute.parser.template.Template;
 import com.redhat.qute.parser.template.TemplateParser;
 import com.redhat.qute.project.QuteProject;
@@ -101,7 +102,9 @@ public class TemplateFileTextDocumentService extends AbstractTextDocumentService
 		this.quteLanguageService = quteLanguageService;
 		this.projectRegistry = quteLanguageService.getProjectRegistry();
 		this.openedDocuments = new QuteOpenedTextDocuments((document, cancelChecker) -> {
-			return TemplateParser.parse(document, () -> cancelChecker.checkCanceled());
+			Collection<InjectionDetector> injectionDetectors = ((QuteOpenedTextDocument) document)
+					.getInjectionDetectors();
+			return TemplateParser.parse(document, injectionDetectors, () -> cancelChecker.checkCanceled());
 		}, projectInfoProvider, projectRegistry);
 		this.validatorDelayer = new ValidatorDelayer<ModelTextDocument<Template>>((template) -> {
 			triggerValidationFor((QuteTextDocument) template);

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/ASTVisitorBase.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/ASTVisitorBase.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.parser;
+
+/**
+ * A visitor for abstract syntax trees.
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public abstract class ASTVisitorBase<T extends NodeBase<T>> {
+
+	/**
+	 * Visits the given AST node prior to the type-specific visit (before
+	 * <code>visit</code>).
+	 * <p>
+	 * The default implementation does nothing. Subclasses may reimplement.
+	 * </p>
+	 *
+	 * @param node the node to visit
+	 *
+	 * @see #preVisit2(NodeBase)
+	 */
+	public void preVisit(T node) {
+		// default implementation: do nothing
+	}
+
+	/**
+	 * Visits the given AST node prior to the type-specific visit (before
+	 * <code>visit</code>).
+	 * <p>
+	 * The default implementation calls {@link #preVisit(NodeBase)} and then returns
+	 * true. Subclasses may reimplement.
+	 * </p>
+	 *
+	 * @param node the node to visit
+	 * @return <code>true</code> if <code>visit(node)</code> should be called, and
+	 *         <code>false</code> otherwise.
+	 * @see #preVisit(NodeBase)
+	 */
+	public boolean preVisit2(T node) {
+		preVisit(node);
+		return true;
+	}
+
+	/**
+	 * Visits the given AST node following the type-specific visit (after
+	 * <code>endVisit</code>).
+	 * <p>
+	 * The default implementation does nothing. Subclasses may reimplement.
+	 * </p>
+	 *
+	 * @param node the node to visit
+	 */
+	public void postVisit(T node) {
+		// default implementation: do nothing
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/CancelChecker.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/CancelChecker.java
@@ -18,6 +18,8 @@ import java.util.concurrent.CancellationException;
  */
 public interface CancelChecker {
 
+	public static final CancelChecker NO_CANCELLABLE = () -> {};
+	
 	/**
 	 * Throw a {@link CancellationException} if the currently processed request
 	 * has been canceled.

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/NodeBase.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/NodeBase.java
@@ -1,0 +1,198 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.parser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+public abstract class NodeBase<T extends NodeBase<T>> {
+
+	/**
+	 * Null value used for offset.
+	 */
+	protected static final int NULL_VALUE = -1;
+
+	private int start;
+	private int end;
+	private boolean closed;
+	private T parent;
+	private List<T> children;
+
+	public NodeBase(int start, int end) {
+		this.start = start;
+		this.end = end;
+		this.closed = false;
+	};
+
+	public int getStart() {
+		return start;
+	}
+
+	protected void setStart(int start) {
+		this.start = start;
+	}
+
+	public int getEnd() {
+		return end;
+	}
+
+	protected void setEnd(int end) {
+		this.end = end;
+	}
+
+	protected void setClosed(boolean closed) {
+		this.closed = closed;
+	}
+
+	public boolean isClosed() {
+		return closed;
+	}
+
+	protected void setParent(T parent) {
+		this.parent = parent;
+	}
+
+	public T getParent() {
+		return parent;
+	}
+
+	protected void addChild(T child) {
+		child.setParent((T) this);
+		if (children == null) {
+			children = new ArrayList<>();
+		}
+		children.add(child);
+	}
+
+	public List<T> getChildren() {
+		if (children == null) {
+			return Collections.emptyList();
+		}
+		return children;
+	}
+
+	/**
+	 * Returns node child at the given index.
+	 * 
+	 * @param index
+	 * @return node child at the given index.
+	 */
+	public T getChild(int index) {
+		return getChildren().get(index);
+	}
+
+	public int getChildCount() {
+		return getChildren().size();
+	}
+
+	public T getLastChild() {
+		return this.children != null && this.children.size() > 0 ? this.children.get(this.children.size() - 1) : null;
+	}
+
+	public T findNodeAt(int offset) {
+		List<T> children = getChildren();
+		T node = findNodeAt(children, offset);
+		return node != null ? node : (T) this;
+	}
+
+	/**
+	 * Returns the node before
+	 */
+	public T findNodeBefore(int offset) {
+		List<T> children = getChildren();
+		int idx = findFirst(children, c -> offset <= c.getStart()) - 1;
+		if (idx >= 0) {
+			T child = children.get(idx);
+			if (offset > child.getStart()) {
+				if (offset < child.getEnd()) {
+					return child.findNodeBefore(offset);
+				}
+				T lastChild = child.getLastChild();
+				if (lastChild != null && lastChild.getEnd() == child.getEnd()) {
+					return child.findNodeBefore(offset);
+				}
+				return child;
+			}
+		}
+		return (T) this;
+	}
+
+	public T getNextSibling() {
+		T parentNode = getParent();
+		if (parentNode == null) {
+			return null;
+		}
+		List<T> children = parentNode.getChildren();
+		int nextIndex = children.indexOf(this) + 1;
+		return nextIndex < children.size() ? children.get(nextIndex) : null;
+	}
+
+	public abstract String getNodeName();
+
+	// Static methods
+
+	public static <T extends NodeBase> T findNodeAt(List<T> children, int offset) {
+		int idx = findFirst(children, c -> offset <= c.getStart()) - 1;
+		if (idx >= 0) {
+			T child = children.get(idx);
+			if (isIncluded(child, offset)) {
+				return (T) child.findNodeAt(offset);
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns true if the node included the given offset and false otherwise.
+	 * 
+	 * @param node
+	 * @param offset
+	 * @return true if the node included the given offset and false otherwise.
+	 */
+	public static <T extends NodeBase> boolean isIncluded(T node, int offset) {
+		if (node == null) {
+			return false;
+		}
+		return isIncluded(node.getStart(), node.getEnd(), offset);
+	}
+
+	public static boolean isIncluded(int start, int end, int offset) {
+		return offset >= start && offset <= end;
+	}
+
+	/**
+	 * Takes a sorted array and a function p. The array is sorted in such a way that
+	 * all elements where p(x) is false are located before all elements where p(x)
+	 * is true.
+	 * 
+	 * @returns the least x for which p(x) is true or array.length if no element
+	 *          full fills the given function.
+	 */
+	private static <T> int findFirst(List<T> array, Function<T, Boolean> p) {
+		int low = 0, high = array.size();
+		if (high == 0) {
+			return 0; // no children
+		}
+		while (low < high) {
+			int mid = (int) Math.floor((low + high) / 2);
+			if (p.apply(array.get(mid))) {
+				high = mid;
+			} else {
+				low = mid + 1;
+			}
+		}
+		return low;
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/injection/InjectionDetector.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/injection/InjectionDetector.java
@@ -1,0 +1,37 @@
+package com.redhat.qute.parser.injection;
+
+import com.redhat.qute.parser.scanner.MultiLineStream;
+
+public interface InjectionDetector {
+    /**
+     * Détecte si une injection commence à la position courante du stream
+     * 
+     * @param stream le stream à la position courante
+     * @return les métadonnées de l'injection, ou null si aucune injection
+     */
+    InjectionMetadata detectInjection(MultiLineStream stream);
+    
+    /**
+     * Trouve la fin de l'injection et avance le stream jusqu'à cette position
+     * 
+     * @param stream le stream positionné au début du contenu de l'injection
+     * @return true si la fin a été trouvée, false sinon
+     */
+    boolean scanToInjectionEnd(MultiLineStream stream);
+    
+    /**
+     * Scanne le délimiteur de début de l'injection
+     * 
+     * @param stream le stream à la position courante
+     * @return true si le délimiteur a été scanné avec succès
+     */
+    boolean scanStartDelimiter(MultiLineStream stream);
+    
+    /**
+     * Scanne le délimiteur de fin de l'injection
+     * 
+     * @param stream le stream à la position courante
+     * @return true si le délimiteur a été scanné avec succès
+     */
+    boolean scanEndDelimiter(MultiLineStream stream);
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/injection/InjectionMetadata.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/injection/InjectionMetadata.java
@@ -1,0 +1,32 @@
+package com.redhat.qute.parser.injection;
+public class InjectionMetadata {
+    private final String languageId;
+    private final InjectionMode mode;
+    
+    public InjectionMetadata(String languageId, InjectionMode mode) {
+        this.languageId = languageId;
+        this.mode = mode;
+    }
+    
+    public String getLanguageId() {
+        return languageId;
+    }
+    
+    public InjectionMode getMode() {
+        return mode;
+    }
+    
+    /**
+     * Returns true if this is an embedded injection (no Qute parsing)
+     */
+    public boolean isEmbedded() {
+        return mode == InjectionMode.EMBEDDED;
+    }
+    
+    /**
+     * Returns true if this is a templated injection (Qute parsing allowed)
+     */
+    public boolean isTemplated() {
+        return mode == InjectionMode.TEMPLATED;
+    }
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/injection/InjectionMode.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/injection/InjectionMode.java
@@ -1,0 +1,6 @@
+package com.redhat.qute.parser.injection;
+
+public enum InjectionMode {
+	EMBEDDED, // No Qute parsing
+	TEMPLATED // Qute parsing allowed
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/injection/LanguageInjectionNode.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/injection/LanguageInjectionNode.java
@@ -1,0 +1,54 @@
+package com.redhat.qute.parser.injection;
+
+import com.redhat.qute.parser.template.ASTVisitor;
+import com.redhat.qute.parser.template.Node;
+import com.redhat.qute.parser.template.NodeKind;
+
+public class LanguageInjectionNode extends Node {
+
+	private final String languageId;
+
+	private int contentStart;
+	private int contentEnd;
+
+	public LanguageInjectionNode(int start, int end, String languageId) {
+		super(start, end);
+		this.languageId = languageId;
+	}
+
+	public String getLanguageId() {
+		return languageId;
+	}
+
+	public int getContentStart() {
+		return contentStart;
+	}
+
+	public void setContentStart(int contentStart) {
+		this.contentStart = contentStart;
+	}
+
+	public int getContentEnd() {
+		return contentEnd;
+	}
+
+	public void setContentEnd(int contentEnd) {
+		this.contentEnd = contentEnd;
+	}
+
+	@Override
+	public String getNodeName() {
+		return "injection";
+	}
+
+	@Override
+	protected void accept0(ASTVisitor visitor) {
+
+	}
+
+	@Override
+	public NodeKind getKind() {
+		return NodeKind.LanguageInjection;
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/injection/scanner/AbstractScannerWithInjection.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/injection/scanner/AbstractScannerWithInjection.java
@@ -1,0 +1,184 @@
+package com.redhat.qute.parser.injection.scanner;
+
+import java.util.Collection;
+
+import com.redhat.qute.parser.injection.InjectionDetector;
+import com.redhat.qute.parser.injection.InjectionMetadata;
+import com.redhat.qute.parser.scanner.AbstractScanner;
+
+public abstract class AbstractScannerWithInjection<T, S> extends AbstractScanner<T, S>
+		implements ScannerWithInjection<T, S> {
+
+	private final T languageInjectionStartToken;
+	private final T languageInjectionContentToken;
+	private final T languageInjectionEndToken;
+
+	private final Collection<InjectionDetector> injectionDetectors;
+
+	// Injection
+	private InjectionMetadata currentInjectionMetadata;
+
+	// State for managing injections
+	private boolean inInjection = false;
+	private int injectionContentStart = -1;
+	private int injectionContentEnd = -1;
+
+	protected AbstractScannerWithInjection(String input, int initialOffset, S initialState, T unknownTokenType,
+			T eosTokenType, T languageInjectionStartToken, T languageInjectionContentToken, T languageInjectionEndToken,
+			Collection<InjectionDetector> injectionDetectors) {
+		super(input, initialOffset, initialState, unknownTokenType, eosTokenType);
+		this.languageInjectionStartToken = languageInjectionStartToken;
+		this.languageInjectionContentToken = languageInjectionContentToken;
+		this.languageInjectionEndToken = languageInjectionEndToken;
+		this.injectionDetectors = injectionDetectors;
+	}
+
+	protected AbstractScannerWithInjection(String input, int initialOffset, int endOffset, S initialState,
+			T unknownTokenType, T eosTokenType, T languageInjectionStartToken, T languageInjectionContentToken,
+			T languageInjectionEndToken, Collection<InjectionDetector> injectionDetectors) {
+		super(input, initialOffset, endOffset, initialState, unknownTokenType, eosTokenType);
+		this.languageInjectionStartToken = languageInjectionStartToken;
+		this.languageInjectionContentToken = languageInjectionContentToken;
+		this.languageInjectionEndToken = languageInjectionEndToken;
+		this.injectionDetectors = injectionDetectors;
+	}
+
+	@Override
+	protected final T internalScan() {
+		int offset = stream.pos();
+		if (stream.eos()) {
+			return finishToken(offset, eosTokenType);
+		}
+		if (!injectionDetectors.isEmpty()) {
+			// Check if we should detect an injection
+			if (!inInjection) {
+				InjectionMetadata injection = detectInjectionAtCurrentPosition();
+				if (injection != null) {
+					return scanInjection(offset, injection);
+				}
+			}
+
+			// If we're in an injection, continue scanning it
+			if (inInjection) {
+				return scanInjectionContent(offset);
+			}
+		}
+
+		// Normal scanning
+		return scanNormal();
+	}
+
+	/**
+	 * Detect if an injection starts at the current position
+	 */
+	private InjectionMetadata detectInjectionAtCurrentPosition() {
+		for (InjectionDetector detector : injectionDetectors) {
+			// Save the current position
+			int savedPos = stream.pos();
+
+			InjectionMetadata metadata = detector.detectInjection(stream);
+
+			// Restore the position (detectInjection should not modify the stream)
+			stream.goBackTo(savedPos);
+
+			if (metadata != null) {
+				return metadata;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Scan the start of an injection
+	 * 
+	 * @param offset
+	 */
+	private T scanInjection(int offset, InjectionMetadata metadata) {
+		this.currentInjectionMetadata = metadata;
+
+		// Find the appropriate detector
+		InjectionDetector detector = findDetectorForMetadata(metadata);
+		if (detector == null) {
+			return eosTokenType;
+		}
+
+		// Scan the start delimiter (e.g., ---)
+		if (!detector.scanStartDelimiter(stream)) {
+			return eosTokenType;
+		}
+
+		// Now we're at the beginning of the content
+		this.injectionContentStart = stream.pos();
+
+		// Find the end of the injection
+		int savedPos = stream.pos();
+		boolean hasEnd = detector.scanToInjectionEnd(stream);
+		this.injectionContentEnd = stream.pos();
+
+		// Restore the position to the beginning of the content
+		stream.goBackTo(savedPos);
+
+		if (!hasEnd) {
+			// No end found, take until EOF
+			this.injectionContentEnd = stream.getSource().length();
+		}
+
+		this.inInjection = true;
+		return finishToken(offset, languageInjectionStartToken);
+	}
+
+	/**
+	 * Scan the content of the injection
+	 * 
+	 * @param offset
+	 */
+	private T scanInjectionContent(int offset) {
+		if (stream.pos() < injectionContentEnd) {
+			// Return all the content at once
+			stream.goBackTo(injectionContentEnd);
+			return finishToken(offset, languageInjectionContentToken);
+		} else {
+			// We've reached the end, scan the end delimiter
+			InjectionDetector detector = findDetectorForMetadata(currentInjectionMetadata);
+			if (detector != null) {
+				detector.scanEndDelimiter(stream);
+			}
+
+			this.inInjection = false;
+			this.currentInjectionMetadata = null;
+			return finishToken(offset, languageInjectionEndToken);
+		}
+	}
+
+	/**
+	 * Find the detector corresponding to the metadata
+	 */
+	private InjectionDetector findDetectorForMetadata(InjectionMetadata metadata) {
+		if (metadata == null) {
+			return null;
+		}
+
+		for (InjectionDetector detector : injectionDetectors) {
+			int savedPos = stream.pos();
+			InjectionMetadata detectorMetadata = detector.detectInjection(stream);
+			stream.goBackTo(savedPos);
+
+			if (detectorMetadata != null && detectorMetadata.getLanguageId().equals(metadata.getLanguageId())) {
+				return detector;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Normal scanning (existing code)
+	 */
+	protected abstract T scanNormal();
+
+	@Override
+	public InjectionMetadata getInjectionMetadata() {
+		return currentInjectionMetadata;
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/injection/scanner/ScannerWithInjection.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/injection/scanner/ScannerWithInjection.java
@@ -1,0 +1,10 @@
+package com.redhat.qute.parser.injection.scanner;
+
+import com.redhat.qute.parser.injection.InjectionMetadata;
+import com.redhat.qute.parser.scanner.Scanner;
+
+public interface ScannerWithInjection<T, S> extends Scanner<T, S> {
+
+	InjectionMetadata getInjectionMetadata();
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/scanner/MultiLineStream.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/scanner/MultiLineStream.java
@@ -20,8 +20,12 @@ import static com.redhat.qute.parser.scanner.Constants._WSP;
 import java.util.function.Predicate;
 
 /**
- * Multi line stream.
+ * Provides a mutable cursor over a multi-line text input.
  *
+ * <p>
+ * This class is a low-level utility used by scanners and parsers to navigate
+ * through a character stream efficiently.
+ * </p>
  */
 public class MultiLineStream {
 
@@ -29,53 +33,100 @@ public class MultiLineStream {
 		return ch == _WSP || ch == _TAB || ch == _NWL || ch == _LFD || ch == _CAR;
 	};
 
+	private static final Predicate<Integer> WHITESPACE_ONLY_PREDICATE = ch -> ch == _WSP || ch == _TAB;
+
 	private final String source;
 	private final int len;
 	private int position;
 
+	/**
+	 * Creates a new MultiLineStream over the given source text.
+	 *
+	 * @param source   the source text
+	 * @param position the initial cursor position
+	 * @param len      the maximum position (exclusive)
+	 */
 	public MultiLineStream(String source, int position, int len) {
 		this.source = source;
 		this.len = Math.min(len, source.length());
 		this.position = position;
 	}
 
+	/**
+	 * Returns true if the cursor has reached the end of the stream.
+	 *
+	 * @return true if end of stream
+	 */
 	public boolean eos() {
 		return this.len <= this.position;
 	}
 
+	/**
+	 * Returns the underlying source text.
+	 *
+	 * @return the source text
+	 */
 	public String getSource() {
 		return this.source;
 	}
 
+	/**
+	 * Returns the current cursor position.
+	 *
+	 * @return current cursor position
+	 */
 	public int pos() {
 		return this.position;
 	}
 
+	/**
+	 * Moves the cursor to a specific absolute position.
+	 *
+	 * @param pos the target position
+	 */
 	public void goBackTo(int pos) {
 		this.position = pos;
 	}
 
+	/**
+	 * Moves the cursor backward by the given number of characters.
+	 *
+	 * @param n number of characters to move back
+	 */
 	public void goBack(int n) {
 		this.position -= n;
 	}
 
+	/**
+	 * Advances the cursor forward by the given number of characters.
+	 *
+	 * @param n number of characters to advance
+	 */
 	public void advance(int n) {
 		this.position += n;
 	}
 
+	/**
+	 * Moves the cursor to the end of the stream.
+	 */
 	public void goToEnd() {
 		this.position = len;
 	}
 
+	/**
+	 * Returns the code point at the current cursor position without advancing.
+	 *
+	 * @return the current character code point, or 0 if end of stream
+	 */
 	public int peekChar() {
 		return peekChar(0);
 	}
 
 	/**
-	 * Peeks at next char at position + n. peekChar() == peekChar(0)
+	 * Returns the code point at position + n without advancing.
 	 *
-	 * @param n
-	 * @return
+	 * @param n offset from current position
+	 * @return the character code point, or 0 if out of bounds
 	 */
 	public int peekChar(int n) {
 		int pos = this.position + n;
@@ -86,10 +137,10 @@ public class MultiLineStream {
 	}
 
 	/**
-	 * Peeks at the char at position 'offset' of the whole document
+	 * Returns the code point at an absolute offset in the source.
 	 *
-	 * @param offset
-	 * @return
+	 * @param offset absolute offset
+	 * @return the character code point, or 0 if out of bounds
 	 */
 	public int peekCharAtOffset(int offset) {
 		if (offset >= len || offset < 0) {
@@ -98,6 +149,12 @@ public class MultiLineStream {
 		return this.source.codePointAt(offset);
 	}
 
+	/**
+	 * Advances the cursor by one if the current character matches the given value.
+	 *
+	 * @param ch the expected character
+	 * @return true if matched and advanced, false otherwise
+	 */
 	public boolean advanceIfChar(int ch) {
 		if (ch == peekChar()) {
 			this.position++;
@@ -106,6 +163,13 @@ public class MultiLineStream {
 		return false;
 	}
 
+	/**
+	 * Advances the cursor if the upcoming characters exactly match the given
+	 * sequence.
+	 *
+	 * @param ch the sequence of expected characters
+	 * @return true if matched and advanced, false otherwise
+	 */
 	public boolean advanceIfChars(int[] ch) {
 		int i;
 		if (this.position + ch.length > this.len) {
@@ -120,6 +184,13 @@ public class MultiLineStream {
 		return true;
 	}
 
+	/**
+	 * Advances the cursor if the current character matches any of the provided
+	 * characters.
+	 *
+	 * @param ch the array of characters to test
+	 * @return true if any matched and advanced, false otherwise
+	 */
 	public boolean advanceIfAnyOfChars(char[] ch) {
 		int i;
 		if (this.position + 1 > this.len) {
@@ -134,9 +205,11 @@ public class MultiLineStream {
 	}
 
 	/**
-	 * Advances stream.position no matter what until it hits ch or eof(this.len)
+	 * Advances the cursor until any of the given characters in the array is reached
+	 * or the end of stream.
 	 *
-	 * @return boolean: was the char found
+	 * @param ch array of target characters
+	 * @return true if a character was found, false if end of stream
 	 */
 	public boolean advanceUntilChar(int[] ch) {
 		while (this.position < this.len) {
@@ -151,9 +224,11 @@ public class MultiLineStream {
 	}
 
 	/**
-	 * Advances stream.position no matter what until it hits ch or eof(this.len)
+	 * Advances the cursor until the given character is reached or the end of
+	 * stream.
 	 *
-	 * @return boolean: was the char found
+	 * @param ch target character
+	 * @return true if found, false if end of stream
 	 */
 	public boolean advanceUntilChar(int ch) {
 		while (this.position < this.len) {
@@ -166,7 +241,10 @@ public class MultiLineStream {
 	}
 
 	/**
-	 * Will advance until any of the provided chars are encountered
+	 * Advances the cursor until any of the specified characters is found.
+	 *
+	 * @param ch array of target characters
+	 * @return true if any character is found, false otherwise
 	 */
 	public boolean advanceUntilAnyOfChars(int[] ch) {
 		while (this.position < this.len) {
@@ -181,6 +259,12 @@ public class MultiLineStream {
 		return false;
 	}
 
+	/**
+	 * Advances until the specified sequence of characters is found.
+	 *
+	 * @param ch target character sequence
+	 * @return true if sequence found, false if end of stream
+	 */
 	public boolean advanceUntilChars(int[] ch) {
 		while (this.position + ch.length <= this.len) {
 			int i = 0;
@@ -196,13 +280,51 @@ public class MultiLineStream {
 	}
 
 	/**
-	 * Advances until it reaches a whitespace character
+	 * Skips over all whitespace characters (spaces, tabs, newlines, CR/LF).
+	 *
+	 * @return true if at least one whitespace character was skipped
 	 */
 	public boolean skipWhitespace() {
 		int n = this.advanceWhileChar(WHITESPACE_PREDICATE);
 		return n > 0;
 	}
 
+	/**
+	 * Skips over spaces and tabs only.
+	 *
+	 * @return true if at least one space or tab was skipped
+	 */
+	public boolean skipWhitespaceOnly() {
+		int n = this.advanceWhileChar(WHITESPACE_ONLY_PREDICATE);
+		return n > 0;
+	}
+
+	/**
+	 * Skips a single newline character, handling both LF and CRLF sequences.
+	 *
+	 * @return true if a newline was skipped
+	 */
+	public boolean skipNewline() {
+		if (peekChar() == _NWL) {
+			advance(1);
+			return true;
+		}
+		if (peekChar() == _CAR) {
+			advance(1);
+			if (peekChar() == _NWL) { // handle CRLF
+				advance(1);
+			}
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Advances the cursor while the given condition is true.
+	 *
+	 * @param condition predicate applied to characters
+	 * @return number of characters advanced
+	 */
 	public int advanceWhileChar(Predicate<Integer> condition) {
 		int posNow = this.position;
 		while (this.position < this.len && condition.test(peekChar())) {
@@ -212,7 +334,10 @@ public class MultiLineStream {
 	}
 
 	/**
-	 * Will advance the stream position until ch or '{'
+	 * Advances until the given character or '{' is reached.
+	 *
+	 * @param ch target character
+	 * @return true if the target or '{' is found, false if end of stream
 	 */
 	public boolean advanceUntilCharOrNewTag(int ch) {
 		while (this.position < this.len) {

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/scanner/Scanner.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/scanner/Scanner.java
@@ -1,45 +1,135 @@
 /*******************************************************************************
-* Copyright (c) 2021 Red Hat Inc. and others.
-* All rights reserved. This program and the accompanying materials
-* which accompanies this distribution, and is available at
-* http://www.eclipse.org/legal/epl-v20.html
-*
-* SPDX-License-Identifier: EPL-2.0
-*
-* Contributors:
-*     Red Hat Inc. - initial API and implementation
-*******************************************************************************/
+ * Copyright (c) 2021 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
 package com.redhat.qute.parser.scanner;
 
 /**
- * Scanner API.
+ * Generic scanner interface for tokenizing input text.
  *
+ * <p>
+ * This scanner identifies high-level structural tokens such as content blocks,
+ * delimiters, and section boundaries.
+ * </p>
+ *
+ * <p>
+ * It deliberately does <strong>not</strong> tokenize the internal structure of
+ * delimited regions. The content of such regions may be scanned separately by a
+ * dedicated scanner and only when needed.
+ * </p>
+ *
+ * <p>
+ * This design enables:
+ * <ul>
+ * <li><b>Lazy parsing</b> – inner content is parsed on demand</li>
+ * <li><b>Cancellation-friendly parsing</b> – avoids unnecessary work when
+ * scanning is interrupted</li>
+ * <li><b>Fault-tolerant scanning</b> – scanning continues even when malformed
+ * input is encountered (e.g. missing closing delimiters)</li>
+ * </ul>
+ * </p>
+ *
+ * <p>
+ * Syntax errors are reported through token error information rather than
+ * interrupting the scanning process.
+ * </p>
+ *
+ * <p>
+ * This interface is intended to be reusable for different syntaxes such as
+ * template languages, markup languages (e.g. HTML), or configuration formats
+ * (e.g. YAML).
+ * </p>
+ *
+ * @param <T> Token type enum
+ * @param <S> Scanner state enum
  */
 public interface Scanner<T, S> {
 
+	/**
+	 * Advances to the next token and returns its type.
+	 *
+	 * <p>
+	 * The scanner identifies structural tokens only. The internal structure of
+	 * delimited regions is not tokenized by this scanner.
+	 * </p>
+	 *
+	 * <h3>Example:</h3>
+	 *
+	 * <pre>
+	 * Input: "{value}"
+	 *
+	 * scan();  // StartDelimiter
+	 * scan();  // EndDelimiter
+	 * scan();  // EOS
+	 * </pre>
+	 *
+	 * @return the type of the token that was just scanned
+	 */
 	T scan();
 
+	/**
+	 * Returns the type of the current token.
+	 *
+	 * @return the type of the current token
+	 */
 	T getTokenType();
 
 	/**
-	 * Starting offset position of the current token
-	 * 
-	 * @return int of token's start offset
+	 * Returns the zero-based starting offset of the current token.
+	 *
+	 * @return zero-based starting offset of the token
 	 */
 	int getTokenOffset();
 
+	/**
+	 * Returns the length of the current token in characters.
+	 *
+	 * @return length of the current token
+	 */
 	int getTokenLength();
 
 	/**
-	 * Ending offset position of the current token
-	 * 
-	 * @return int of token's end offset
+	 * Returns the exclusive ending offset of the current token.
+	 *
+	 * @return exclusive ending offset of the token
 	 */
 	int getTokenEnd();
 
+	/**
+	 * Returns the text content of the current token.
+	 *
+	 * <p>
+	 * For delimiter-related tokens, this method returns only the delimiter text,
+	 * not the content inside the delimited region.
+	 * </p>
+	 *
+	 * @return the text content of the current token
+	 */
 	String getTokenText();
 
+	/**
+	 * Returns the error message for the current token, if any.
+	 *
+	 * <p>
+	 * The scanner is fault-tolerant and continues scanning even when malformed
+	 * input is encountered.
+	 * </p>
+	 *
+	 * @return error message for the token, or {@code null} if the token is valid
+	 */
 	String getTokenError();
 
+	/**
+	 * Returns the current internal state of the scanner.
+	 *
+	 * @return the current scanner state
+	 */
 	S getScannerState();
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/ASTVisitor.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/ASTVisitor.java
@@ -11,6 +11,7 @@
 *******************************************************************************/
 package com.redhat.qute.parser.template;
 
+import com.redhat.qute.parser.ASTVisitorBase;
 import com.redhat.qute.parser.expression.MethodPart;
 import com.redhat.qute.parser.expression.NamespacePart;
 import com.redhat.qute.parser.expression.ObjectPart;
@@ -38,41 +39,7 @@ import com.redhat.qute.parser.template.sections.WithSection;
  * @author Angelo ZERR
  *
  */
-public abstract class ASTVisitor {
-
-	/**
-	 * Visits the given AST node prior to the type-specific visit (before
-	 * <code>visit</code>).
-	 * <p>
-	 * The default implementation does nothing. Subclasses may reimplement.
-	 * </p>
-	 *
-	 * @param node the node to visit
-	 *
-	 * @see #preVisit2(Node)
-	 */
-	public void preVisit(Node node) {
-		// default implementation: do nothing
-	}
-
-	/**
-	 * Visits the given AST node prior to the type-specific visit (before
-	 * <code>visit</code>).
-	 * <p>
-	 * The default implementation calls {@link #preVisit(Node)} and then returns
-	 * true. Subclasses may reimplement.
-	 * </p>
-	 *
-	 * @param node the node to visit
-	 * @return <code>true</code> if <code>visit(node)</code> should be called, and
-	 *         <code>false</code> otherwise.
-	 * @see #preVisit(ASTNode)
-	 * @since 3.5
-	 */
-	public boolean preVisit2(Node node) {
-		preVisit(node);
-		return true;
-	}
+public abstract class ASTVisitor extends ASTVisitorBase<Node> {
 
 	/**
 	 * Visits the given AST node following the type-specific visit (after

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/JavaTypeInfoProvider.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/JavaTypeInfoProvider.java
@@ -11,6 +11,8 @@
 *******************************************************************************/
 package com.redhat.qute.parser.template;
 
+import com.redhat.qute.commons.ResolvedJavaTypeInfo;
+
 /**
  * Java type provider.
  * 
@@ -62,4 +64,8 @@ public interface JavaTypeInfoProvider {
 	 * @return the owner node where the Java type comes from and null otherwise.
 	 */
 	Node getJavaTypeOwnerNode();
+
+	default ResolvedJavaTypeInfo getResolvedType() {
+		return null;
+	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/NodeKind.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/NodeKind.java
@@ -27,5 +27,8 @@ public enum NodeKind {
 	ExpressionPart,
 
 	// Parameter in section
-	Parameter;
+	Parameter, //
+
+	// Language injection
+	LanguageInjection;
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/scanner/TokenType.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/template/scanner/TokenType.java
@@ -51,6 +51,11 @@ public enum TokenType {
 	ParameterDeclaration, //
 	EndParameterDeclaration, //
 
+	// Language injections
+	LanguageInjectionStart, // Start of an injected zone (e.g., first ---)
+	LanguageInjectionContent, // Content of the injected zone
+	LanguageInjectionEnd, // End of an injected zone (e.g., second ---)
+
 	// Other token types
 	Content, //
 	Whitespace, //

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlASTVisitor.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlASTVisitor.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.parser.yaml;
+
+import com.redhat.qute.parser.ASTVisitorBase;
+
+/**
+ * A visitor for YAML AST.
+ */
+public abstract class YamlASTVisitor extends ASTVisitorBase<YamlNode> {
+
+	public boolean visit(YamlDocument node) {
+		return true;
+	}
+
+	public boolean visit(YamlMapping node) {
+		return true;
+	}
+
+	public boolean visit(YamlSequence node) {
+		return true;
+	}
+
+	public boolean visit(YamlScalar node) {
+		return true;
+	}
+
+	public boolean visit(YamlProperty node) {
+		return true;
+	}
+
+	public boolean visit(YamlComment node) {
+		return true;
+	}
+
+	public void endVisit(YamlDocument node) {
+		// default implementation: do nothing
+	}
+
+	public void endVisit(YamlMapping node) {
+		// default implementation: do nothing
+	}
+
+	public void endVisit(YamlSequence node) {
+		// default implementation: do nothing
+	}
+
+	public void endVisit(YamlScalar node) {
+		// default implementation: do nothing
+	}
+
+	public void endVisit(YamlProperty node) {
+		// default implementation: do nothing
+	}
+
+	public void endVisit(YamlComment node) {
+		// default implementation: do nothing
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlCollectionNode.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlCollectionNode.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.parser.yaml;
+
+public abstract class YamlCollectionNode extends YamlNode {
+	private final boolean flowStyle;
+
+	protected YamlCollectionNode(int start, int end, boolean flowStyle) {
+		super(start, end);
+		this.flowStyle = flowStyle;
+	}
+
+	public boolean isFlowStyle() {
+		return flowStyle;
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlComment.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlComment.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.parser.yaml;
+
+/**
+ * YAML Comment node.
+ */
+public class YamlComment extends YamlNode {
+
+	private int startContentOffset = NULL_VALUE;
+	private int endContentOffset = NULL_VALUE;
+
+	public YamlComment(int start, int end) {
+		super(start, end);
+	}
+
+	@Override
+	public YamlNodeKind getKind() {
+		return YamlNodeKind.YamlComment;
+	}
+
+	@Override
+	public String getNodeName() {
+		return "comment";
+	}
+
+	public int getStartContentOffset() {
+		return startContentOffset;
+	}
+
+	public void setStartContentOffset(int startContentOffset) {
+		this.startContentOffset = startContentOffset;
+	}
+
+	public int getEndContentOffset() {
+		return endContentOffset;
+	}
+
+	public void setEndContentOffset(int endContentOffset) {
+		this.endContentOffset = endContentOffset;
+	}
+
+	public String getContent() {
+		YamlDocument doc = getOwnerDocument();
+		if (doc == null || startContentOffset == NULL_VALUE || endContentOffset == NULL_VALUE) {
+			return null;
+		}
+		return doc.getText(startContentOffset, endContentOffset);
+	}
+
+	@Override
+	protected void accept0(YamlASTVisitor visitor) {
+		boolean visitChildren = visitor.visit(this);
+		if (visitChildren) {
+			acceptChildren(visitor, getChildren());
+		}
+		visitor.endVisit(this);
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlDocument.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlDocument.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.parser.yaml;
+
+import com.redhat.qute.ls.commons.TextDocument;
+
+public class YamlDocument extends YamlNode {
+
+	private final TextDocument textDocument;
+
+	public YamlDocument(TextDocument textDocument) {
+		super(0, textDocument.getText().length());
+		this.textDocument = textDocument;
+		super.setClosed(true);
+	}
+
+	@Override
+	public YamlNodeKind getKind() {
+		return YamlNodeKind.YamlDocument;
+	}
+
+	@Override
+	public String getNodeName() {
+		return "#yaml-document";
+	}
+
+	@Override
+	public YamlDocument getOwnerDocument() {
+		return this;
+	}
+
+	public String getUri() {
+		return textDocument.getUri();
+	}
+
+	public String getText() {
+		return textDocument.getText();
+	}
+
+	public TextDocument getTextDocument() {
+		return textDocument;
+	}
+
+	public String getText(int start, int end) {
+		String text = getText();
+		return text.substring(start, end);
+	}
+
+	@Override
+	protected void accept0(YamlASTVisitor visitor) {
+		boolean visitChildren = visitor.visit(this);
+		if (visitChildren) {
+			acceptChildren(visitor, getChildren());
+		}
+		visitor.endVisit(this);
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlMapping.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlMapping.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.parser.yaml;
+
+/**
+ * YAML Mapping node (like an object with key-value pairs).
+ */
+public class YamlMapping extends YamlCollectionNode {
+
+	public YamlMapping(int start, int end, boolean flowStyle) {
+		super(start, end, flowStyle);
+	}
+
+	@Override
+	public YamlNodeKind getKind() {
+		return YamlNodeKind.YamlMapping;
+	}
+
+	@Override
+	public String getNodeName() {
+		return "mapping";
+	}
+
+	@Override
+	protected void accept0(YamlASTVisitor visitor) {
+		boolean visitChildren = visitor.visit(this);
+		if (visitChildren) {
+			acceptChildren(visitor, getChildren());
+		}
+		visitor.endVisit(this);
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlNode.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlNode.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.parser.yaml;
+
+import java.util.List;
+
+import com.redhat.qute.parser.NodeBase;
+
+public abstract class YamlNode extends NodeBase<YamlNode> {
+
+	public YamlNode(int start, int end) {
+		super(start, end);
+	}
+
+	public YamlDocument getOwnerDocument() {
+		YamlNode node = getParent();
+		while (node != null) {
+			if (node.getKind() == YamlNodeKind.YamlDocument) {
+				return (YamlDocument) node;
+			}
+			node = node.getParent();
+		}
+		return null;
+	}
+
+	@Override
+	protected void setStart(int start) {
+		super.setStart(start);
+	}
+
+	@Override
+	protected void setEnd(int end) {
+		super.setEnd(end);
+	}
+
+	@Override
+	protected void setClosed(boolean closed) {
+		super.setClosed(closed);
+	}
+
+	@Override
+	protected void setParent(YamlNode parent) {
+		super.setParent(parent);
+	}
+
+	@Override
+	protected void addChild(YamlNode child) {
+		super.addChild(child);
+	}
+
+	public final void accept(YamlASTVisitor visitor) {
+		if (visitor == null) {
+			throw new IllegalArgumentException();
+		}
+		if (visitor.preVisit2(this)) {
+			accept0(visitor);
+		}
+		visitor.postVisit(this);
+	}
+
+	protected abstract void accept0(YamlASTVisitor visitor);
+
+	protected final void acceptChild(YamlASTVisitor visitor, YamlNode child) {
+		if (child == null) {
+			return;
+		}
+		child.accept(visitor);
+	}
+
+	protected final void acceptChildren(YamlASTVisitor visitor, List<YamlNode> children) {
+		for (YamlNode child : children) {
+			child.accept(visitor);
+		}
+	}
+
+	public abstract YamlNodeKind getKind();
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlNodeKind.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlNodeKind.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.parser.yaml;
+
+public enum YamlNodeKind {
+	YamlDocument, //
+	YamlMapping, //
+	YamlSequence, //
+	YamlScalar, //
+	YamlProperty, //
+	YamlComment; //
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlParser.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlParser.java
@@ -1,0 +1,385 @@
+package com.redhat.qute.parser.yaml;
+
+import java.util.Stack;
+
+import com.redhat.qute.ls.commons.TextDocument;
+import com.redhat.qute.parser.scanner.Scanner;
+import com.redhat.qute.parser.yaml.scanner.YamlScanner;
+import com.redhat.qute.parser.yaml.scanner.YamlScannerState;
+import com.redhat.qute.parser.yaml.scanner.YamlTokenType;
+
+/**
+ * YAML parser (fault-tolerant).
+ */
+public class YamlParser {
+
+	public static YamlDocument parse(String content, String uri) {
+		return parse(new TextDocument(content, uri));
+	}
+
+	public static YamlDocument parse(TextDocument textDocument) {
+		YamlDocument document = new YamlDocument(textDocument);
+		String content = textDocument.getText();
+		Scanner<YamlTokenType, YamlScannerState> scanner = YamlScanner.createScanner(content);
+
+		YamlNode curr = document;
+		Stack<Integer> indentStack = new Stack<>();
+		indentStack.push(-1); // Document level
+
+		int currentIndent = 0;
+		boolean afterNewline = true;
+
+		YamlProperty currentProperty = null;
+		YamlScalar currentScalar = null;
+
+		YamlTokenType token = scanner.scan();
+		while (token != YamlTokenType.EOS) {
+
+			switch (token) {
+
+			case Whitespace:
+				if (afterNewline && !isInFlowCollection(curr)) {
+					currentIndent = scanner.getTokenText().length();
+				}
+				break;
+
+			case Newline:
+				if (!isInFlowCollection(curr)) {
+					afterNewline = true;
+					currentIndent = 0;
+
+					if (currentProperty != null && currentProperty.getValue() != null) {
+						currentProperty.setClosed(true);
+						currentProperty.setEnd(scanner.getTokenOffset());
+						currentProperty = null;
+					}
+				}
+				break;
+
+			case StartComment:
+				afterNewline = false;
+				int commentStart = scanner.getTokenOffset();
+				int commentEnd = scanner.getTokenEnd();
+				YamlComment comment = new YamlComment(commentStart, commentEnd);
+
+				YamlNode commentParent = curr;
+				while (commentParent != null && commentParent.getKind() == YamlNodeKind.YamlProperty) {
+					commentParent = commentParent.getParent();
+				}
+				if (commentParent != null) {
+					commentParent.addChild(comment);
+				} else {
+					curr.addChild(comment);
+				}
+				curr = comment;
+				break;
+
+			case Comment:
+				if (curr.getKind() == YamlNodeKind.YamlComment) {
+					YamlComment yamlComment = (YamlComment) curr;
+					yamlComment.setStartContentOffset(scanner.getTokenOffset());
+					yamlComment.setEndContentOffset(scanner.getTokenEnd());
+					yamlComment.setEnd(scanner.getTokenEnd());
+					yamlComment.setClosed(true);
+					curr = curr.getParent();
+				}
+				break;
+
+			case Key:
+				afterNewline = false;
+
+				// Handle indentation - close structures when indentation decreases
+				if (!isInFlowCollection(curr)) {
+					while (!indentStack.isEmpty() && currentIndent < indentStack.peek()) {
+						indentStack.pop();
+						if (curr.getParent() != null && curr.getKind() != YamlNodeKind.YamlDocument) {
+							curr.setEnd(scanner.getTokenOffset());
+							curr.setClosed(true);
+							curr = curr.getParent();
+						}
+					}
+				}
+
+				// Check if we need to create a nested mapping as a property value
+				// This happens when: person:\n name: John (key at higher indentation after
+				// colon)
+				if (!isInFlowCollection(curr) && curr.getKind() == YamlNodeKind.YamlMapping) {
+					if (curr.getChildCount() > 0) {
+						YamlNode lastChild = curr.getChild(curr.getChildCount() - 1);
+						if (lastChild.getKind() == YamlNodeKind.YamlProperty) {
+							YamlProperty prop = (YamlProperty) lastChild;
+							// Property has colon, no value, and we're at higher indentation
+							if (prop.getColonOffset() != -1 && prop.getValue() == null
+									&& currentIndent > indentStack.peek()) {
+								// Create nested mapping as property value
+								YamlMapping nestedMapping = new YamlMapping(scanner.getTokenOffset(),
+										scanner.getTokenEnd(), false);
+								prop.setValue(nestedMapping);
+								curr = nestedMapping;
+								indentStack.push(currentIndent);
+							}
+						}
+					}
+				}
+
+				// If at document level, create root mapping
+				if (curr.getKind() == YamlNodeKind.YamlDocument) {
+					YamlMapping mapping = new YamlMapping(scanner.getTokenOffset(), scanner.getTokenEnd(), false);
+					curr.addChild(mapping);
+					curr = mapping;
+					indentStack.push(currentIndent);
+				}
+				// If in a sequence at the expected indentation, create a mapping for the item
+				else if (curr.getKind() == YamlNodeKind.YamlSequence) {
+					// Check if we need a new mapping or can reuse the last one
+					YamlNode lastChild = curr.getChildCount() > 0 ? curr.getChild(curr.getChildCount() - 1) : null;
+
+					if (lastChild == null || lastChild.getKind() != YamlNodeKind.YamlMapping || lastChild.isClosed()) {
+						// Create a new mapping for this sequence item
+						YamlMapping itemMapping = new YamlMapping(scanner.getTokenOffset(), scanner.getTokenEnd(),
+								false);
+						curr.addChild(itemMapping);
+						curr = itemMapping;
+						indentStack.push(currentIndent);
+					} else {
+						// Continue with the existing mapping
+						curr = lastChild;
+					}
+				}
+
+				// Create the property
+				currentProperty = new YamlProperty(scanner.getTokenOffset(), scanner.getTokenEnd());
+				YamlScalar keyScalar = new YamlScalar(scanner.getTokenOffset(), scanner.getTokenEnd(),
+						YamlTokenType.ScalarString);
+				currentProperty.setKey(keyScalar);
+
+				if (curr.getKind() == YamlNodeKind.YamlMapping) {
+					curr.addChild(currentProperty);
+				}
+				break;
+
+			case Colon:
+				afterNewline = false;
+				if (currentProperty != null) {
+					currentProperty.setColonOffset(scanner.getTokenOffset());
+				}
+				break;
+
+			case Dash:
+				afterNewline = false;
+
+				// Handle indentation
+				if (!isInFlowCollection(curr)) {
+					while (!indentStack.isEmpty() && currentIndent < indentStack.peek()) {
+						indentStack.pop();
+
+						YamlNode parent = curr.getParent();
+						while (parent != null && parent.getKind() != YamlNodeKind.YamlSequence) {
+							parent = parent.getParent();
+						}
+						if (parent != null) {
+							curr = parent;
+						}
+					}
+				}
+
+				// Determine where to create the sequence
+				YamlSequence sequence = null;
+
+				if (curr.getKind() == YamlNodeKind.YamlDocument) {
+					// Top-level sequence
+					sequence = new YamlSequence(scanner.getTokenOffset(), scanner.getTokenEnd(), false);
+					curr.addChild(sequence);
+					curr = sequence;
+					indentStack.push(currentIndent);
+				} else if (curr.getKind() == YamlNodeKind.YamlMapping && currentProperty != null
+						&& currentProperty.getValue() == null && currentProperty.getColonOffset() != -1) {
+					// Sequence as a property value (e.g., items:\n- ...)
+					sequence = new YamlSequence(scanner.getTokenOffset(), scanner.getTokenEnd(), false);
+					currentProperty.setValue(sequence);
+					currentProperty = null;
+					curr = sequence;
+					indentStack.push(currentIndent);
+				} else if (curr.getKind() == YamlNodeKind.YamlSequence) {
+					// Already in a sequence - close previous mapping if exists
+					if (curr.getChildCount() > 0) {
+						YamlNode lastChild = curr.getChild(curr.getChildCount() - 1);
+						if (lastChild.getKind() == YamlNodeKind.YamlMapping && !lastChild.isClosed()) {
+							lastChild.setClosed(true);
+							lastChild.setEnd(scanner.getTokenOffset());
+						}
+					}
+				} else if (curr.getKind() == YamlNodeKind.YamlMapping && curr.getParent() != null
+						&& curr.getParent().getKind() == YamlNodeKind.YamlSequence) {
+					// We're in a mapping within a sequence, close it and return to sequence
+					curr.setClosed(true);
+					curr.setEnd(scanner.getTokenOffset());
+					curr = curr.getParent();
+				}
+				break;
+
+			case ScalarString:
+			case ScalarNumber:
+			case ScalarBoolean:
+			case ScalarNull:
+			case Value:
+				afterNewline = false;
+				currentScalar = new YamlScalar(scanner.getTokenOffset(), scanner.getTokenEnd(), token);
+
+				if (currentProperty != null && currentProperty.getValue() == null
+						&& currentProperty.getColonOffset() != -1) {
+					// Scalar as property value
+					currentProperty.setValue(currentScalar);
+					currentProperty.setEnd(scanner.getTokenEnd());
+				} else if (curr.getKind() == YamlNodeKind.YamlSequence) {
+					curr.addChild(currentScalar);
+					curr.setEnd(scanner.getTokenEnd());
+				} else {
+					curr.addChild(currentScalar);
+				}
+				currentScalar = null;
+				break;
+
+			case StartString:
+				afterNewline = false;
+				int stringStart = scanner.getTokenEnd();
+				currentScalar = new YamlScalar(stringStart, stringStart, YamlTokenType.ScalarString);
+				currentScalar.setQuoted(true);
+				break;
+
+			case String:
+				if (currentScalar != null) {
+					if (currentScalar.getStart() == currentScalar.getEnd()) {
+						currentScalar.setStart(scanner.getTokenOffset());
+					}
+					currentScalar.setEnd(scanner.getTokenEnd());
+				}
+				break;
+
+			case EndString:
+				if (currentScalar != null) {
+					if (currentProperty != null && currentProperty.getValue() == null
+							&& currentProperty.getColonOffset() != -1) {
+						currentProperty.setValue(currentScalar);
+						currentProperty.setEnd(scanner.getTokenEnd());
+					} else if (curr.getKind() == YamlNodeKind.YamlSequence) {
+						curr.addChild(currentScalar);
+						curr.setEnd(scanner.getTokenEnd());
+					} else if (curr.getKind() == YamlNodeKind.YamlMapping && currentProperty != null
+							&& currentProperty.getKey() == null) {
+						currentProperty.setKey(currentScalar);
+					} else {
+						curr.addChild(currentScalar);
+					}
+					currentScalar = null;
+				}
+				break;
+
+			case ArrayOpen:
+				afterNewline = false;
+				YamlSequence flowSeq = new YamlSequence(scanner.getTokenOffset(), scanner.getTokenEnd(), true);
+
+				if (currentProperty != null && currentProperty.getValue() == null
+						&& currentProperty.getColonOffset() != -1) {
+					currentProperty.setValue(flowSeq);
+				} else if (curr.getKind() == YamlNodeKind.YamlSequence) {
+					curr.addChild(flowSeq);
+				} else {
+					curr.addChild(flowSeq);
+				}
+				curr = flowSeq;
+				break;
+
+			case ArrayClose:
+				afterNewline = false;
+				if (curr.getKind() == YamlNodeKind.YamlSequence) {
+					curr.setEnd(scanner.getTokenEnd());
+					curr.setClosed(true);
+					if (curr.getParent() != null) {
+						curr = curr.getParent();
+						if (curr != null && curr.getKind() == YamlNodeKind.YamlProperty) {
+							curr = curr.getParent();
+						}
+					}
+				}
+				break;
+
+			case ObjectOpen:
+				afterNewline = false;
+				YamlMapping flowMap = new YamlMapping(scanner.getTokenOffset(), scanner.getTokenEnd(), true);
+
+				if (currentProperty != null && currentProperty.getValue() == null
+						&& currentProperty.getColonOffset() != -1) {
+					currentProperty.setValue(flowMap);
+				} else if (curr.getKind() == YamlNodeKind.YamlSequence) {
+					curr.addChild(flowMap);
+				} else {
+					curr.addChild(flowMap);
+				}
+				curr = flowMap;
+				break;
+
+			case ObjectClose:
+				afterNewline = false;
+				if (curr.getKind() == YamlNodeKind.YamlMapping) {
+					curr.setEnd(scanner.getTokenEnd());
+					curr.setClosed(true);
+					if (curr.getParent() != null) {
+						curr = curr.getParent();
+						if (curr != null && curr.getKind() == YamlNodeKind.YamlProperty) {
+							curr = curr.getParent();
+						}
+					}
+				}
+				break;
+
+			case Comma:
+				afterNewline = false;
+				if (currentProperty != null) {
+					currentProperty.setClosed(true);
+					currentProperty.setEnd(scanner.getTokenOffset());
+					currentProperty = null;
+				}
+				break;
+
+			default:
+				afterNewline = false;
+				break;
+			}
+
+			token = scanner.scan();
+		}
+
+		// Close any remaining open nodes
+		while (curr.getParent() != null) {
+			curr.setEnd(content.length());
+			if (!curr.isClosed()) {
+				if (shouldBeClosed(curr)) {
+					curr.setClosed(true);
+				}
+			}
+			curr = curr.getParent();
+		}
+
+		return document;
+	}
+
+	private static boolean shouldBeClosed(YamlNode curr) {
+		if (curr.getKind() == YamlNodeKind.YamlSequence || curr.getKind() == YamlNodeKind.YamlMapping) {
+			return !((YamlCollectionNode) curr).isFlowStyle();
+		}
+		return true;
+	}
+
+	private static boolean isInFlowCollection(YamlNode node) {
+		while (node != null) {
+			if (node.getKind() == YamlNodeKind.YamlSequence || node.getKind() == YamlNodeKind.YamlMapping) {
+				if (((YamlCollectionNode) node).isFlowStyle()) {
+					return true;
+				}
+			}
+			node = node.getParent();
+		}
+		return false;
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlProperty.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlProperty.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.parser.yaml;
+
+/**
+ * YAML Property node (key-value pair in a mapping).
+ */
+public class YamlProperty extends YamlNode {
+
+	private YamlNode key;
+	private YamlNode value;
+	private int colonOffset = NULL_VALUE;
+
+	public YamlProperty(int start, int end) {
+		super(start, end);
+	}
+
+	@Override
+	public YamlNodeKind getKind() {
+		return YamlNodeKind.YamlProperty;
+	}
+
+	@Override
+	public String getNodeName() {
+		return "property";
+	}
+
+	public YamlNode getKey() {
+		return key;
+	}
+
+	public void setKey(YamlNode key) {
+		this.key = key;
+		if (key != null) {
+			key.setParent(this);
+		}
+	}
+
+	public YamlNode getValue() {
+		return value;
+	}
+
+	public void setValue(YamlNode value) {
+		this.value = value;
+		if (value != null) {
+			value.setParent(this);
+		}
+	}
+
+	public int getColonOffset() {
+		return colonOffset;
+	}
+
+	public void setColonOffset(int colonOffset) {
+		this.colonOffset = colonOffset;
+	}
+
+	@Override
+	protected void accept0(YamlASTVisitor visitor) {
+		boolean visitChildren = visitor.visit(this);
+		if (visitChildren) {
+			if (key != null) {
+				acceptChild(visitor, key);
+			}
+			if (value != null) {
+				acceptChild(visitor, value);
+			}
+		}
+		visitor.endVisit(this);
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlScalar.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlScalar.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.parser.yaml;
+
+import com.redhat.qute.parser.yaml.scanner.YamlTokenType;
+
+/**
+ * YAML Scalar node (string, number, boolean, null).
+ */
+public class YamlScalar extends YamlNode {
+
+	private YamlTokenType scalarType;
+	private boolean quoted;
+
+	public YamlScalar(int start, int end, YamlTokenType scalarType) {
+		super(start, end);
+		this.scalarType = scalarType;
+		this.quoted = false;
+	}
+
+	@Override
+	public YamlNodeKind getKind() {
+		return YamlNodeKind.YamlScalar;
+	}
+
+	@Override
+	public String getNodeName() {
+		return "scalar";
+	}
+
+	public YamlTokenType getScalarType() {
+		return scalarType;
+	}
+
+	public void setScalarType(YamlTokenType scalarType) {
+		this.scalarType = scalarType;
+	}
+
+	public boolean isQuoted() {
+		return quoted;
+	}
+
+	public void setQuoted(boolean quoted) {
+		this.quoted = quoted;
+	}
+
+	public String getValue() {
+		YamlDocument doc = getOwnerDocument();
+		if (doc == null) {
+			return null;
+		}
+		return doc.getText(getStart(), getEnd());
+	}
+
+	@Override
+	protected void accept0(YamlASTVisitor visitor) {
+		boolean visitChildren = visitor.visit(this);
+		if (visitChildren) {
+			acceptChildren(visitor, getChildren());
+		}
+		visitor.endVisit(this);
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlSequence.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/YamlSequence.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.parser.yaml;
+
+/**
+ * YAML Sequence node (like an array).
+ */
+public class YamlSequence extends YamlCollectionNode {
+
+	public YamlSequence(int start, int end, boolean flowStyle) {
+		super(start, end, flowStyle);
+	}
+
+	@Override
+	public YamlNodeKind getKind() {
+		return YamlNodeKind.YamlSequence;
+	}
+
+	@Override
+	public String getNodeName() {
+		return "sequence";
+	}
+
+	@Override
+	protected void accept0(YamlASTVisitor visitor) {
+		boolean visitChildren = visitor.visit(this);
+		if (visitChildren) {
+			acceptChildren(visitor, getChildren());
+		}
+		visitor.endVisit(this);
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/scanner/YamlConstants.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/scanner/YamlConstants.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.parser.yaml.scanner;
+
+public class YamlConstants {
+    public static final int _MIN = "-".codePointAt(0);      // dash for list items
+    public static final int _DDT = ":".codePointAt(0);      // key/value separator
+    public static final int _DQO = "\"".codePointAt(0);     // double quote
+    public static final int _SQO = "\'".codePointAt(0);     // single quote
+    public static final int _WSP = " ".codePointAt(0);      // space
+    public static final int _TAB = "\t".codePointAt(0);
+    public static final int _NWL = "\n".codePointAt(0);     // newline
+    public static final int _CAR = "\r".codePointAt(0);     // carriage return
+    public static final int _LFD = "\f".codePointAt(0);     // form feed
+    public static final int _PIPE = "|".codePointAt(0);     // multi-line scalar
+    public static final int _GT = ">".codePointAt(0);       // folded scalar
+    public static final int _HASHTAG = "#".codePointAt(0);  // comment
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/scanner/YamlScanner.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/scanner/YamlScanner.java
@@ -1,0 +1,571 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.parser.yaml.scanner;
+
+import java.util.function.Predicate;
+
+import com.redhat.qute.parser.scanner.AbstractScanner;
+import com.redhat.qute.parser.scanner.Scanner;
+
+/**
+ * YAML scanner (fault-tolerant).
+ */
+public class YamlScanner extends AbstractScanner<YamlTokenType, YamlScannerState> {
+
+	private static final int[] QUOTE = new int[] { '"', '\'', };
+	private static final char[] QUOTE_C = new char[] { '"', '\'', };
+	private static final int[] NEWLINE_CHARS = new int[] { '\n', '\r' };
+	private static final int[] STRUCTURAL_CHARS = new int[] { ':', '-', '#', '[', ']', '{', '}', ',', '\n', '\r' };
+	private static final int[] VALUE_END_CHARS = new int[] { '\n', '\r', '#', ',', ']', '}' };
+	private static final int[] FLOW_END_CHARS = new int[] { ',', ']', '}', '\n', '\r' };
+
+	private static final Predicate<Integer> KEY_CHAR_PREDICATE = ch -> {
+		return ch != ':' && ch != '\n' && ch != '\r' && ch != '#' && ch != '[' && ch != ']' && ch != '{' && ch != '}'
+				&& ch != ',';
+	};
+
+	private static final Predicate<Integer> VALUE_CHAR_PREDICATE = ch -> {
+		return ch != '\n' && ch != '\r' && ch != '#' && ch != ',' && ch != ']' && ch != '}';
+	};
+
+	private static final Predicate<Integer> VALUE_CHAR_PREDICATE2 = ch -> {
+		return ch != '\n' && ch != '\r' && ch != '#' && ch != ',' && ch != ']' && ch != '}' && ch != ':';
+	};
+
+	public static Scanner<YamlTokenType, YamlScannerState> createScanner(String input) {
+		return createScanner(input, 0);
+	}
+
+	public static Scanner<YamlTokenType, YamlScannerState> createScanner(String input, int initialOffset) {
+		return createScanner(input, initialOffset, YamlScannerState.WithinContent);
+	}
+
+	public static Scanner<YamlTokenType, YamlScannerState> createScanner(String input, int initialOffset,
+			YamlScannerState initialState) {
+		return new YamlScanner(input, initialOffset, initialState);
+	}
+
+	private int flowSequenceDepth = 0;
+	private int flowMappingDepth = 0;
+	private YamlScannerState returnStateAfterString;
+	private char stringQuote;
+	private YamlTokenType previousNoWhitespacesToken;
+
+	YamlScanner(String input, int initialOffset, YamlScannerState initialState) {
+		super(input, initialOffset, initialState, YamlTokenType.Unknown, YamlTokenType.EOS);
+	}
+
+	@Override
+	protected YamlTokenType internalScan() {
+		if (getTokenType() != YamlTokenType.Whitespace) {
+			previousNoWhitespacesToken = getTokenType();
+		}
+		int offset = stream.pos();
+		if (stream.eos()) {
+			return finishToken(offset, YamlTokenType.EOS);
+		}
+
+		String errorMessage = null;
+
+		switch (state) {
+
+		case WithinContent: {
+			// Handle comments
+			if (stream.advanceIfChar('#')) {
+				state = YamlScannerState.WithinComment;
+				return finishToken(offset, YamlTokenType.StartComment);
+			}
+
+			// Handle whitespace (but not newlines)
+			if (stream.peekChar() == ' ' || stream.peekChar() == '\t') {
+				while (!stream.eos() && (stream.peekChar() == ' ' || stream.peekChar() == '\t')) {
+					stream.advance(1);
+				}
+				return finishToken(offset, YamlTokenType.Whitespace);
+			}
+
+			// Handle newlines
+			if (stream.peekChar() == '\n' || stream.peekChar() == '\r') {
+				stream.advance(1);
+				if (stream.peekChar(-1) == '\r' && stream.peekChar() == '\n') {
+					stream.advance(1);
+				}
+				state = YamlScannerState.WithinContent;
+				return finishToken(offset, YamlTokenType.Newline);
+			}
+
+			// Handle flow sequence start
+			if (stream.advanceIfChar('[')) {
+				flowSequenceDepth++;
+				state = YamlScannerState.WithinFlowSequence;
+				return finishToken(offset, YamlTokenType.ArrayOpen);
+			}
+
+			// Handle flow mapping start
+			if (stream.advanceIfChar('{')) {
+				flowMappingDepth++;
+				state = YamlScannerState.WithinFlowMapping;
+				return finishToken(offset, YamlTokenType.ObjectOpen);
+			}
+
+			// Handle list dash
+			if (stream.peekChar() == '-') {
+				int next = stream.peekChar(1);
+				if (next == ' ' || next == '\t' || next == '\n' || next == '\r' || next == 0) {
+					stream.advance(1);
+					state = YamlScannerState.AfterDash;
+					return finishToken(offset, YamlTokenType.Dash);
+				}
+			}
+
+			// Handle quoted strings
+			YamlTokenType startStringToken = handleStartString(offset);
+			if (startStringToken != null) {
+				return startStringToken;
+			}
+
+			// Handle key or value
+			return scanKeyOrValue(offset);
+		}
+
+		case WithinComment: {
+			int ch = stream.peekChar();
+			if (ch == '\n' || ch == '\r') {
+				// Newline after comment
+				stream.advance(1);
+				if (ch == '\r' && stream.peekChar() == '\n') {
+					stream.advance(1); // handle CRLF
+				}
+				state = YamlScannerState.WithinContent;
+				return finishToken(offset, YamlTokenType.Newline);
+			}
+
+			// consume comment content until newline
+			int startCommentOffset = stream.pos();
+			stream.advanceUntilChar(NEWLINE_CHARS);
+			return finishToken(startCommentOffset, YamlTokenType.Comment);
+		}
+
+		case WithinString: {
+			int start = stream.pos();
+
+			while (!stream.eos()) {
+				int ch = stream.peekChar();
+
+				// end of string
+				if (ch == stringQuote) {
+					if (stream.pos() > start) {
+						return finishToken(start, YamlTokenType.String);
+					}
+					stream.advance(1);
+					state = returnStateAfterString;
+					return finishToken(offset, YamlTokenType.EndString);
+				}
+
+				// YAML single-quoted escape: '' -> '
+				if (stringQuote == '\'' && ch == '\'' && stream.peekChar(1) == '\'') {
+					stream.advance(2);
+					continue;
+				}
+
+				stream.advance(1);
+			}
+
+			// unterminated string (fault tolerant)
+			state = returnStateAfterString;
+			return finishToken(start, YamlTokenType.String);
+		}
+
+		case AfterKey: {
+			if (stream.skipWhitespaceOnly()) {
+				return finishToken(offset, YamlTokenType.Whitespace);
+			}
+
+			if (stream.advanceIfChar(':')) {
+				state = YamlScannerState.AfterColon;
+				return finishToken(offset, YamlTokenType.Colon);
+			}
+
+			// Fault-tolerant: missing colon
+			state = YamlScannerState.WithinContent;
+			return finishToken(offset, YamlTokenType.Unknown, "Expected ':' after key");
+		}
+
+		case AfterColon: {
+			if (stream.skipWhitespaceOnly()) {
+				return finishToken(offset, YamlTokenType.Whitespace);
+			}
+
+			// Handle newline after colon (nested structure)
+			if (stream.peekChar() == '\n' || stream.peekChar() == '\r') {
+				state = YamlScannerState.WithinContent;
+				return internalScan();
+			}
+
+			// Handle comment after colon
+			if (stream.peekChar() == '#') {
+				state = YamlScannerState.WithinContent;
+				return internalScan();
+			}
+
+			// Parse value
+			state = YamlScannerState.WithinValue;
+			return scanValue(offset, true);
+		}
+
+		case AfterDash: {
+			if (stream.skipWhitespaceOnly()) {
+				return finishToken(offset, YamlTokenType.Whitespace);
+			}
+
+			// Handle newline after dash (nested structure)
+			if (stream.peekChar() == '\n' || stream.peekChar() == '\r') {
+				state = YamlScannerState.WithinContent;
+				return internalScan();
+			}
+
+			// Handle comment after dash
+			if (stream.peekChar() == '#') {
+				state = YamlScannerState.WithinContent;
+				return internalScan();
+			}
+
+			// Parse value
+			state = YamlScannerState.WithinValue;
+			return scanValue(offset, false);
+		}
+
+		case WithinValue: {
+			if (stream.skipWhitespaceOnly()) {
+				return finishToken(offset, YamlTokenType.Whitespace);
+			}
+
+			// After value, we go back to content
+			state = YamlScannerState.WithinContent;
+			return internalScan();
+		}
+
+		case WithinFlowSequence: {
+			if (stream.skipWhitespaceOnly()) {
+				return finishToken(offset, YamlTokenType.Whitespace);
+			}
+
+			int ch = stream.peekChar();
+
+			// Nested sequence
+			if (ch == '[') {
+				stream.advance(1);
+				flowSequenceDepth++;
+				return finishToken(offset, YamlTokenType.ArrayOpen);
+			}
+
+			// Close sequence
+			if (ch == ']') {
+				stream.advance(1);
+				flowSequenceDepth--;
+				
+				// Determine next state based on what we're still in
+				if (flowSequenceDepth > 0) {
+					// Still in nested flow sequence
+					state = YamlScannerState.WithinFlowSequence;
+				} else if (flowMappingDepth > 0) {
+					// Back to flow mapping
+					state = YamlScannerState.WithinFlowMapping;
+				} else {
+					// Back to regular content
+					state = YamlScannerState.WithinContent;
+				}
+				return finishToken(offset, YamlTokenType.ArrayClose);
+			}
+
+			// Comma
+			if (ch == ',') {
+				stream.advance(1);
+				return finishToken(offset, YamlTokenType.Comma);
+			}
+
+			// Nested mapping
+			if (ch == '{') {
+				stream.advance(1);
+				flowMappingDepth++;
+				state = YamlScannerState.WithinFlowMapping;
+				return finishToken(offset, YamlTokenType.ObjectOpen);
+			}
+
+			// Comment
+			if (ch == '#') {
+				state = YamlScannerState.WithinComment;
+				stream.advance(1);
+				return finishToken(offset, YamlTokenType.StartComment);
+			}
+
+			// Newline
+			if (ch == '\n' || ch == '\r') {
+				stream.advance(1);
+				if (stream.peekChar(-1) == '\r' && stream.peekChar() == '\n') {
+					stream.advance(1);
+				}
+				return finishToken(offset, YamlTokenType.Newline);
+			}
+
+			// Handle quoted strings
+			YamlTokenType startStringToken = handleStartString(offset);
+			if (startStringToken != null) {
+				return startStringToken;
+			}
+
+			// Anything else is a value
+			return scanFlowValue(offset, YamlScannerState.WithinFlowSequence);
+		}
+
+		case WithinFlowMapping: {
+			if (stream.skipWhitespaceOnly()) {
+				return finishToken(offset, YamlTokenType.Whitespace);
+			}
+
+			if (stream.advanceIfChar('}')) {
+				flowMappingDepth--;
+				
+				// Determine next state based on what we're still in
+				if (flowMappingDepth > 0) {
+					// Still in nested flow mapping
+					state = YamlScannerState.WithinFlowMapping;
+				} else if (flowSequenceDepth > 0) {
+					// Back to flow sequence
+					state = YamlScannerState.WithinFlowSequence;
+				} else {
+					// Back to regular content
+					state = YamlScannerState.WithinContent;
+				}
+				return finishToken(offset, YamlTokenType.ObjectClose);
+			}
+
+			if (stream.advanceIfChar(',')) {
+				return finishToken(offset, YamlTokenType.Comma);
+			}
+
+			if (stream.advanceIfChar(':')) {
+				return finishToken(offset, YamlTokenType.Colon);
+			}
+
+			if (stream.peekChar() == '\n' || stream.peekChar() == '\r') {
+				stream.advance(1);
+				if (stream.peekChar(-1) == '\r' && stream.peekChar() == '\n') {
+					stream.advance(1);
+				}
+				return finishToken(offset, YamlTokenType.Newline);
+			}
+
+			if (stream.peekChar() == '#') {
+				state = YamlScannerState.WithinComment;
+				stream.advance(1);
+				return finishToken(offset, YamlTokenType.StartComment);
+			}
+
+			// Handle nested structures
+			if (stream.peekChar() == '[') {
+				stream.advance(1);
+				flowSequenceDepth++;
+				state = YamlScannerState.WithinFlowSequence;
+				return finishToken(offset, YamlTokenType.ArrayOpen);
+			}
+
+			if (stream.peekChar() == '{') {
+				stream.advance(1);
+				flowMappingDepth++;
+				return finishToken(offset, YamlTokenType.ObjectOpen);
+			}
+
+			// Handle quoted strings
+			YamlTokenType startStringToken = handleStartString(offset);
+			if (startStringToken != null) {
+				return startStringToken;
+			}
+
+			// Parse key or value
+			return scanFlowValue(offset, YamlScannerState.WithinFlowMapping);
+		}
+
+		default:
+			stream.advance(1);
+			return finishToken(offset, YamlTokenType.Unknown, errorMessage);
+		}
+	}
+
+	private YamlTokenType scanKeyOrValue(int offset) {
+		int start = stream.pos();
+
+		// Skip leading whitespace
+		while (!stream.eos() && (stream.peekChar() == ' ' || stream.peekChar() == '\t')) {
+			stream.advance(1);
+		}
+
+		// Check for quoted string
+		if (stream.peekChar() == '"' || stream.peekChar() == '\'') {
+			// Remember current flow state
+			returnStateAfterString = state;
+			stringQuote = (char) stream.peekChar();
+			stream.advance(1);
+			state = YamlScannerState.WithinString;
+			return finishToken(stream.pos() - 1, YamlTokenType.StartString);
+		}
+
+		// Scan until we hit a structural character
+		int consumed = stream.advanceWhileChar(KEY_CHAR_PREDICATE);
+
+		if (consumed == 0 && !stream.eos()) {
+			stream.advance(1);
+			return finishToken(offset, YamlTokenType.Unknown);
+		}
+
+		// Check what comes after to determine if it's a key or value
+		int savePos = stream.pos();
+		while (!stream.eos() && (stream.peekChar() == ' ' || stream.peekChar() == '\t')) {
+			stream.advance(1);
+		}
+
+		boolean isKey = stream.peekChar() == ':';
+		stream.goBackTo(savePos);
+
+		if (isKey) {
+			state = YamlScannerState.AfterKey;
+			return finishToken(offset, YamlTokenType.Key);
+		} else {
+			String text = stream.getSource().substring(offset, stream.pos()).trim();
+			YamlTokenType valueType = classifyValue(text);
+			state = YamlScannerState.WithinValue;
+			return finishToken(offset, valueType);
+		}
+	}
+
+	private YamlTokenType scanValue(int offset, boolean colonAllowed) {
+		// Check for quoted string
+		if (stream.peekChar() == '"' || stream.peekChar() == '\'') {
+			// Remember current flow state
+			returnStateAfterString = state;
+			stringQuote = (char) stream.peekChar();
+			stream.advance(1);
+			state = YamlScannerState.WithinString;
+			return finishToken(stream.pos() - 1, YamlTokenType.StartString);
+		}
+
+		// Check for nested list
+		if (stream.peekChar() == '-') {
+			int next = stream.peekChar(1);
+			if (next == ' ' || next == '\t' || next == '\n' || next == '\r' || next == 0) {
+				state = YamlScannerState.WithinContent;
+				return internalScan();
+			}
+		}
+
+		// Check for flow collections
+		if (stream.peekChar() == '[') {
+			state = YamlScannerState.WithinContent;
+			return internalScan();
+		}
+
+		if (stream.peekChar() == '{') {
+			state = YamlScannerState.WithinContent;
+			return internalScan();
+		}
+
+		// Scan the value
+		int consumed = stream.advanceWhileChar(colonAllowed ? VALUE_CHAR_PREDICATE : VALUE_CHAR_PREDICATE2);
+		if (stream.peekChar() == ':') {
+			state = YamlScannerState.AfterKey;
+			return finishToken(offset, YamlTokenType.Key);
+		}
+		if (consumed == 0) {
+			state = YamlScannerState.WithinContent;
+			return internalScan();
+		}
+
+		String text = stream.getSource().substring(offset, stream.pos()).trim();
+		YamlTokenType valueType = classifyValue(text);
+		state = YamlScannerState.WithinValue;
+		return finishToken(offset, valueType);
+	}
+
+	private YamlTokenType scanFlowValue(int offset, YamlScannerState returnState) {
+		// Scan until we hit a flow terminator
+		int consumed = stream.advanceWhileChar(ch -> {
+			return ch != ',' && ch != ']' && ch != '}' && ch != '\n' && ch != '\r' && ch != '#' && ch != ':';
+		});
+
+		if (consumed == 0 && !stream.eos()) {
+			stream.advance(1);
+			return finishToken(offset, YamlTokenType.Unknown);
+		}
+
+		if (returnState == YamlScannerState.WithinFlowMapping) {
+			// In flow mapping, determine if this is a key or value
+			// It's a key if we just opened the object, after a comma, or after ObjectOpen
+			if (previousNoWhitespacesToken == YamlTokenType.Comma || 
+			    previousNoWhitespacesToken == YamlTokenType.ObjectOpen) {
+				return finishToken(offset, YamlTokenType.Key);
+			}
+		}
+
+		String text = stream.getSource().substring(offset, stream.pos()).trim();
+		YamlTokenType valueType = classifyValue(text);
+		state = returnState;
+		return finishToken(offset, valueType);
+	}
+
+	private YamlTokenType classifyValue(String text) {
+		if (text.isEmpty()) {
+			return YamlTokenType.Value;
+		}
+
+		// Check for null
+		if (text.equals("null") || text.equals("~") || text.equals("Null") || text.equals("NULL")) {
+			return YamlTokenType.ScalarNull;
+		}
+
+		// Check for boolean
+		if (text.equals("true") || text.equals("false") || text.equals("True") || text.equals("False")
+				|| text.equals("TRUE") || text.equals("FALSE") || text.equals("yes") || text.equals("no")
+				|| text.equals("Yes") || text.equals("No") || text.equals("YES") || text.equals("NO")
+				|| text.equals("on") || text.equals("off") || text.equals("On") || text.equals("Off")
+				|| text.equals("ON") || text.equals("OFF")) {
+			return YamlTokenType.ScalarBoolean;
+		}
+
+		// Check for number (basic check)
+		if (text.matches("-?\\d+(\\.\\d+)?([eE][+-]?\\d+)?") || text.matches("0x[0-9a-fA-F]+")
+				|| text.matches("0o[0-7]+")) {
+			return YamlTokenType.ScalarNumber;
+		}
+
+		// Check for special float values
+		if (text.equals(".inf") || text.equals(".Inf") || text.equals(".INF") || text.equals("-.inf")
+				|| text.equals("-.Inf") || text.equals("-.INF") || text.equals(".nan") || text.equals(".NaN")
+				|| text.equals(".NAN")) {
+			return YamlTokenType.ScalarNumber;
+		}
+
+		// Default to string scalar
+		return YamlTokenType.ScalarString;
+	}
+
+	private YamlTokenType handleStartString(int offset) {
+		if (stream.peekChar() == '"' || stream.peekChar() == '\'') {
+			// Remember current flow state
+			returnStateAfterString = state;
+			stringQuote = (char) stream.peekChar();
+			stream.advance(1);
+			state = YamlScannerState.WithinString;
+			return finishToken(offset, YamlTokenType.StartString);
+		}
+		return null;
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/scanner/YamlScannerState.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/scanner/YamlScannerState.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.parser.yaml.scanner;
+
+/**
+ * YAML scanner states.
+ * Represents the current scanning context.
+ */
+public enum YamlScannerState {
+	    WithinContent,
+	    AfterKey,
+	    AfterColon,
+	    AfterDash,
+	    WithinValue,
+	    WithinString,
+	    WithinComment,
+	    WithinFlowSequence,    // Inside [...]
+	    WithinFlowMapping;     // Inside {...}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/scanner/YamlTokenType.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/parser/yaml/scanner/YamlTokenType.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.parser.yaml.scanner;
+
+/**
+ * YAML token types.
+ */
+public enum YamlTokenType {
+
+	// Content tokens
+    Content,
+    Whitespace,
+    Newline,
+    
+    // Key-Value tokens
+    Key,
+    Colon,
+    Value,
+    
+    // Scalar value types
+    ScalarString,
+    ScalarNumber,
+    ScalarBoolean,
+    ScalarNull,
+    
+    // String tokens
+    StartString,
+    String,
+    EndString,
+    
+    // List tokens
+    Dash,
+    
+    // Flow collection tokens (JSON-style)
+    ArrayOpen,      // [
+    ArrayClose,     // ]
+    ObjectOpen,     // {
+    ObjectClose,    // }
+    Comma,
+    
+    // Comment tokens
+    StartComment,
+    Comment,
+    EndComment,
+    
+    // Other
+    Unknown,
+    EOS;
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/QuteTextDocument.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/QuteTextDocument.java
@@ -11,10 +11,12 @@
 *******************************************************************************/
 package com.redhat.qute.project;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import com.redhat.qute.commons.ProjectInfo;
+import com.redhat.qute.parser.injection.InjectionDetector;
 import com.redhat.qute.parser.template.Parameter;
 import com.redhat.qute.parser.template.Section;
 import com.redhat.qute.parser.template.Template;
@@ -106,6 +108,8 @@ public interface QuteTextDocument {
 	}
 
 	default void save() {
-		
+
 	}
+
+	Collection<InjectionDetector> getInjectionDetectors();
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/config/PropertyConfig.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/config/PropertyConfig.java
@@ -1,0 +1,20 @@
+package com.redhat.qute.project.config;
+
+public class PropertyConfig {
+
+	private final String name;
+	private final String defaultValue;
+
+	public PropertyConfig(String name, String defaultValue) {
+		this.name = name;
+		this.defaultValue = defaultValue;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getDefaultValue() {
+		return defaultValue;
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/ExtendedDataModelProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/ExtendedDataModelProject.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import com.redhat.qute.commons.JavaElementKind;
 import com.redhat.qute.commons.JavaParameterInfo;
 import com.redhat.qute.commons.JavaTypeInfo;
+import com.redhat.qute.commons.ProjectFeature;
 import com.redhat.qute.commons.datamodel.DataModelParameter;
 import com.redhat.qute.commons.datamodel.DataModelProject;
 import com.redhat.qute.commons.datamodel.DataModelTemplate;
@@ -33,7 +34,9 @@ import com.redhat.qute.commons.datamodel.resolvers.NamespaceResolverInfo;
 import com.redhat.qute.commons.datamodel.resolvers.ValueResolverKind;
 import com.redhat.qute.parser.expression.NamespacePart;
 import com.redhat.qute.project.QuteProject;
+import com.redhat.qute.project.config.PropertyConfig;
 import com.redhat.qute.project.datamodel.resolvers.FieldValueResolver;
+import com.redhat.qute.project.datamodel.resolvers.CustomValueResolver;
 import com.redhat.qute.project.datamodel.resolvers.MessageMethodValueResolver;
 import com.redhat.qute.project.datamodel.resolvers.MethodValueResolver;
 import com.redhat.qute.project.datamodel.resolvers.TypeValueResolver;
@@ -54,6 +57,8 @@ public class ExtendedDataModelProject extends DataModelProject<ExtendedDataModel
 
 	private final List<MethodValueResolver> methodValueResolvers;
 
+	private final List<CustomValueResolver> customValueResolvers;
+
 	private final Map<String, String> similarNamespaces;
 
 	private Set<String> javaTypesSupportedInNativeMode;
@@ -66,7 +71,8 @@ public class ExtendedDataModelProject extends DataModelProject<ExtendedDataModel
 
 		typeValueResolvers = new ArrayList<>();
 		fieldValueResolvers = new ArrayList<>();
-		methodValueResolvers = new ArrayList<MethodValueResolver>();
+		methodValueResolvers = new ArrayList<>();
+		customValueResolvers = new ArrayList<>();
 		updateValueResolvers(typeValueResolvers, fieldValueResolvers, methodValueResolvers, dataModelProject);
 		Collections.sort(methodValueResolvers, (r1, r2) -> {
 			if (r1.isMatchNameAny()) {
@@ -218,6 +224,10 @@ public class ExtendedDataModelProject extends DataModelProject<ExtendedDataModel
 		return fieldValueResolvers;
 	}
 
+	public List<CustomValueResolver> getCustomValueResolvers() {
+		return customValueResolvers;
+	}
+	
 	public NamespaceResolverInfo getNamespaceResolver(String namespace) {
 		String mainNamespace = getSimilarNamespace(namespace);
 		return super.getNamespaceResolverInfos().get(mainNamespace);
@@ -259,8 +269,24 @@ public class ExtendedDataModelProject extends DataModelProject<ExtendedDataModel
 		return javaTypesSupportedInNativeMode;
 	}
 
+	public boolean hasProjectFeature(ProjectFeature projectFeature) {
+		return project.hasProjectFeature(projectFeature);
+	}
+
+	public Path getProjectFolder() {
+		return project.getProjectFolder();
+	}
+
 	public Set<Path> getSourcePaths() {
 		return project.getSourcePaths();
+	}
+
+	public Path getConfigAsPath(PropertyConfig property) {
+		return project.getConfigAsPath(property);
+	}
+
+	public String getConfig(PropertyConfig property) {
+		return project.getConfig(property);
 	}
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/resolvers/CustomValueResolver.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/resolvers/CustomValueResolver.java
@@ -1,0 +1,68 @@
+package com.redhat.qute.project.datamodel.resolvers;
+
+import java.util.List;
+
+import com.redhat.qute.commons.JavaElementKind;
+import com.redhat.qute.commons.ResolvedJavaTypeInfo;
+import com.redhat.qute.commons.datamodel.resolvers.ValueResolverKind;
+import com.redhat.qute.parser.template.JavaTypeInfoProvider;
+import com.redhat.qute.parser.template.Node;
+
+public abstract class CustomValueResolver extends ResolvedJavaTypeInfo implements ValueResolver, JavaTypeInfoProvider {
+
+	private String namespace;
+
+	@Override
+	public String getNamed() {
+		return null;
+	}
+
+	public void setNamespace(String namespace) {
+		this.namespace = namespace;
+	}
+
+	@Override
+	public String getNamespace() {
+		return namespace;
+	}
+
+	@Override
+	public List<String> getMatchNames() {
+		return null;
+	}
+
+	@Override
+	public String getSignature() {
+		return null;
+	}
+
+	@Override
+	public String getSourceType() {
+		return null;
+	}
+
+	@Override
+	public boolean isGlobalVariable() {
+		return false;
+	}
+
+	@Override
+	public JavaElementKind getJavaElementKind() {
+		return JavaElementKind.CUSTOM;
+	}
+
+	@Override
+	public ValueResolverKind getKind() {
+		return ValueResolverKind.File;
+	}
+
+	@Override
+	public String getJavaElementType() {
+		return null;
+	}
+
+	@Override
+	public Node getJavaTypeOwnerNode() {
+		return null;
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/resolvers/ValueResolver.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/datamodel/resolvers/ValueResolver.java
@@ -13,6 +13,8 @@ package com.redhat.qute.project.datamodel.resolvers;
 
 import java.util.List;
 
+import org.eclipse.lsp4j.CompletionItemKind;
+
 import com.redhat.qute.commons.JavaElementKind;
 import com.redhat.qute.commons.datamodel.resolvers.ValueResolverKind;
 
@@ -46,14 +48,14 @@ public interface ValueResolver {
 	 * @return the namespace of the resolver and null otherwise.
 	 */
 	String getNamespace();
-	
+
 	/**
 	 * Returns match names of the resolver.
 	 * 
 	 * @return the match names of the resolver.
 	 */
 	List<String> getMatchNames();
-	
+
 	/**
 	 * Returns the Java element signature.
 	 *
@@ -83,4 +85,19 @@ public interface ValueResolver {
 	boolean isGlobalVariable();
 
 	ValueResolverKind getKind();
+
+	default CompletionItemKind getCompletionKind() {
+		switch (getJavaElementKind()) {
+		case FIELD:
+			return CompletionItemKind.Field;
+		case METHOD:
+			return CompletionItemKind.Method;
+		case TYPE:
+			return CompletionItemKind.Class;
+		case PARAMETER:
+			return CompletionItemKind.TypeParameter;
+		default:
+			return CompletionItemKind.Class;
+		}
+	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/documents/QuteClosedTextDocument.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/documents/QuteClosedTextDocument.java
@@ -12,6 +12,7 @@
 package com.redhat.qute.project.documents;
 
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -22,6 +23,8 @@ import java.util.stream.Collectors;
 import com.redhat.qute.commons.FileUtils;
 import com.redhat.qute.commons.ProjectInfo;
 import com.redhat.qute.ls.commons.TextDocument;
+import com.redhat.qute.parser.CancelChecker;
+import com.redhat.qute.parser.injection.InjectionDetector;
 import com.redhat.qute.parser.template.Parameter;
 import com.redhat.qute.parser.template.Section;
 import com.redhat.qute.parser.template.Template;
@@ -76,8 +79,7 @@ public class QuteClosedTextDocument implements QuteTextDocument {
 		}
 		try {
 			TextDocument document = new TextDocument(IOUtils.getContent(path), uri);
-			Template template = TemplateParser.parse(document, () -> {
-			});
+			Template template = TemplateParser.parse(document, getInjectionDetectors(), CancelChecker.NO_CANCELLABLE);
 			template.setTemplateId(templateId);
 			template.setProjectRegistry(project.getProjectRegistry());
 			template.setProjectUri(project.getUri());
@@ -170,5 +172,10 @@ public class QuteClosedTextDocument implements QuteTextDocument {
 			}
 
 		}
+	}
+
+	@Override
+	public Collection<InjectionDetector> getInjectionDetectors() {
+		return project.getInjectionDetectorsFor(path);
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/documents/QuteOpenedTextDocument.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/documents/QuteOpenedTextDocument.java
@@ -14,6 +14,8 @@ package com.redhat.qute.project.documents;
 import static com.redhat.qute.commons.FileUtils.createPath;
 
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
@@ -26,6 +28,7 @@ import com.redhat.qute.commons.QuteProjectParams;
 import com.redhat.qute.ls.api.QuteProjectInfoProvider;
 import com.redhat.qute.ls.commons.ModelTextDocument;
 import com.redhat.qute.ls.commons.TextDocument;
+import com.redhat.qute.parser.injection.InjectionDetector;
 import com.redhat.qute.parser.template.Parameter;
 import com.redhat.qute.parser.template.Section;
 import com.redhat.qute.parser.template.Template;
@@ -157,5 +160,17 @@ public class QuteOpenedTextDocument extends ModelTextDocument<Template> implemen
 			}
 
 		}
+	}
+
+	@Override
+	public Collection<InjectionDetector> getInjectionDetectors() {
+		if (templatePath == null) {
+			return Collections.emptyList();
+		}
+		QuteProject project = projectUri != null ? projectRegistry.getProject(projectUri) : null;
+		if (project == null) {
+			return Collections.emptyList();
+		}
+		return project.getInjectionDetectorsFor(templatePath);
 	}
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/DidChangeWatchedFilesParticipant.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/DidChangeWatchedFilesParticipant.java
@@ -12,8 +12,9 @@
 package com.redhat.qute.project.extensions;
 
 import java.nio.file.Path;
+import java.util.Set;
 
-import org.eclipse.lsp4j.FileEvent;
+import org.eclipse.lsp4j.FileChangeType;
 
 /**
  * Participant for handling file system changes relevant to the extension.
@@ -38,9 +39,9 @@ public interface DidChangeWatchedFilesParticipant {
 	 * </p>
 	 * 
 	 * @param filePath  the path of the changed file
-	 * @param fileEvent the file change event (type: Created, Changed, or Deleted)
+	 * @param changeTypes the file change event (type: Created, Changed, or Deleted)
 	 * @return true if this participant handled the file change, false otherwise
 	 */
-	boolean didChangeWatchedFile(Path filePath, FileEvent fileEvent);
+	boolean didChangeWatchedFile(Path filePath, Set<FileChangeType> changeTypes);
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/roq/RoqConfig.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/roq/RoqConfig.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.project.extensions.roq;
+
+import com.redhat.qute.project.config.PropertyConfig;
+
+/**
+ * Configuration properties for Roq integration.
+ * 
+ * <p>
+ * Defines Quarkus configuration properties that control Roq's behavior,
+ * particularly the location of Roq directories and data files.
+ * </p>
+ * 
+ * <h3>Configuration in application.properties:</h3>
+ * 
+ * <pre>
+ * # Root directory for Roq content (default: project root)
+ * quarkus.roq.dir=
+ * 
+ * # Directory containing data files (default: "data")
+ * quarkus.roq.data.dir=data
+ * </pre>
+ * 
+ * <h3>Directory Structure Example:</h3>
+ * 
+ * <pre>
+ * project-root/
+ * └── data/                      ← quarkus.roq.data.dir
+ *     ├── authors.yaml           → accessible as {inject:authors} in templates
+ *     ├── posts.json             → accessible as {inject:posts} in templates
+ *     └── site-config.yaml       → accessible as {inject:site-config} in templates
+ * </pre>
+ */
+public class RoqConfig {
+
+	/**
+	 * Root directory for Roq content.
+	 * 
+	 * <p>
+	 * <b>Property:</b> {@code quarkus.roq.dir}<br>
+	 * <b>Default:</b> {@code ""} (empty = project root)
+	 * </p>
+	 */
+	public static final PropertyConfig ROQ_DIR = new PropertyConfig("quarkus.roq.dir", "");
+
+	/**
+	 * Directory containing Roq data files (YAML, JSON).
+	 * 
+	 * <p>
+	 * <b>Property:</b> {@code quarkus.roq.data.dir}<br>
+	 * <b>Default:</b> {@code "data"}
+	 * </p>
+	 * 
+	 * <p>
+	 * Files in this directory are automatically loaded and made available in Qute
+	 * templates using the {@code inject:} namespace. For example,
+	 * {@code authors.yaml} becomes accessible as {@code {inject:authors}} in
+	 * templates.
+	 * </p>
+	 */
+	public static final PropertyConfig ROQ_DATA_DIR = new PropertyConfig("quarkus.roq.data.dir", "data");
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/roq/RoqProjectExtension.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/roq/RoqProjectExtension.java
@@ -1,0 +1,524 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.project.extensions.roq;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.FileChangeType;
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.InlayHint;
+import org.eclipse.lsp4j.LocationLink;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+
+import com.redhat.qute.commons.ProjectFeature;
+import com.redhat.qute.parser.expression.Part;
+import com.redhat.qute.parser.expression.Parts;
+import com.redhat.qute.parser.template.Expression;
+import com.redhat.qute.project.datamodel.ExtendedDataModelProject;
+import com.redhat.qute.project.datamodel.resolvers.CustomValueResolver;
+import com.redhat.qute.project.extensions.ProjectExtension;
+import com.redhat.qute.project.extensions.roq.data.DataLoader;
+import com.redhat.qute.project.extensions.roq.data.RoqDataFile;
+import com.redhat.qute.project.extensions.roq.data.json.JsonDataLoader;
+import com.redhat.qute.project.extensions.roq.data.yaml.YamlDataLoader;
+import com.redhat.qute.services.ResolvingJavaTypeContext;
+import com.redhat.qute.services.completions.CompletionRequest;
+import com.redhat.qute.settings.QuteCompletionSettings;
+import com.redhat.qute.settings.QuteFormattingSettings;
+import com.redhat.qute.settings.QuteValidationSettings;
+
+/**
+ * Qute project extension for Roq integration.
+ * 
+ * <p>
+ * This extension enables Roq data file support in Qute templates by:
+ * </p>
+ * <ul>
+ * <li>Discovering data files (YAML, JSON) in the configured data directory</li>
+ * <li>Loading and parsing data files using appropriate loaders</li>
+ * <li>Registering data files as value resolvers for template access</li>
+ * <li>Watching for file changes and updating resolvers accordingly</li>
+ * </ul>
+ * 
+ * <h3>Lifecycle:</h3>
+ * <ol>
+ * <li><b>init()</b> - Detects Roq projects, locates data directory</li>
+ * <li><b>loadRoqDataFiles()</b> - Scans and loads all data files</li>
+ * <li><b>didChangeWatchedFile()</b> - Handles file
+ * changes/creation/deletion</li>
+ * </ol>
+ * 
+ * <h3>Data File Registration:</h3>
+ * <p>
+ * Each data file is registered with two namespaces:
+ * <ul>
+ * <li>{@code cdi:} - CDI namespace for backward compatibility</li>
+ * <li>{@code inject:} - Inject namespace (primary access method)</li>
+ * </ul>
+ * </p>
+ * 
+ * <h3>Example:</h3>
+ * 
+ * <pre>
+ * data/
+ * └── authors.yaml
+ * 
+ * Template access:
+ * {inject:authors.name}  ← Primary
+ * {cdi:authors.name}     ← Alternative
+ * </pre>
+ * 
+ * <h3>Supported File Types:</h3>
+ * <ul>
+ * <li><b>.yaml, .yml</b> - YAML files (YamlDataLoader)</li>
+ * <li><b>.json</b> - JSON files (JsonDataLoader)</li>
+ * </ul>
+ * 
+ * @see ProjectExtension
+ * @see RoqDataFile
+ * @see DataLoader
+ */
+public class RoqProjectExtension implements ProjectExtension {
+
+	/**
+	 * Registry mapping file extensions to their corresponding data loaders.
+	 * 
+	 * <p>
+	 * This static registry is initialized once and shared across all instances. It
+	 * determines which loader to use based on the file extension.
+	 * </p>
+	 * 
+	 * <h3>Registered Loaders:</h3>
+	 * <ul>
+	 * <li>"yml" → YamlDataLoader</li>
+	 * <li>"yaml" → YamlDataLoader</li>
+	 * <li>"json" → JsonDataLoader</li>
+	 * </ul>
+	 * 
+	 * <h3>Adding New Loaders:</h3>
+	 * 
+	 * <pre>
+	 * // Example: Add TOML support
+	 * dataLoaderRegistry.put("toml", new TomlDataLoader());
+	 * </pre>
+	 */
+	private static final Map<String /* file extension */, DataLoader> dataLoaderRegistrty;
+
+	static {
+		// Initialize the loader registry
+		dataLoaderRegistrty = new HashMap<>();
+
+		// YAML files (.yml and .yaml)
+		YamlDataLoader yamlDataLoader = new YamlDataLoader();
+		dataLoaderRegistrty.put("yml", yamlDataLoader);
+		dataLoaderRegistrty.put("yaml", yamlDataLoader);
+
+		// JSON files (.json)
+		dataLoaderRegistrty.put("json", new JsonDataLoader());
+	}
+
+	/**
+	 * Cache entry for a registered data file.
+	 * 
+	 * <p>
+	 * Each data file is registered with two resolvers (cdi and inject namespaces).
+	 * This class keeps both references together for efficient cache management.
+	 * </p>
+	 * 
+	 * <h3>Purpose:</h3>
+	 * <p>
+	 * When a file changes or is deleted, we need to remove both resolvers from the
+	 * data model. This cache entry provides quick access to both.
+	 * </p>
+	 */
+	private static class ResolverCache {
+		/** Resolver for cdi namespace (e.g., {cdi:authors}) */
+		public final CustomValueResolver cdi;
+
+		/** Resolver for inject namespace (e.g., {inject:authors}) */
+		public final CustomValueResolver inject;
+
+		public ResolverCache(CustomValueResolver cdi, CustomValueResolver inject) {
+			this.cdi = cdi;
+			this.inject = inject;
+		}
+	}
+
+	/** Whether this extension is enabled (true for Roq projects) */
+	private boolean enabled;
+
+	/** Path to the data directory (e.g., project-root/data/) */
+	private Path dataDir;
+
+	/**
+	 * Cache mapping file paths to their registered resolvers.
+	 * 
+	 * <p>
+	 * Used for efficient lookup when handling file change events:
+	 * <ul>
+	 * <li>File modified → Remove old resolvers, register new ones</li>
+	 * <li>File deleted → Remove resolvers</li>
+	 * </ul>
+	 * </p>
+	 */
+	private final Map<Path, ResolverCache> dataResolverCache;
+
+	/** Reference to the parent data model project */
+	private ExtendedDataModelProject dataModelProject;
+
+	/**
+	 * Creates a new Roq project extension.
+	 */
+	public RoqProjectExtension() {
+		this.dataResolverCache = new HashMap<>();
+	}
+
+	/**
+	 * Initializes the extension for a Qute project.
+	 * 
+	 * <p>
+	 * This method is called when the project is loaded. It:
+	 * <ol>
+	 * <li>Checks if Roq is enabled via ProjectFeature.Roq</li>
+	 * <li>Resolves the data directory from configuration</li>
+	 * <li>Loads all data files from the directory</li>
+	 * </ol>
+	 * </p>
+	 * 
+	 * <h3>Configuration:</h3>
+	 * <p>
+	 * The data directory is determined by:
+	 * 
+	 * <pre>
+	 * dataDir = quarkus.roq.dir / quarkus.roq.data.dir
+	 * 
+	 * Example:
+	 * quarkus.roq.dir=          (project root)
+	 * quarkus.roq.data.dir=data (relative path)
+	 * → dataDir = project-root/data/
+	 * </pre>
+	 * </p>
+	 * 
+	 * @param dataModelProject The project data model to extend
+	 */
+	@Override
+	public void init(ExtendedDataModelProject dataModelProject) {
+		this.dataModelProject = dataModelProject;
+
+		// Check if Roq is enabled for this project
+		enabled = dataModelProject.hasProjectFeature(ProjectFeature.Roq);
+
+		if (enabled) {
+			if (dataDir == null) {
+				// Resolve the Roq root directory
+				Path roqDir = dataModelProject.getConfigAsPath(RoqConfig.ROQ_DIR);
+
+				if (roqDir != null) {
+					// Resolve the data subdirectory
+					dataDir = roqDir.resolve(dataModelProject.getConfig(RoqConfig.ROQ_DATA_DIR));
+
+					if (dataDir != null) {
+						// Load all data files from the directory
+						loadRoqDataFiles(dataModelProject);
+					}
+				}
+			}
+		} else {
+			// Roq not enabled - clear data directory
+			dataDir = null;
+		}
+	}
+
+	/**
+	 * Scans the data directory and loads all data files.
+	 * 
+	 * <p>
+	 * Iterates through all regular files in the data directory and registers them
+	 * as data file resolvers if they have a supported file extension (.yaml, .yml,
+	 * .json).
+	 * </p>
+	 * 
+	 * <h3>Error Handling:</h3>
+	 * <p>
+	 * IOException is silently ignored - this handles cases where:
+	 * <ul>
+	 * <li>The data directory doesn't exist yet</li>
+	 * <li>Permission errors occur</li>
+	 * <li>I/O errors happen during scanning</li>
+	 * </ul>
+	 * </p>
+	 * 
+	 * @param dataModelProject The project to register resolvers with
+	 */
+	private void loadRoqDataFiles(ExtendedDataModelProject dataModelProject) {
+		try (DirectoryStream<Path> stream = Files.newDirectoryStream(dataDir)) {
+			for (Path file : stream) {
+				// Only process regular files (skip directories, symlinks, etc.)
+				if (Files.isRegularFile(file)) {
+					regsterRoqDataFile(file, dataModelProject);
+				}
+			}
+		} catch (IOException e) {
+			// Silently ignore - data directory may not exist yet
+		}
+	}
+
+	/**
+	 * Registers a single data file as a value resolver.
+	 * 
+	 * <p>
+	 * This method:
+	 * <ol>
+	 * <li>Determines the file extension</li>
+	 * <li>Looks up the appropriate DataLoader</li>
+	 * <li>Creates two RoqDataFile instances (cdi and inject namespaces)</li>
+	 * <li>Registers both with the data model</li>
+	 * <li>Caches them for future updates</li>
+	 * </ol>
+	 * </p>
+	 * 
+	 * <h3>Example:</h3>
+	 * 
+	 * <pre>
+	 * File: data/authors.yaml
+	 * 
+	 * Creates:
+	 * - RoqDataFile(authors.yaml, "cdi", YamlDataLoader)
+	 * - RoqDataFile(authors.yaml, "inject", YamlDataLoader)
+	 * 
+	 * Template access:
+	 * {cdi:authors.name}
+	 * {inject:authors.name}
+	 * </pre>
+	 * 
+	 * <h3>Unsupported Files:</h3>
+	 * <p>
+	 * If the file extension has no registered loader (e.g., .txt, .xml), the file
+	 * is silently ignored.
+	 * </p>
+	 * 
+	 * @param file             The data file to register
+	 * @param dataModelProject The project to register with
+	 */
+	private void regsterRoqDataFile(Path file, ExtendedDataModelProject dataModelProject) {
+		// Get file extension (e.g., "yaml", "json")
+		String fileExtension = getFileExtension(file);
+
+		// Look up the appropriate loader
+		DataLoader dataLoader = dataLoaderRegistrty.get(fileExtension);
+
+		if (dataLoader != null) {
+			// Create resolver for cdi namespace
+			RoqDataFile cdiResolver = new RoqDataFile(file, "cdi", dataLoader);
+
+			// Create resolver for inject namespace (reuses fields from cdi)
+			RoqDataFile injectResolver = cdiResolver.create("inject");
+
+			// Cache both resolvers for this file
+			dataResolverCache.put(file, new ResolverCache(cdiResolver, injectResolver));
+
+			// Register both resolvers with the data model
+			dataModelProject.getCustomValueResolvers().add(cdiResolver);
+			dataModelProject.getCustomValueResolvers().add(injectResolver);
+		}
+		// Else: Unsupported file type, silently ignore
+	}
+
+	/**
+	 * Handles autocomplete requests.
+	 * 
+	 * <p>
+	 * Currently not implemented for Roq extension. Autocomplete for data files is
+	 * handled by the standard Qute completion mechanism using the registered
+	 * resolvers.
+	 * </p>
+	 */
+	@Override
+	public void doComplete(CompletionRequest completionRequest, Part part, Parts parts,
+			QuteCompletionSettings completionSettings, QuteFormattingSettings formattingSettings,
+			Set<CompletionItem> completionItems, CancelChecker cancelChecker) {
+		// Not implemented - standard completion handles data file resolvers
+	}
+
+	/**
+	 * Handles go-to-definition requests.
+	 * 
+	 * <p>
+	 * Currently not implemented for Roq extension. Definition navigation for data
+	 * files is handled by the DefinitionExtensionProvider interface implemented by
+	 * RoqDataFile.
+	 * </p>
+	 */
+	@Override
+	public void definition(Part part, List<LocationLink> locationLinks, CancelChecker cancelChecker) {
+		// Not implemented - RoqDataFile handles its own definition navigation
+	}
+
+	/**
+	 * Validates template expressions.
+	 * 
+	 * <p>
+	 * Currently not implemented for Roq extension. Validation is handled by the
+	 * standard Qute validation mechanism using the registered resolvers.
+	 * </p>
+	 */
+	@Override
+	public boolean validateExpression(Parts parts, QuteValidationSettings validationSettings,
+			ResolvingJavaTypeContext resolvingJavaTypeContext, List<Diagnostic> diagnostics) {
+		// Not implemented - standard validation handles data file resolvers
+		return false;
+	}
+
+	/**
+	 * Handles file system change events for data files.
+	 * 
+	 * <p>
+	 * This method watches for changes to files in the data directory and:
+	 * <ul>
+	 * <li><b>Created</b> - Registers the new file as a resolver</li>
+	 * <li><b>Changed</b> - Reloads the file and updates resolvers</li>
+	 * <li><b>Deleted</b> - Removes resolvers from the data model</li>
+	 * </ul>
+	 * </p>
+	 * 
+	 * <h3>Hot Reload:</h3>
+	 * <p>
+	 * This enables hot reload of data files during development:
+	 * 
+	 * <pre>
+	 * 1. User edits data/authors.yaml
+	 * 2. didChangeWatchedFile() is called
+	 * 3. Old resolvers removed, new ones created
+	 * 4. Templates immediately reflect new data
+	 * </pre>
+	 * </p>
+	 * 
+	 * <h3>Return Value:</h3>
+	 * <p>
+	 * Returns true if the file was handled by this extension, false otherwise. This
+	 * allows other extensions to handle the event if needed.
+	 * </p>
+	 * 
+	 * @param filePath    The file that changed
+	 * @param changeTypes The types of changes (Created, Changed, Deleted)
+	 * @return true if this extension handled the file, false otherwise
+	 */
+	@Override
+	public boolean didChangeWatchedFile(Path filePath, Set<FileChangeType> changeTypes) {
+		// Check if the file is in our data directory
+		if (dataDir != null && filePath.startsWith(dataDir)) {
+
+			if (changeTypes.contains(FileChangeType.Changed)) {
+				// File modified - reload it
+
+				// Remove old resolvers
+				ResolverCache resolver = dataResolverCache.remove(filePath);
+				if (resolver != null) {
+					dataModelProject.getCustomValueResolvers().remove(resolver.cdi);
+					dataModelProject.getCustomValueResolvers().remove(resolver.inject);
+				}
+
+				// Register new resolvers with fresh data
+				regsterRoqDataFile(filePath, dataModelProject);
+				return true;
+
+			} else if (changeTypes.contains(FileChangeType.Created)) {
+				// New file created - register it
+				regsterRoqDataFile(filePath, dataModelProject);
+				return true;
+
+			} else if (changeTypes.contains(FileChangeType.Deleted)) {
+				// File deleted - remove resolvers
+				ResolverCache resolver = dataResolverCache.remove(filePath);
+				if (resolver != null) {
+					dataModelProject.getCustomValueResolvers().remove(resolver.cdi);
+					dataModelProject.getCustomValueResolvers().remove(resolver.inject);
+					return true;
+				}
+				return false;
+			}
+		}
+
+		// Not our file
+		return false;
+	}
+
+	/**
+	 * Handles hover requests.
+	 * 
+	 * <p>
+	 * Currently not implemented for Roq extension. Hover support for data files is
+	 * handled by the HoverExtensionProvider interface implemented by RoqDataFile.
+	 * </p>
+	 */
+	@Override
+	public void doHover(Part part, List<Hover> hovers, CancelChecker cancelChecker) {
+		// Not implemented - RoqDataFile handles its own hover documentation
+	}
+
+	/**
+	 * Handles inlay hint requests.
+	 * 
+	 * <p>
+	 * Currently not implemented for Roq extension. Inlay hints (inline parameter
+	 * names, type hints, etc.) are not currently provided for data file access.
+	 * </p>
+	 */
+	@Override
+	public void inlayHint(Expression node, List<InlayHint> inlayHints, CancelChecker cancelChecker) {
+		// Not implemented - no inlay hints for data files yet
+	}
+
+	/**
+	 * Checks if this extension is enabled.
+	 * 
+	 * <p>
+	 * Returns true if the project has the Roq feature enabled, false otherwise.
+	 * When disabled, all extension methods are skipped for performance.
+	 * </p>
+	 * 
+	 * @return true if Roq is enabled for this project
+	 */
+	@Override
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	/**
+	 * Extracts the file extension from a path.
+	 * 
+	 * <h3>Examples:</h3>
+	 * <ul>
+	 * <li>{@code authors.yaml} → "yaml"</li>
+	 * <li>{@code data.json} → "json"</li>
+	 * <li>{@code no-extension} → ""</li>
+	 * <li>{@code .hidden} → "hidden"</li>
+	 * </ul>
+	 * 
+	 * @param path The file path to process
+	 * @return The file extension (without dot) or empty string if none
+	 */
+	static String getFileExtension(Path path) {
+		String name = path.getFileName().toString();
+		int lastDot = name.lastIndexOf('.');
+		return (lastDot == -1) ? "" : name.substring(lastDot + 1);
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/roq/data/DataLoader.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/roq/data/DataLoader.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.project.extensions.roq.data;
+
+/**
+ * Strategy interface for loading data files in different formats.
+ * 
+ * <p>
+ * This interface defines the contract for data loaders that convert various
+ * file formats (YAML, JSON, etc.) into JavaFieldInfo structures that provide
+ * IDE support (autocomplete, validation) in Qute templates.
+ * </p>
+ * 
+ * <p>
+ * Each implementation is responsible for:
+ * <ul>
+ * <li>Reading the file content from disk</li>
+ * <li>Parsing the content using an appropriate parser (Jackson, Gson,
+ * etc.)</li>
+ * <li>Extracting the data structure and inferring Java types</li>
+ * <li>Populating the RoqDataFile with discovered fields</li>
+ * <li>Handling errors gracefully (malformed files, IO errors, etc.)</li>
+ * </ul>
+ * </p>
+ * 
+ * <h3>Implementations:</h3>
+ * <ul>
+ * <li>{@code YamlDataLoader} - Uses Jackson's YAMLMapper for .yaml/.yml
+ * files</li>
+ * <li>{@code JsonDataLoader} - Uses Gson's JsonParser for .json files</li>
+ * </ul>
+ * 
+ * <h3>Example Usage:</h3>
+ * 
+ * <pre>
+ * RoqDataFile dataFile = new RoqDataFile(path, "authors");
+ * DataLoader loader = new YamlDataLoader();
+ * loader.load(dataFile);
+ * 
+ * // Now dataFile contains:
+ * // - List of JavaFieldInfo (discovered fields)
+ * // - Type signatures for each field
+ * // - Nested structures for complex objects
+ * </pre>
+ * 
+ * <h3>Type Inference:</h3>
+ * <p>
+ * Implementations should infer Java types from data file values:
+ * <ul>
+ * <li>Scalars → String, Integer, Long, Double, Boolean</li>
+ * <li>Objects/Maps → java.lang.Object with nested fields</li>
+ * <li>Arrays/Lists → java.util.Collection&lt;T&gt; with inferred item type</li>
+ * <li>Null values → java.lang.Object (unknown type)</li>
+ * </ul>
+ * </p>
+ * 
+ * @see RoqDataFile
+ * @see com.redhat.qute.commons.JavaFieldInfo
+ * @see com.redhat.qute.project.extensions.roq.data.yaml.YamlDataLoader
+ * @see com.redhat.qute.project.extensions.roq.data.json.JsonDataLoader
+ */
+public interface DataLoader {
+
+	/**
+	 * Loads and parses a data file, populating the RoqDataFile with discovered
+	 * field information.
+	 * 
+	 * <p>
+	 * This method should:
+	 * <ol>
+	 * <li>Read the file content from {@code roqDataFile.getFilePath()}</li>
+	 * <li>Parse the content using an appropriate parser</li>
+	 * <li>Extract all fields and their types recursively</li>
+	 * <li>Call {@code roqDataFile.setFields()} with discovered fields</li>
+	 * <li>Call {@code roqDataFile.setSignature()} with the file signature</li>
+	 * <li>Handle errors gracefully (set empty fields on failure)</li>
+	 * </ol>
+	 * </p>
+	 * 
+	 * <h3>Error Handling:</h3>
+	 * <p>
+	 * Implementations should NOT throw exceptions. Instead, on any error
+	 * (IOException, parse error, etc.), they should initialize the RoqDataFile with
+	 * empty/default values:
+	 * </p>
+	 * 
+	 * <pre>
+	 * try {
+	 * 	// parsing logic
+	 * } catch (Exception e) {
+	 * 	roqDataFile.setFields(List.of());
+	 * 	roqDataFile.setSignature(roqDataFile.getName() + " : Object");
+	 * }
+	 * </pre>
+	 * 
+	 * <h3>Thread Safety:</h3>
+	 * <p>
+	 * Implementations should be stateless and thread-safe. Multiple threads may
+	 * call this method concurrently on different RoqDataFile instances.
+	 * </p>
+	 * 
+	 * @param roqDataFile The data file to load and populate with field information.
+	 *                    Must not be null. The file path must be set via
+	 *                    {@code roqDataFile.getFilePath()}.
+	 */
+	void load(RoqDataFile roqDataFile);
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/roq/data/RoqDataCollection.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/roq/data/RoqDataCollection.java
@@ -1,0 +1,166 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.project.extensions.roq.data;
+
+import com.redhat.qute.commons.ResolvedJavaTypeInfo;
+
+/**
+ * Represents a collection/array type from data files (YAML, JSON).
+ * 
+ * <p>
+ * This class wraps another type to indicate it's iterable, enabling Qute
+ * templates to use loop constructs like {@code #for} and {@code #each}.
+ * </p>
+ * 
+ * <h3>Purpose:</h3>
+ * <p>
+ * When a data file contains an array/list:
+ * 
+ * <pre>
+ * books:
+ *   - title: "Book 1"
+ *     author: "John"
+ *   - title: "Book 2"
+ *     author: "Jane"
+ * </pre>
+ * </p>
+ * 
+ * <p>
+ * The "books" field is represented as:
+ * <ul>
+ * <li><b>Outer type:</b> ArrayDataMapping (indicates it's iterable)</li>
+ * <li><b>Inner type:</b> ResolvedJavaTypeInfo with fields [title, author]</li>
+ * </ul>
+ * </p>
+ * 
+ * <h3>Template Usage:</h3>
+ * 
+ * <pre>
+ * {#for book in authors.books}
+ *   {book.title} by {book.author}
+ * {/for}
+ * </pre>
+ * 
+ * <h3>Type Mapping:</h3>
+ * <ul>
+ * <li>YAML/JSON array → {@code java.util.Collection<T>}</li>
+ * <li>Item type T → stored as resolvedType</li>
+ * <li>Signature → {@code "java.util.Collection<ItemType>"}</li>
+ * </ul>
+ * 
+ * <h3>Alternative Names:</h3>
+ * <p>
+ * Consider renaming to make the purpose clearer:
+ * <ul>
+ * <li>{@code RoqDataCollection} - emphasizes it's from data files</li>
+ * <li>{@code IterableDataType} - emphasizes the iterable behavior</li>
+ * <li>{@code DataArrayType} - shorter, clearer than "Mapping"</li>
+ * <li>{@code CollectionTypeWrapper} - describes the wrapping pattern</li>
+ * </ul>
+ * </p>
+ * 
+ * @see ResolvedJavaTypeInfo
+ * @see RoqDataField
+ * @see RoqDataFile
+ */
+public class RoqDataCollection extends ResolvedJavaTypeInfo {
+
+	/**
+	 * Creates a new array/collection type wrapper.
+	 * 
+	 * <p>
+	 * Wraps an item type to indicate it's iterable in templates.
+	 * </p>
+	 * 
+	 * <h3>Example:</h3>
+	 * 
+	 * <pre>
+	 * // For array of strings: ["a", "b", "c"]
+	 * ResolvedJavaTypeInfo stringType = new ResolvedJavaTypeInfo();
+	 * stringType.setSignature("java.lang.String");
+	 * ArrayDataMapping arrayType = new ArrayDataMapping(stringType);
+	 * 
+	 * // Now arrayType.isIterable() returns true
+	 * // And arrayType.getResolvedType() returns stringType
+	 * </pre>
+	 * 
+	 * <h3>Example with complex objects:</h3>
+	 * 
+	 * <pre>
+	 * // For array of objects: [{ name: "John" }, { name: "Jane" }]
+	 * ResolvedJavaTypeInfo objectType = new ResolvedJavaTypeInfo();
+	 * objectType.setFields([nameField]);
+	 * objectType.setSignature("java.lang.Object");
+	 * ArrayDataMapping arrayType = new ArrayDataMapping(objectType);
+	 * 
+	 * // Template can now iterate and access fields:
+	 * // {#for person in people}{person.name}{/for}
+	 * </pre>
+	 * 
+	 * @param iterableType The type of items in the collection. This is the "T" in
+	 *                     Collection<T>. For example: String, Integer, or a complex
+	 *                     object type
+	 */
+	public RoqDataCollection(ResolvedJavaTypeInfo iterableType) {
+		// Store the item type - used by template engine to resolve item properties
+		super.setResolvedType(iterableType);
+
+		// Empty signature - actual signature set by caller
+		// (e.g., "fieldName : java.util.Collection<String>")
+		super.setSignature("");
+	}
+
+	/**
+	 * Indicates this type is iterable in templates.
+	 * 
+	 * <p>
+	 * Enables Qute template loop constructs:
+	 * <ul>
+	 * <li>{@code #for item in collection}</li>
+	 * <li>{@code #each collection}</li>
+	 * <li>{@code collection.size}</li>
+	 * <li>{@code collection.isEmpty}</li>
+	 * </ul>
+	 * </p>
+	 * 
+	 * @return true - always iterable
+	 */
+	@Override
+	public boolean isIterable() {
+		return true;
+	}
+
+	/**
+	 * Returns the iteration type name.
+	 * 
+	 * <p>
+	 * Currently returns empty string. The actual item type is retrieved via
+	 * {@code getResolvedType()}.
+	 * </p>
+	 * 
+	 * <p>
+	 * This method might be used for type hints in IDEs or error messages. Consider
+	 * returning a meaningful value like:
+	 * <ul>
+	 * <li>{@code "java.util.Collection"}</li>
+	 * <li>{@code getResolvedType().getSignature()}</li>
+	 * </ul>
+	 * </p>
+	 * 
+	 * @return Empty string (could be enhanced to return actual type)
+	 */
+	@Override
+	public String getIterableOf() {
+		return "";
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/roq/data/RoqDataField.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/roq/data/RoqDataField.java
@@ -1,0 +1,287 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.project.extensions.roq.data;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.LocationLink;
+import org.eclipse.lsp4j.MarkupContent;
+import org.eclipse.lsp4j.MarkupKind;
+import org.eclipse.lsp4j.Range;
+
+import com.redhat.qute.commons.FileUtils;
+import com.redhat.qute.commons.JavaFieldInfo;
+import com.redhat.qute.commons.ResolvedJavaTypeInfo;
+import com.redhat.qute.parser.expression.Part;
+import com.redhat.qute.services.extensions.DefinitionExtensionProvider;
+import com.redhat.qute.services.extensions.HoverExtensionProvider;
+import com.redhat.qute.services.hover.HoverRequest;
+import com.redhat.qute.utils.DocumentationUtils;
+import com.redhat.qute.utils.QutePositionUtility;
+
+/**
+ * Represents a field from a Roq data file (YAML, JSON, etc.).
+ * 
+ * <p>
+ * This class extends JavaFieldInfo to provide LSP (Language Server Protocol)
+ * features for data file fields in Qute templates:
+ * </p>
+ * <ul>
+ * <li><b>Go to Definition</b> - Navigate from template usage to source data
+ * file</li>
+ * <li><b>Hover</b> - Show field type and source file in tooltip</li>
+ * <li><b>Autocomplete</b> - Field appears in template completion lists</li>
+ * </ul>
+ * 
+ * <h3>Example:</h3>
+ * <p>
+ * Given a YAML file {@code authors.yaml}:
+ * 
+ * <pre>
+ * name: John Doe
+ * email: john@example.com
+ * </pre>
+ * </p>
+ * 
+ * <p>
+ * In a Qute template {@code {authors.name}}:
+ * <ul>
+ * <li>Hovering over "name" shows: {@code String name} (Source:
+ * authors.yaml)</li>
+ * <li>Ctrl+Click on "name" opens authors.yaml</li>
+ * </ul>
+ * </p>
+ * 
+ * @see JavaFieldInfo
+ * @see RoqDataFile
+ * @see DefinitionExtensionProvider
+ * @see HoverExtensionProvider
+ */
+public class RoqDataField extends JavaFieldInfo implements DefinitionExtensionProvider, HoverExtensionProvider {
+
+	/** The resolved field name (e.g., "name", "email", "items") */
+	private final String resolvedName;
+
+	/** Reference to the parent data file that contains this field */
+	private final RoqDataFile document;
+
+	/**
+	 * Creates a new RoqDataField.
+	 * 
+	 * @param resolvedName The field name as it appears in the data file
+	 * @param resolvedType The Java type of this field (String, Integer, Object,
+	 *                     Collection, etc.) May be null for simple scalar types
+	 * @param document     The parent RoqDataFile containing this field
+	 */
+	public RoqDataField(String resolvedName, ResolvedJavaTypeInfo resolvedType, RoqDataFile document) {
+		this.resolvedName = resolvedName;
+		super.setResolvedType(resolvedType);
+		this.document = document;
+	}
+
+	/**
+	 * Indicates that documentation should not be lazily loaded.
+	 * 
+	 * <p>
+	 * Data file fields generate their documentation on-the-fly from the field type
+	 * and source file, so there's no need to load external JavaDoc or similar
+	 * resources.
+	 * </p>
+	 * 
+	 * @return false - documentation is generated dynamically, not loaded
+	 */
+	@Override
+	public boolean shouldLoadDocumentation() {
+		return false;
+	}
+
+	/**
+	 * Returns the field name.
+	 * 
+	 * <p>
+	 * This is the name used in templates, matching the key from the source data
+	 * file (e.g., "name" from {@code name: John}).
+	 * </p>
+	 * 
+	 * @return The field name
+	 */
+	@Override
+	public String getName() {
+		return resolvedName;
+	}
+
+	/**
+	 * Returns the parent data file that contains this field.
+	 * 
+	 * <p>
+	 * Used for "Go to Definition" to navigate to the source file, and for hover
+	 * documentation to show the file path.
+	 * </p>
+	 * 
+	 * @return The parent RoqDataFile
+	 */
+	public RoqDataFile getDocument() {
+		return document;
+	}
+
+	/**
+	 * Provides "Go to Definition" support for this field.
+	 * 
+	 * <p>
+	 * When a user Ctrl+Clicks on this field in a template, the IDE will open the
+	 * source data file (YAML, JSON, etc.) that defines it.
+	 * </p>
+	 * 
+	 * <p>
+	 * Currently navigates to the start of the file (position 0:0) rather than the
+	 * exact field location. Future enhancement could parse the file to find the
+	 * precise line/column of the field definition.
+	 * </p>
+	 * 
+	 * @param part The template expression part being navigated from (e.g., "name"
+	 *             in {@code {authors.name}})
+	 * @return A list containing a single LocationLink to the source file
+	 */
+	@Override
+	public List<? extends LocationLink> getLocations(Part part) {
+		LocationLink link = new LocationLink();
+
+		// Origin: The position in the template where the user clicked
+		link.setOriginSelectionRange(QutePositionUtility.createRange(part));
+
+		// Target: The data file URI (e.g., file:///path/to/authors.yaml)
+		link.setTargetUri(FileUtils.toUri(document.getFilePath()));
+
+		// Target position: Start of file (0:0)
+		// TODO: Could enhance to find exact field location in the data file
+		link.setTargetRange(QutePositionUtility.ZERO_RANGE);
+		link.setTargetSelectionRange(QutePositionUtility.ZERO_RANGE);
+
+		return Collections.singletonList(link);
+	}
+
+	/**
+	 * Provides hover documentation for this field.
+	 * 
+	 * <p>
+	 * When a user hovers over this field in a template, displays:
+	 * <ul>
+	 * <li>Field type and name in code block (e.g., {@code String name})</li>
+	 * <li>Source file as a clickable link</li>
+	 * </ul>
+	 * </p>
+	 * 
+	 * <p>
+	 * Example hover content (Markdown):
+	 * 
+	 * <pre>
+	 * ```java
+	 * String name
+	 * ```
+	 * Source: [authors.yaml](file:///path/to/authors.yaml)
+	 * </pre>
+	 * </p>
+	 * 
+	 * @param part         The template expression part being hovered over
+	 * @param hoverRequest The hover request with client capabilities
+	 * @return A Hover object with formatted documentation
+	 */
+	@Override
+	public Hover getHover(Part part, HoverRequest hoverRequest) {
+		// Check if the client supports Markdown formatting
+		boolean hasMarkdown = hoverRequest.canSupportMarkupKind(MarkupKind.MARKDOWN);
+
+		// Generate the hover content
+		MarkupContent content = getDocumentation(this, hasMarkdown);
+
+		// The range in the template that this hover applies to
+		Range range = QutePositionUtility.createRange(part);
+
+		return new Hover(content, range);
+	}
+
+	/**
+	 * Generates the hover documentation content for a field.
+	 * 
+	 * <p>
+	 * Creates formatted documentation showing:
+	 * <ol>
+	 * <li>Field signature in a code block (if Markdown supported)</li>
+	 * <li>Source file path as a clickable link (if Markdown supported)</li>
+	 * </ol>
+	 * </p>
+	 * 
+	 * <h3>Markdown Format:</h3>
+	 * 
+	 * <pre>
+	 * ```java
+	 * String name
+	 * ```
+	 * Source: [authors.yaml](file:///path/to/authors.yaml)
+	 * </pre>
+	 * 
+	 * <h3>Plain Text Format:</h3>
+	 * 
+	 * <pre>
+	 * String name
+	 * Source: file:///path/to/authors.yaml
+	 * </pre>
+	 * 
+	 * @param field    The field to document
+	 * @param markdown Whether to use Markdown formatting
+	 * @return Formatted documentation as MarkupContent
+	 */
+	private static MarkupContent getDocumentation(RoqDataField field, boolean markdown) {
+		StringBuilder documentation = new StringBuilder();
+
+		// Field signature section
+		if (markdown) {
+			documentation.append("```java");
+			documentation.append(System.lineSeparator());
+		}
+
+		// Type and name (e.g., "String name")
+		documentation.append(getSimpleType(field.getType()));
+		documentation.append(" ");
+		documentation.append(field.getName());
+
+		if (markdown) {
+			documentation.append(System.lineSeparator());
+			documentation.append("```");
+		}
+		documentation.append(System.lineSeparator());
+
+		// Source file section
+		Path filePath = field.getDocument().getFilePath();
+		String fileUri = filePath.toUri().toString();
+		documentation.append("Source: ");
+
+		if (markdown) {
+			// Create a clickable link: [filename](file://...)
+			documentation.append("[");
+			documentation.append(filePath.getFileName().toString());
+			documentation.append("]");
+			documentation.append("(");
+			documentation.append(fileUri);
+			documentation.append(")");
+		} else {
+			// Plain text: just show the URI
+			documentation.append(fileUri);
+		}
+
+		return DocumentationUtils.createMarkupContent(documentation, markdown);
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/roq/data/RoqDataFile.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/roq/data/RoqDataFile.java
@@ -1,0 +1,442 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.project.extensions.roq.data;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.lsp4j.CompletionItemKind;
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.LocationLink;
+import org.eclipse.lsp4j.MarkupContent;
+import org.eclipse.lsp4j.MarkupKind;
+import org.eclipse.lsp4j.Range;
+
+import com.redhat.qute.commons.FileUtils;
+import com.redhat.qute.parser.expression.Part;
+import com.redhat.qute.parser.template.Node;
+import com.redhat.qute.project.datamodel.resolvers.CustomValueResolver;
+import com.redhat.qute.services.extensions.DefinitionExtensionProvider;
+import com.redhat.qute.services.extensions.HoverExtensionProvider;
+import com.redhat.qute.services.hover.HoverRequest;
+import com.redhat.qute.utils.DocumentationUtils;
+import com.redhat.qute.utils.QutePositionUtility;
+
+/**
+ * Represents a Roq data file (YAML, JSON, etc.) as a top-level value resolver
+ * in Qute templates.
+ * 
+ * <p>
+ * This class enables IDE support for data files in Qute templates by:
+ * </p>
+ * <ul>
+ * <li><b>Autocomplete</b> - Data file appears in completion lists with File
+ * icon</li>
+ * <li><b>Go to Definition</b> - Navigate from template usage to the source
+ * file</li>
+ * <li><b>Hover</b> - Show file path in tooltip with clickable link</li>
+ * <li><b>Field Resolution</b> - Fields from the data file are accessible as
+ * properties</li>
+ * </ul>
+ * 
+ * <h3>Example:</h3>
+ * <p>
+ * Given a YAML file {@code data/authors.yaml}:
+ * 
+ * <pre>
+ * name: John Doe
+ * email: john@example.com
+ * books:
+ *   - title: Book 1
+ *   - title: Book 2
+ * </pre>
+ * </p>
+ * 
+ * <p>
+ * In a Qute template:
+ * 
+ * <pre>
+ * {authors.name}           // "John Doe" - authors is a RoqDataFile
+ * {authors.email}          // "john@example.com"
+ * {#for book in authors.books}
+ *   {book.title}
+ * {/for}
+ * </pre>
+ * </p>
+ * 
+ * <h3>Namespace Support:</h3>
+ * <p>
+ * Data files can be accessed via namespaces:
+ * <ul>
+ * <li>{@code data:authors.name} - Global namespace "data"</li>
+ * <li>{@code site:authors.name} - Custom namespace "site"</li>
+ * </ul>
+ * </p>
+ * 
+ * <h3>Lifecycle:</h3>
+ * <ol>
+ * <li>RoqDataFile is created with file path and namespace</li>
+ * <li>DataLoader (YAML/JSON) parses the file and extracts fields</li>
+ * <li>Fields are set via {@code setFields()} - each becomes a RoqDataField</li>
+ * <li>Template engine resolves {@code {authors.name}} to the field</li>
+ * <li>LSP provides IDE features (hover, go-to-def, completion)</li>
+ * </ol>
+ * 
+ * @see CustomValueResolver
+ * @see RoqDataField
+ * @see DataLoader
+ * @see DefinitionExtensionProvider
+ * @see HoverExtensionProvider
+ */
+public class RoqDataFile extends CustomValueResolver implements DefinitionExtensionProvider, HoverExtensionProvider {
+
+	/** The file system path to the data file (e.g., /path/to/data/authors.yaml) */
+	private final Path filePath;
+
+	/** The file name without extension (e.g., "authors" from "authors.yaml") */
+	private final String name;
+
+	/**
+	 * Creates a new RoqDataFile and loads its contents.
+	 * 
+	 * <p>
+	 * The constructor:
+	 * <ol>
+	 * <li>Sets up the resolver to resolve itself as a type</li>
+	 * <li>Assigns the namespace (e.g., "data", "site")</li>
+	 * <li>Extracts the file name without extension</li>
+	 * <li>Delegates to the DataLoader to parse and extract fields</li>
+	 * </ol>
+	 * </p>
+	 * 
+	 * <h3>Example:</h3>
+	 * 
+	 * <pre>
+	 * Path yamlFile = Paths.get("data/authors.yaml");
+	 * DataLoader loader = new YamlDataLoader();
+	 * RoqDataFile dataFile = new RoqDataFile(yamlFile, "data", loader);
+	 * 
+	 * // Now dataFile contains:
+	 * // - name: "authors"
+	 * // - namespace: "data"
+	 * // - fields: [name, email, books, ...]
+	 * </pre>
+	 * 
+	 * @param filePath   The path to the data file on disk
+	 * @param namespace  The namespace for accessing this file (e.g., "data",
+	 *                   "site")
+	 * @param dataLoader The loader to parse this file type (YamlDataLoader,
+	 *                   JsonDataLoader, etc.) May be null if fields will be set
+	 *                   manually later
+	 */
+	public RoqDataFile(Path filePath, String namespace, DataLoader dataLoader) {
+		// Set this instance as its own resolved type (acts as both resolver and type)
+		super.setResolvedType(this);
+
+		// Set the namespace for template access (e.g., "data" in {data:authors})
+		super.setNamespace(namespace);
+
+		// Store the file path for LSP features (go-to-def, hover)
+		this.filePath = filePath;
+
+		// Extract the base name without extension (e.g., "authors" from "authors.yaml")
+		this.name = getFileNameWithoutExtension(filePath);
+
+		// Load the file contents and populate fields
+		if (dataLoader != null) {
+			dataLoader.load(this);
+		}
+	}
+
+	/**
+	 * Creates a clone of this data file with a different namespace.
+	 * 
+	 * <p>
+	 * Used when the same data file needs to be accessible from multiple namespaces.
+	 * For example, the same file might be accessible as both {@code data:authors}
+	 * and {@code site:authors}.
+	 * </p>
+	 * 
+	 * <p>
+	 * The clone shares the same fields and file reference but has a different
+	 * namespace for template resolution.
+	 * </p>
+	 * 
+	 * @param namespace The new namespace for the clone
+	 * @return A new RoqDataFile instance with the same data but different namespace
+	 */
+	public RoqDataFile create(String namespace) {
+		// Create a new instance without loading (dataLoader = null)
+		RoqDataFile resolver = new RoqDataFile(getFilePath(), namespace, null);
+
+		// Copy the fields from this instance
+		resolver.setFields(getFields());
+		resolver.setSignature("name : Object");
+
+		return resolver;
+	}
+
+	/**
+	 * Returns the file name without extension.
+	 * 
+	 * <p>
+	 * This name is used as the identifier in templates. For example,
+	 * {@code authors.yaml} → "authors"
+	 * </p>
+	 * 
+	 * @return The base file name (e.g., "authors")
+	 */
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Returns the Java element type for this resolver.
+	 * 
+	 * <p>
+	 * Data files don't have a specific Java type (they're dynamic), so this returns
+	 * null. The actual types are in the individual fields.
+	 * </p>
+	 * 
+	 * @return null - no specific Java type
+	 */
+	@Override
+	public String getJavaElementType() {
+		return null;
+	}
+
+	/**
+	 * Returns the completion item kind for IDE autocomplete.
+	 * 
+	 * <p>
+	 * Data files appear in completion lists with a "File" icon to distinguish them
+	 * from Java classes, methods, etc.
+	 * </p>
+	 * 
+	 * @return CompletionItemKind.File - displays with file icon
+	 */
+	@Override
+	public CompletionItemKind getCompletionKind() {
+		return CompletionItemKind.File;
+	}
+
+	/**
+	 * Returns the file system path to the data file.
+	 * 
+	 * <p>
+	 * Used for:
+	 * <ul>
+	 * <li>Go to Definition - navigate to the file</li>
+	 * <li>Hover - display file path/link</li>
+	 * <li>File watching - reload on changes</li>
+	 * </ul>
+	 * </p>
+	 * 
+	 * @return The path to the data file
+	 */
+	public Path getFilePath() {
+		return filePath;
+	}
+
+	/**
+	 * Extracts the file name without extension from a path.
+	 * 
+	 * <h3>Examples:</h3>
+	 * <ul>
+	 * <li>{@code authors.yaml} → "authors"</li>
+	 * <li>{@code site-config.json} → "site-config"</li>
+	 * <li>{@code .hidden} → ".hidden" (no extension)</li>
+	 * <li>{@code noext} → "noext"</li>
+	 * </ul>
+	 * 
+	 * @param path The file path to process
+	 * @return The file name without extension, or null if path/filename is null
+	 */
+	public static String getFileNameWithoutExtension(Path path) {
+		if (path == null || path.getFileName() == null) {
+			return null;
+		}
+
+		String fileName = path.getFileName().toString();
+		int lastDot = fileName.lastIndexOf('.');
+
+		// No extension or starts with dot (hidden file like .gitignore)
+		if (lastDot <= 0) {
+			return fileName;
+		}
+
+		// Return everything before the last dot
+		return fileName.substring(0, lastDot);
+	}
+
+	/**
+	 * Returns the owner node for Java type resolution.
+	 * 
+	 * <p>
+	 * Data files don't have a Java type owner (they're not Java classes), so this
+	 * returns null.
+	 * </p>
+	 * 
+	 * @return null - no Java type owner
+	 */
+	@Override
+	public Node getJavaTypeOwnerNode() {
+		return null;
+	}
+
+	// ========================================================================
+	// LSP Feature: Go to Definition
+	// ========================================================================
+
+	/**
+	 * Provides "Go to Definition" support for this data file.
+	 * 
+	 * <p>
+	 * When a user Ctrl+Clicks on the data file name in a template (e.g.,
+	 * {@code {authors.name}}), the IDE opens the source data file.
+	 * </p>
+	 * 
+	 * <p>
+	 * Currently navigates to the start of the file (position 0:0). Future
+	 * enhancement could navigate to a specific field if the user clicked on a field
+	 * access like {@code authors.name}.
+	 * </p>
+	 * 
+	 * <h3>Example:</h3>
+	 * 
+	 * <pre>
+	 * Template: {authors.name}
+	 *           ^^^^^^^^
+	 *           Ctrl+Click here → Opens authors.yaml
+	 * </pre>
+	 * 
+	 * @param part The template expression part being navigated from
+	 * @return A list containing a single LocationLink to the data file
+	 */
+	@Override
+	public List<? extends LocationLink> getLocations(Part part) {
+		LocationLink link = new LocationLink();
+
+		// Origin: The position in the template where the user clicked
+		link.setOriginSelectionRange(QutePositionUtility.createRange(part));
+
+		// Target: The data file URI (e.g., file:///path/to/authors.yaml)
+		link.setTargetUri(FileUtils.toUri(getFilePath()));
+
+		// Target position: Start of file (0:0)
+		// TODO: Could enhance to navigate to specific field location
+		link.setTargetRange(QutePositionUtility.ZERO_RANGE);
+		link.setTargetSelectionRange(QutePositionUtility.ZERO_RANGE);
+
+		return Collections.singletonList(link);
+	}
+
+	// ========================================================================
+	// LSP Feature: Hover
+	// ========================================================================
+
+	/**
+	 * Provides hover documentation for this data file.
+	 * 
+	 * <p>
+	 * When a user hovers over the data file name in a template, displays a
+	 * clickable link to open the file.
+	 * </p>
+	 * 
+	 * <h3>Example hover content (Markdown):</h3>
+	 * 
+	 * <pre>
+	 * Open [authors.yaml](file:///path/to/data/authors.yaml)
+	 * </pre>
+	 * 
+	 * <h3>Example hover content (Plain Text):</h3>
+	 * 
+	 * <pre>
+	 * file:///path/to/data/authors.yaml
+	 * </pre>
+	 * 
+	 * @param part         The template expression part being hovered over
+	 * @param hoverRequest The hover request with client capabilities
+	 * @return A Hover object with the file link
+	 */
+	@Override
+	public Hover getHover(Part part, HoverRequest hoverRequest) {
+		// Check if the client supports Markdown formatting
+		boolean hasMarkdown = hoverRequest.canSupportMarkupKind(MarkupKind.MARKDOWN);
+
+		// Generate the hover content (file link)
+		MarkupContent content = getDocumentation(this, null, hasMarkdown);
+
+		// The range in the template that this hover applies to
+		Range range = QutePositionUtility.createRange(part);
+
+		return new Hover(content, range);
+	}
+
+	/**
+	 * Generates the hover documentation content for a data file.
+	 * 
+	 * <p>
+	 * Creates formatted documentation showing a clickable link to open the source
+	 * data file.
+	 * </p>
+	 * 
+	 * <h3>Markdown Format:</h3>
+	 * 
+	 * <pre>
+	 * [description]
+	 * Open [authors.yaml](file:///path/to/authors.yaml)
+	 * </pre>
+	 * 
+	 * <h3>Plain Text Format:</h3>
+	 * 
+	 * <pre>
+	 * [description]
+	 * file:///path/to/authors.yaml
+	 * </pre>
+	 * 
+	 * @param file        The data file to document
+	 * @param description Optional description text to prepend (may be null)
+	 * @param markdown    Whether to use Markdown formatting
+	 * @return Formatted documentation as MarkupContent
+	 */
+	private static MarkupContent getDocumentation(RoqDataFile file, String description, boolean markdown) {
+		StringBuilder documentation = new StringBuilder();
+
+		// Optional description section (if provided)
+		if (description != null) {
+			documentation.append(description);
+			documentation.append(System.lineSeparator());
+		}
+
+		// File path and link
+		Path filePath = file.getFilePath();
+		String fileUri = filePath.toUri().toString();
+
+		if (markdown) {
+			// Create a clickable link: Open [filename](file://...)
+			documentation.append("Open [");
+			documentation.append(filePath.getFileName().toString());
+			documentation.append("]");
+			documentation.append("(");
+			documentation.append(fileUri);
+			documentation.append(")");
+		} else {
+			// Plain text: just show the URI
+			documentation.append(fileUri);
+		}
+
+		return DocumentationUtils.createMarkupContent(documentation, markdown);
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/roq/data/json/JsonDataLoader.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/roq/data/json/JsonDataLoader.java
@@ -1,0 +1,304 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.project.extensions.roq.data.json;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import com.redhat.qute.commons.JavaFieldInfo;
+import com.redhat.qute.commons.ResolvedJavaTypeInfo;
+import com.redhat.qute.project.extensions.roq.data.RoqDataCollection;
+import com.redhat.qute.project.extensions.roq.data.DataLoader;
+import com.redhat.qute.project.extensions.roq.data.RoqDataField;
+import com.redhat.qute.project.extensions.roq.data.RoqDataFile;
+
+/**
+ * JSON data loader for Roq.
+ * 
+ * Converts JSON files into JavaFieldInfo structures that provide: -
+ * Autocomplete support in Qute templates - Type validation - Field discovery
+ * for data files
+ * 
+ * Uses Gson's JsonParser to parse JSON into a JsonElement tree, then
+ * recursively builds the Java type structure.
+ */
+public class JsonDataLoader implements DataLoader {
+
+	/**
+	 * Main entry point - loads a JSON file and populates the RoqDataFile with
+	 * discovered field information.
+	 * 
+	 * @param roqDataFile The data file object to populate with field info
+	 */
+	@Override
+	public void load(RoqDataFile roqDataFile) {
+		try {
+			// Read the raw JSON content from disk
+			String content = Files.readString(roqDataFile.getFilePath());
+			loadFromJson(roqDataFile, content);
+		} catch (IOException e) {
+			// On error, initialize with empty structure to prevent NPEs
+			roqDataFile.setFields(List.of());
+			roqDataFile.setSignature(roqDataFile.getName() + " : Object");
+		}
+	}
+
+	/**
+	 * Parses JSON content and extracts the field structure.
+	 * 
+	 * Handles two root cases: 1. Object root (most common) - extracts all key-value
+	 * pairs as fields 2. Array root (less common) - wraps in a synthetic "items"
+	 * collection field
+	 * 
+	 * @param roqDataFile The file to populate
+	 * @param content     Raw JSON string content
+	 */
+	private static void loadFromJson(RoqDataFile roqDataFile, String content) {
+		try {
+			// Parse JSON into Gson's JsonElement tree structure
+			JsonElement rootElement = JsonParser.parseString(content);
+			String name = roqDataFile.getName();
+
+			List<JavaFieldInfo> fields = new ArrayList<>();
+
+			if (rootElement.isJsonObject()) {
+				// Case 1: Root is a JSON object
+				// Example: { "name": "John", "age": 30 }
+				JsonObject rootObject = rootElement.getAsJsonObject();
+				fields = extractFieldsFromObject(rootObject, roqDataFile);
+
+			} else if (rootElement.isJsonArray()) {
+				// Case 2: Root is a JSON array
+				// Example: [{ "name": "John" }, { "name": "Jane" }]
+				// We wrap this in a synthetic "items" field for template access
+				JsonArray rootArray = rootElement.getAsJsonArray();
+				ResolvedJavaTypeInfo itemType = inferArrayItemType(rootArray, roqDataFile);
+				ResolvedJavaTypeInfo arrayType = new RoqDataCollection(itemType);
+
+				RoqDataField field = new RoqDataField("items", arrayType, roqDataFile);
+				field.setSignature("items : java.util.Collection<" + itemType.getJavaElementType() + ">");
+				fields.add(field);
+			}
+
+			// Set the discovered fields and overall signature
+			roqDataFile.setFields(fields);
+			roqDataFile.setSignature(name + " : file");
+
+		} catch (Exception e) {
+			// Graceful fallback on any parsing error (malformed JSON, etc.)
+			roqDataFile.setFields(List.of());
+			roqDataFile.setSignature(roqDataFile.getName() + " : Object");
+		}
+	}
+
+	/**
+	 * Extracts all fields from a JSON object.
+	 * 
+	 * Iterates over all key-value pairs in the object and converts each to a
+	 * JavaFieldInfo with appropriate type information.
+	 * 
+	 * @param jsonObject The Gson JsonObject representing a JSON object
+	 * @param fileInfo   Reference to the parent file (for traceability)
+	 * @return List of discovered fields
+	 */
+	private static List<JavaFieldInfo> extractFieldsFromObject(JsonObject jsonObject, RoqDataFile fileInfo) {
+		List<JavaFieldInfo> fields = new ArrayList<>();
+
+		// Iterate over all entries in the JSON object
+		for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
+			String fieldName = entry.getKey(); // JSON key becomes field name
+			JsonElement value = entry.getValue(); // JSON value determines type
+
+			// Convert the value to a typed field
+			JavaFieldInfo field = createFieldFromValue(fieldName, value, fileInfo);
+			if (field != null) {
+				fields.add(field);
+			}
+		}
+
+		return fields;
+	}
+
+	/**
+	 * Creates a JavaFieldInfo from a JSON value, recursively handling nested
+	 * structures.
+	 * 
+	 * Type mapping: - null → java.lang.Object - primitive (string/number/boolean) →
+	 * primitive Java type - object → java.lang.Object with nested fields - array →
+	 * java.util.Collection<T> with item type
+	 * 
+	 * @param fieldName The field name (from JSON key)
+	 * @param value     The JSON value as JsonElement
+	 * @param fileInfo  Parent file reference
+	 * @return JavaFieldInfo representing this field, or null if invalid
+	 */
+	private static JavaFieldInfo createFieldFromValue(String fieldName, JsonElement value, RoqDataFile fileInfo) {
+		if (value.isJsonNull()) {
+			// JSON: "key": null
+			// Maps to Object since we don't know the intended type
+			RoqDataField field = new RoqDataField(fieldName, null, fileInfo);
+			field.setSignature(fieldName + " : java.lang.Object");
+			return field;
+
+		} else if (value.isJsonPrimitive()) {
+			// JSON: "key": "value" or "key": 123 or "key": true
+			// Primitive value (string, number, boolean)
+			JsonPrimitive primitive = value.getAsJsonPrimitive();
+			String javaType = inferJavaType(primitive);
+			RoqDataField field = new RoqDataField(fieldName, null, fileInfo);
+			field.setSignature(fieldName + " : " + javaType);
+			return field;
+
+		} else if (value.isJsonObject()) {
+			// JSON: "key": { "nested": "value" }
+			// Nested object - recursively extract its fields
+			JsonObject jsonObject = value.getAsJsonObject();
+			ResolvedJavaTypeInfo objectType = new ResolvedJavaTypeInfo();
+			objectType.setResolvedType(objectType);
+
+			// Recursively extract fields from the nested object
+			List<JavaFieldInfo> nestedFields = extractFieldsFromObject(jsonObject, fileInfo);
+			objectType.setFields(nestedFields);
+			objectType.setSignature(fieldName + " : java.lang.Object");
+
+			RoqDataField field = new RoqDataField(fieldName, objectType, fileInfo);
+			field.setSignature(fieldName + " : java.lang.Object");
+			return field;
+
+		} else if (value.isJsonArray()) {
+			// JSON: "key": ["item1", "item2"]
+			// Array - infer the item type from first element
+			JsonArray jsonArray = value.getAsJsonArray();
+			ResolvedJavaTypeInfo itemType = inferArrayItemType(jsonArray, fileInfo);
+			ResolvedJavaTypeInfo arrayType = new RoqDataCollection(itemType);
+
+			RoqDataField field = new RoqDataField(fieldName, arrayType, fileInfo);
+			field.setSignature(fieldName + " : java.util.Collection<" + itemType.getJavaElementType() + ">");
+			return field;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Infers the item type of a JSON array by examining the first element.
+	 * 
+	 * Strategy: - Empty array → defaults to String - Array of primitives → infer
+	 * type from first primitive - Array of objects → infer object structure from
+	 * first object
+	 * 
+	 * Limitation: Assumes homogeneous arrays (all items same type)
+	 * 
+	 * @param jsonArray The Gson JsonArray representing a JSON array
+	 * @param fileInfo  Parent file reference
+	 * @return The inferred type of array items
+	 */
+	private static ResolvedJavaTypeInfo inferArrayItemType(JsonArray jsonArray, RoqDataFile fileInfo) {
+		if (jsonArray.size() == 0) {
+			// Empty array - default to String as a safe fallback
+			ResolvedJavaTypeInfo type = new ResolvedJavaTypeInfo();
+			type.setSignature("java.lang.String");
+			return type;
+		}
+
+		// Examine the first item to infer the type
+		JsonElement firstItem = jsonArray.get(0);
+
+		if (firstItem.isJsonPrimitive()) {
+			// Array of primitives: ["a", "b"] or [1, 2] or [true, false]
+			JsonPrimitive primitive = firstItem.getAsJsonPrimitive();
+			String javaType = inferJavaType(primitive);
+			ResolvedJavaTypeInfo type = new ResolvedJavaTypeInfo();
+			type.setSignature(javaType);
+			return type;
+
+		} else if (firstItem.isJsonObject()) {
+			// Array of objects: [{ "name": "John" }, { "name": "Jane" }]
+			// Extract the structure from the first object
+			JsonObject jsonObject = firstItem.getAsJsonObject();
+			ResolvedJavaTypeInfo type = new ResolvedJavaTypeInfo();
+			type.setResolvedType(type);
+
+			// Recursively extract fields from the first array item
+			List<JavaFieldInfo> fields = extractFieldsFromObject(jsonObject, fileInfo);
+			type.setFields(fields);
+			type.setSignature("java.lang.Object");
+			return type;
+		}
+
+		// Fallback for other types (arrays of arrays, etc.)
+		ResolvedJavaTypeInfo type = new ResolvedJavaTypeInfo();
+		type.setSignature("java.lang.String");
+		return type;
+	}
+
+	/**
+	 * Infers the Java type from a JSON primitive value.
+	 * 
+	 * Type inference rules: - true/false → Boolean - Integer literals (123) →
+	 * Integer - Large integers that exceed int range → Long - Floating point (3.14)
+	 * → Double - Scientific notation (1e10) → Double - "text" → String
+	 * 
+	 * Note: Gson parses all JSON numbers as the most appropriate Java type
+	 * (Integer, Long, Double), so we check both the string representation and the
+	 * actual Number instance type.
+	 * 
+	 * @param primitive A Gson JsonPrimitive representing a scalar value
+	 * @return The fully qualified Java type name
+	 */
+	private static String inferJavaType(JsonPrimitive primitive) {
+		if (primitive.isBoolean()) {
+			// JSON: true or false
+			return "java.lang.Boolean";
+
+		} else if (primitive.isNumber()) {
+			Number number = primitive.getAsNumber();
+			String str = primitive.getAsString();
+
+			// Check if it's a floating point number by looking at the string representation
+			// This catches cases like 3.14 or 1e10 that should be Double
+			if (str.contains(".") || str.toLowerCase().contains("e")) {
+				return "java.lang.Double";
+			}
+
+			// Check the actual Number instance type that Gson created
+			if (number instanceof Double || number instanceof Float) {
+				return "java.lang.Double";
+			} else if (number instanceof Long) {
+				// For Long, check if it actually fits in an Integer
+				long val = number.longValue();
+				if (val >= Integer.MIN_VALUE && val <= Integer.MAX_VALUE) {
+					return "java.lang.Integer";
+				}
+				return "java.lang.Long";
+			} else {
+				// Default case for Integer and other number types
+				return "java.lang.Integer";
+			}
+
+		} else if (primitive.isString()) {
+			// JSON: "text"
+			return "java.lang.String";
+		}
+
+		// Fallback (should rarely be reached)
+		return "java.lang.String";
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/roq/data/yaml/YamlDataLoader.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/roq/data/yaml/YamlDataLoader.java
@@ -1,0 +1,290 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.project.extensions.roq.data.yaml;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.redhat.qute.commons.JavaFieldInfo;
+import com.redhat.qute.commons.ResolvedJavaTypeInfo;
+import com.redhat.qute.project.extensions.roq.data.RoqDataCollection;
+import com.redhat.qute.project.extensions.roq.data.DataLoader;
+import com.redhat.qute.project.extensions.roq.data.RoqDataField;
+import com.redhat.qute.project.extensions.roq.data.RoqDataFile;
+
+/**
+ * YAML data loader for Roq.
+ * 
+ * Converts YAML files into JavaFieldInfo structures that provide: -
+ * Autocomplete support in Qute templates - Type validation - Field discovery
+ * for data files
+ * 
+ * Uses Jackson's YAMLMapper to parse YAML into a JsonNode tree, then
+ * recursively builds the Java type structure.
+ */
+public class YamlDataLoader implements DataLoader {
+
+	// Static YAML parser instance - reused across all file loads
+	private static final YAMLMapper yamlMapper = new YAMLMapper();
+
+	/**
+	 * Main entry point - loads a YAML file and populates the RoqDataFile with
+	 * discovered field information.
+	 * 
+	 * @param roqDataFile The data file object to populate with field info
+	 */
+	@Override
+	public void load(RoqDataFile roqDataFile) {
+		try {
+			// Read the raw YAML content from disk
+			String content = Files.readString(roqDataFile.getFilePath());
+			loadFromYaml(roqDataFile, content);
+		} catch (IOException e) {
+			// On error, initialize with empty structure to prevent NPEs
+			roqDataFile.setFields(List.of());
+			roqDataFile.setSignature(roqDataFile.getName() + " : Object");
+		}
+	}
+
+	/**
+	 * Parses YAML content and extracts the field structure.
+	 * 
+	 * Handles two root cases: 1. Object/Map root (most common) - extracts all
+	 * key-value pairs as fields 2. Array root (less common) - wraps in a synthetic
+	 * "items" collection field
+	 * 
+	 * @param roqDataFile The file to populate
+	 * @param content     Raw YAML string content
+	 */
+	private static void loadFromYaml(RoqDataFile roqDataFile, String content) {
+		try {
+			// Parse YAML into Jackson's JsonNode tree structure
+			// (YAMLMapper produces the same JsonNode as JSON parsing)
+			JsonNode rootNode = yamlMapper.readTree(content);
+			String name = roqDataFile.getName();
+
+			List<JavaFieldInfo> fields = new ArrayList<>();
+
+			if (rootNode.isObject()) {
+				// Case 1: Root is a YAML map/object
+				// Example: { name: "John", age: 30 }
+				ObjectNode rootObject = (ObjectNode) rootNode;
+				fields = extractFieldsFromObject(rootObject, roqDataFile);
+
+			} else if (rootNode.isArray()) {
+				// Case 2: Root is a YAML sequence/array
+				// Example: [{ name: "John" }, { name: "Jane" }]
+				// We wrap this in a synthetic "items" field for template access
+				ArrayNode rootArray = (ArrayNode) rootNode;
+				ResolvedJavaTypeInfo itemType = inferArrayItemType(rootArray, roqDataFile);
+				ResolvedJavaTypeInfo arrayType = new RoqDataCollection(itemType);
+
+				RoqDataField field = new RoqDataField("items", arrayType, roqDataFile);
+				field.setSignature("items : java.util.Collection<" + itemType.getJavaElementType() + ">");
+				fields.add(field);
+			}
+
+			// Set the discovered fields and overall signature
+			roqDataFile.setFields(fields);
+			roqDataFile.setSignature(name + " : file");
+
+		} catch (Exception e) {
+			// Graceful fallback on any parsing error
+			roqDataFile.setFields(List.of());
+			roqDataFile.setSignature(roqDataFile.getName() + " : Object");
+		}
+	}
+
+	/**
+	 * Extracts all fields from a YAML object/map.
+	 * 
+	 * Iterates over all key-value pairs in the object and converts each to a
+	 * JavaFieldInfo with appropriate type information.
+	 * 
+	 * @param objectNode The Jackson ObjectNode representing a YAML map
+	 * @param fileInfo   Reference to the parent file (for traceability)
+	 * @return List of discovered fields
+	 */
+	private static List<JavaFieldInfo> extractFieldsFromObject(ObjectNode objectNode, RoqDataFile fileInfo) {
+		List<JavaFieldInfo> fields = new ArrayList<>();
+
+		// Iterate over all entries in the YAML map
+		objectNode.fields().forEachRemaining(entry -> {
+			String fieldName = entry.getKey(); // YAML key becomes field name
+			JsonNode value = entry.getValue(); // YAML value determines type
+
+			// Convert the value to a typed field
+			JavaFieldInfo field = createFieldFromValue(fieldName, value, fileInfo);
+			if (field != null) {
+				fields.add(field);
+			}
+		});
+
+		return fields;
+	}
+
+	/**
+	 * Creates a JavaFieldInfo from a YAML value, recursively handling nested
+	 * structures.
+	 * 
+	 * Type mapping: - null → java.lang.Object - scalar (string/number/boolean) →
+	 * primitive Java type - object/map → java.lang.Object with nested fields -
+	 * array/sequence → java.util.Collection<T> with item type
+	 * 
+	 * @param fieldName The field name (from YAML key)
+	 * @param value     The YAML value as JsonNode
+	 * @param fileInfo  Parent file reference
+	 * @return JavaFieldInfo representing this field, or null if invalid
+	 */
+	private static JavaFieldInfo createFieldFromValue(String fieldName, JsonNode value, RoqDataFile fileInfo) {
+		if (value.isNull()) {
+			// YAML: key: null or key: ~
+			// Maps to Object since we don't know the intended type
+			RoqDataField field = new RoqDataField(fieldName, null, fileInfo);
+			field.setSignature(fieldName + " : java.lang.Object");
+			return field;
+
+		} else if (value.isValueNode()) {
+			// YAML: key: "value" or key: 123 or key: true
+			// Primitive scalar value (string, number, boolean)
+			String javaType = inferJavaType(value);
+			RoqDataField field = new RoqDataField(fieldName, null, fileInfo);
+			field.setSignature(fieldName + " : " + javaType);
+			return field;
+
+		} else if (value.isObject()) {
+			// YAML: key: { nested: "value" }
+			// Nested object - recursively extract its fields
+			ObjectNode objectNode = (ObjectNode) value;
+			ResolvedJavaTypeInfo objectType = new ResolvedJavaTypeInfo();
+			objectType.setResolvedType(objectType);
+
+			// Recursively extract fields from the nested object
+			List<JavaFieldInfo> nestedFields = extractFieldsFromObject(objectNode, fileInfo);
+			objectType.setFields(nestedFields);
+			objectType.setSignature(fieldName + " : java.lang.Object");
+
+			RoqDataField field = new RoqDataField(fieldName, objectType, fileInfo);
+			field.setSignature(fieldName + " : java.lang.Object");
+			return field;
+
+		} else if (value.isArray()) {
+			// YAML: key: [item1, item2] or key: - item1
+			// - item2
+			// Array/sequence - infer the item type from first element
+			ArrayNode arrayNode = (ArrayNode) value;
+			ResolvedJavaTypeInfo itemType = inferArrayItemType(arrayNode, fileInfo);
+			ResolvedJavaTypeInfo arrayType = new RoqDataCollection(itemType);
+
+			RoqDataField field = new RoqDataField(fieldName, arrayType, fileInfo);
+			field.setSignature(fieldName + " : java.util.Collection<" + itemType.getJavaElementType() + ">");
+			return field;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Infers the item type of a YAML array by examining the first element.
+	 * 
+	 * Strategy: - Empty array → defaults to String - Array of scalars → infer type
+	 * from first scalar - Array of objects → infer object structure from first
+	 * object
+	 * 
+	 * Limitation: Assumes homogeneous arrays (all items same type)
+	 * 
+	 * @param arrayNode The Jackson ArrayNode representing a YAML sequence
+	 * @param fileInfo  Parent file reference
+	 * @return The inferred type of array items
+	 */
+	private static ResolvedJavaTypeInfo inferArrayItemType(ArrayNode arrayNode, RoqDataFile fileInfo) {
+		if (arrayNode.size() == 0) {
+			// Empty array - default to String as a safe fallback
+			ResolvedJavaTypeInfo type = new ResolvedJavaTypeInfo();
+			type.setSignature("java.lang.String");
+			return type;
+		}
+
+		// Examine the first item to infer the type
+		JsonNode firstItem = arrayNode.get(0);
+
+		if (firstItem.isValueNode()) {
+			// Array of primitives: ["a", "b"] or [1, 2] or [true, false]
+			String javaType = inferJavaType(firstItem);
+			ResolvedJavaTypeInfo type = new ResolvedJavaTypeInfo();
+			type.setSignature(javaType);
+			return type;
+
+		} else if (firstItem.isObject()) {
+			// Array of objects: [{ name: "John" }, { name: "Jane" }]
+			// Extract the structure from the first object
+			ObjectNode objectNode = (ObjectNode) firstItem;
+			ResolvedJavaTypeInfo type = new ResolvedJavaTypeInfo();
+			type.setResolvedType(type);
+
+			// Recursively extract fields from the first array item
+			List<JavaFieldInfo> fields = extractFieldsFromObject(objectNode, fileInfo);
+			type.setFields(fields);
+			type.setSignature("java.lang.Object");
+			return type;
+		}
+
+		// Fallback for other types (arrays of arrays, etc.)
+		ResolvedJavaTypeInfo type = new ResolvedJavaTypeInfo();
+		type.setSignature("java.lang.String");
+		return type;
+	}
+
+	/**
+	 * Infers the Java type from a YAML scalar value.
+	 * 
+	 * Type inference rules: - true/false → Boolean - 123 → Integer (if fits in int
+	 * range) - 999999999999 → Long (if exceeds int range) - 3.14 → Double - "text"
+	 * → String
+	 * 
+	 * @param node A Jackson JsonNode representing a scalar value
+	 * @return The fully qualified Java type name
+	 */
+	private static String inferJavaType(JsonNode node) {
+		if (node.isBoolean()) {
+			// YAML: true, false, yes, no, on, off
+			return "java.lang.Boolean";
+
+		} else if (node.isNumber()) {
+			if (node.isInt() || node.isLong()) {
+				// Integer or Long - check if it fits in Integer range
+				if (node.canConvertToInt()) {
+					return "java.lang.Integer";
+				}
+				return "java.lang.Long";
+			} else if (node.isFloat() || node.isDouble()) {
+				// Floating point number
+				return "java.lang.Double";
+			}
+			// Fallback for other numeric types
+			return "java.lang.Number";
+
+		} else if (node.isTextual()) {
+			// YAML: "text", 'text', or unquoted text
+			return "java.lang.String";
+		}
+
+		// Default fallback
+		return "java.lang.String";
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/roq/frontmatter/YamlFrontMatterDetector.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/extensions/roq/frontmatter/YamlFrontMatterDetector.java
@@ -1,0 +1,121 @@
+package com.redhat.qute.project.extensions.roq.frontmatter;
+
+import com.redhat.qute.parser.injection.InjectionDetector;
+import com.redhat.qute.parser.injection.InjectionMetadata;
+import com.redhat.qute.parser.injection.InjectionMode;
+import com.redhat.qute.parser.scanner.MultiLineStream;
+
+public class YamlFrontMatterDetector implements InjectionDetector {
+
+	private static final int[] FRONT_MATTER_DELIMITER = new int[] { '-', '-', '-' };
+
+	private static final InjectionMetadata YAML_METADATA = new InjectionMetadata("yaml", InjectionMode.EMBEDDED); // Embedded
+																													// -
+																													// no
+																													// Qute
+																													// parsing!
+
+	@Override
+	public InjectionMetadata detectInjection(MultiLineStream stream) {
+		// Must be at the beginning of the file
+		if (stream.pos() != 0) {
+			return null;
+		}
+
+		// Must start with ---
+		if (stream.peekChar(0) == '-' && stream.peekChar(1) == '-' && stream.peekChar(2) == '-') {
+
+			// Check that it's followed by a newline or EOF
+			int charAfter = stream.peekChar(3);
+			if (charAfter == -1 || charAfter == '\n' || charAfter == '\r') {
+				return YAML_METADATA;
+			}
+		}
+
+		return null;
+	}
+
+	@Override
+	public boolean scanStartDelimiter(MultiLineStream stream) {
+		// Scan ---
+		if (stream.advanceIfChars(FRONT_MATTER_DELIMITER)) {
+			// Scan the newline after ---
+			if (stream.peekChar() == '\r') {
+				stream.advance(1);
+				if (stream.peekChar() == '\n') {
+					stream.advance(1);
+				}
+			} else if (stream.peekChar() == '\n') {
+				stream.advance(1);
+			}
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean scanToInjectionEnd(MultiLineStream stream) {
+		// Look for the pattern "\n---" or "\r\n---"
+		while (!stream.eos()) {
+			int ch = stream.peekChar();
+
+			if (ch == '\n') {
+				// Check if it's followed by ---
+				if (stream.peekChar(1) == '-' && stream.peekChar(2) == '-' && stream.peekChar(3) == '-') {
+
+					// Check that --- is followed by a newline or EOF
+					int charAfter = stream.peekChar(4);
+					if (charAfter == -1 || charAfter == '\n' || charAfter == '\r') {
+						// Found! Don't include the \n
+						return true;
+					}
+				}
+			} else if (ch == '\r') {
+				// Check if it's \r\n followed by ---
+				if (stream.peekChar(1) == '\n' && stream.peekChar(2) == '-' && stream.peekChar(3) == '-'
+						&& stream.peekChar(4) == '-') {
+
+					int charAfter = stream.peekChar(5);
+					if (charAfter == -1 || charAfter == '\n' || charAfter == '\r') {
+						// Found! Don't include the \r\n
+						return true;
+					}
+				}
+			}
+
+			stream.advance(1);
+		}
+
+		// No end found, we're at EOF
+		return false;
+	}
+
+	@Override
+	public boolean scanEndDelimiter(MultiLineStream stream) {
+		// Scan the newline before ---
+		if (stream.peekChar() == '\r') {
+			stream.advance(1);
+			if (stream.peekChar() == '\n') {
+				stream.advance(1);
+			}
+		} else if (stream.peekChar() == '\n') {
+			stream.advance(1);
+		}
+
+		// Scan ---
+		if (stream.advanceIfChars(FRONT_MATTER_DELIMITER)) {
+			// Scan the newline after --- (optional)
+			if (stream.peekChar() == '\r') {
+				stream.advance(1);
+				if (stream.peekChar() == '\n') {
+					stream.advance(1);
+				}
+			} else if (stream.peekChar() == '\n') {
+				stream.advance(1);
+			}
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/tags/UserTag.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/project/tags/UserTag.java
@@ -74,17 +74,17 @@ public abstract class UserTag extends Snippet {
 		for (UserTagParameter parameter : parameters) {
 			if (parameter.isRequired()) {
 				switch (parameter.getName()) {
-					case UserTagUtils.IT_OBJECT_PART_NAME:
-						startSection.append(" ");
-						SnippetsBuilder.placeholders(index++, parameter.getName(), startSection);
-						break;
-					case UserTagUtils.NESTED_CONTENT_OBJECT_PART_NAME:
-						hasNestedContent = true;
-						break;
-					default:
-						startSection.append(" ");
-						generateUserTagParameter(parameter, true, index++, startSection);
-						break;
+				case UserTagUtils.IT_OBJECT_PART_NAME:
+					startSection.append(" ");
+					SnippetsBuilder.placeholders(index++, parameter.getName(), startSection);
+					break;
+				case UserTagUtils.NESTED_CONTENT_OBJECT_PART_NAME:
+					hasNestedContent = true;
+					break;
+				default:
+					startSection.append(" ");
+					generateUserTagParameter(parameter, true, index++, startSection);
+					break;
 				}
 			}
 		}
@@ -135,11 +135,11 @@ public abstract class UserTag extends Snippet {
 				quote = null;
 			}
 		}
-		
+
 		if (quote != null) {
 			snippet.append(quote);
 		}
-		
+
 		if (snippetsSupported) {
 			SnippetsBuilder.placeholders(index, value, snippet);
 		} else {
@@ -194,7 +194,7 @@ public abstract class UserTag extends Snippet {
 		}
 		return parameters.values();
 	}
-	
+
 	public boolean hasArgs() {
 		getParameters();
 		return hasArgs;
@@ -206,9 +206,7 @@ public abstract class UserTag extends Snippet {
 	 * @return all required parameter names.
 	 */
 	public List<String> getRequiredParameterNames() {
-		return getParameters().stream()
-				.filter(UserTagParameter::isRequired)
-				.map(UserTagParameter::getName)
+		return getParameters().stream().filter(UserTagParameter::isRequired).map(UserTagParameter::getName)
 				.filter(paramName -> !paramName.equals(UserTagUtils.NESTED_CONTENT_OBJECT_PART_NAME))
 				.collect(Collectors.toList());
 	}
@@ -256,7 +254,7 @@ public abstract class UserTag extends Snippet {
 		if (content == null) {
 			return null;
 		}
-		return TemplateParser.parse(content, getUri());
+		return TemplateParser.parse(content, getUri(), Collections.emptyList());
 	}
 
 	/**

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteDefinition.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/QuteDefinition.java
@@ -57,6 +57,7 @@ import com.redhat.qute.project.tags.ObjectPartCollector;
 import com.redhat.qute.project.tags.UserTag;
 import com.redhat.qute.project.tags.UserTagParameter;
 import com.redhat.qute.services.definition.DefinitionRequest;
+import com.redhat.qute.services.extensions.DefinitionExtensionProvider;
 import com.redhat.qute.utils.QutePositionUtility;
 import com.redhat.qute.utils.QuteSearchUtils;
 
@@ -447,6 +448,10 @@ class QuteDefinition {
 			Part part, QuteProject project, CancelChecker cancelChecker) {
 		if (member == null) {
 			return NO_DEFINITION;
+		}
+
+		if (member instanceof DefinitionExtensionProvider) {
+			return CompletableFuture.completedFuture(((DefinitionExtensionProvider) member).getLocations(part));
 		}
 
 		String sourceType = member.getJavaElementKind() == JavaElementKind.TYPE ? member.getName()

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/extensions/DefinitionExtensionProvider.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/extensions/DefinitionExtensionProvider.java
@@ -1,0 +1,13 @@
+package com.redhat.qute.services.extensions;
+
+import java.util.List;
+
+import org.eclipse.lsp4j.LocationLink;
+
+import com.redhat.qute.parser.expression.Part;
+
+public interface DefinitionExtensionProvider {
+
+	List<? extends LocationLink> getLocations(Part part);
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/extensions/HoverExtensionProvider.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/extensions/HoverExtensionProvider.java
@@ -1,0 +1,12 @@
+package com.redhat.qute.services.extensions;
+
+import org.eclipse.lsp4j.Hover;
+
+import com.redhat.qute.parser.expression.Part;
+import com.redhat.qute.services.hover.HoverRequest;
+
+public interface HoverExtensionProvider {
+
+	Hover getHover(Part part, HoverRequest hoverRequest);
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/inlayhint/InlayHintASTVistor.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/services/inlayhint/InlayHintASTVistor.java
@@ -383,6 +383,9 @@ public class InlayHintASTVistor extends ASTVisitor {
 					return CompletableFuture.completedFuture(null);
 				}
 				if (javaTypeIterable.isIterable()) {
+					if (javaTypeIterable.isTypeResolved()) {
+						return CompletableFuture.completedFuture(javaTypeIterable.getResolvedType());
+					}
 					return project.resolveJavaType(javaTypeIterable.getIterableOf());
 				}
 				return CompletableFuture.completedFuture(null);

--- a/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/utils/QutePositionUtility.java
+++ b/qute.ls/com.redhat.qute.ls/src/main/java/com/redhat/qute/utils/QutePositionUtility.java
@@ -16,6 +16,7 @@ import java.util.logging.Logger;
 
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
+import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 
 import com.redhat.qute.ls.commons.BadLocationException;
@@ -32,6 +33,8 @@ import com.redhat.qute.parser.template.Template;
 public class QutePositionUtility {
 
 	private static final Logger LOGGER = Logger.getLogger(QutePositionUtility.class.getName());
+
+	public static final Range ZERO_RANGE = new Range(new Position(0, 0), new Position(0, 0));
 
 	public static Location toLocation(LocationLink locationLink) {
 		return new Location(locationLink.getTargetUri(), locationLink.getTargetRange());

--- a/qute.ls/com.redhat.qute.ls/src/main/resources/META-INF/services/com.redhat.qute.project.extensions.ProjectExtension
+++ b/qute.ls/com.redhat.qute.ls/src/main/resources/META-INF/services/com.redhat.qute.project.extensions.ProjectExtension
@@ -1,1 +1,2 @@
 com.redhat.qute.project.extensions.renarde.RenardeProjectExtension
+com.redhat.qute.project.extensions.roq.RoqProjectExtension

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/QuteAssert.java
@@ -1070,8 +1070,8 @@ public class QuteAssert {
 			QuteProjectRegistry projectRegistry) {
 		Template template = TemplateParser.parse(value, fileUri != null ? fileUri : FILE_URI);
 		template.setProjectUri(projectUri);
-		projectRegistry.getProject(new ProjectInfo(projectUri, Collections.emptyList(),
-				Arrays.asList(new TemplateRootPath(templateBaseDir)), Collections.emptySet()));
+		projectRegistry.getProject(new ProjectInfo(projectUri, null, Collections.emptyList(),
+				Arrays.asList(new TemplateRootPath(templateBaseDir)), Collections.emptySet(), Collections.emptySet()));
 		template.setProjectRegistry(projectRegistry);
 		return template;
 	}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/parser/yaml/YamlParserTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/parser/yaml/YamlParserTest.java
@@ -1,0 +1,761 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.parser.yaml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.parser.yaml.scanner.YamlTokenType;
+
+/**
+ * Test with YAML parser which builds a YamlDocument AST.
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class YamlParserTest {
+
+	@Test
+	public void simpleKeyValue() {
+		String content = "key: value";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+		assertEquals(1, document.getChildCount());
+
+		YamlNode first = document.getChild(0);
+		assertEquals(YamlNodeKind.YamlMapping, first.getKind());
+		YamlMapping mapping = (YamlMapping) first;
+		assertTrue(mapping.isClosed());
+
+		assertEquals(1, mapping.getChildCount());
+		YamlNode property = mapping.getChild(0);
+		assertEquals(YamlNodeKind.YamlProperty, property.getKind());
+		YamlProperty prop = (YamlProperty) property;
+
+		assertNotNull(prop.getKey());
+		assertEquals(YamlNodeKind.YamlScalar, prop.getKey().getKind());
+		YamlScalar key = (YamlScalar) prop.getKey();
+		assertEquals(0, key.getStart());
+		assertEquals(3, key.getEnd());
+		assertEquals("key", key.getValue());
+
+		assertEquals(3, prop.getColonOffset());
+
+		assertNotNull(prop.getValue());
+		assertEquals(YamlNodeKind.YamlScalar, prop.getValue().getKind());
+		YamlScalar value = (YamlScalar) prop.getValue();
+		assertEquals(5, value.getStart());
+		assertEquals(10, value.getEnd());
+		assertEquals("value", value.getValue());
+	}
+
+	@Test
+	public void multipleProperties() {
+		String content = //
+				"name: John\n" + //
+						"age: 30";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+		assertEquals(1, document.getChildCount());
+
+		YamlNode first = document.getChild(0);
+		assertEquals(YamlNodeKind.YamlMapping, first.getKind());
+		YamlMapping mapping = (YamlMapping) first;
+
+		assertEquals(2, mapping.getChildCount());
+
+		// First property: name: John
+		YamlProperty prop1 = (YamlProperty) mapping.getChild(0);
+		assertEquals("name", ((YamlScalar) prop1.getKey()).getValue());
+		assertEquals("John", ((YamlScalar) prop1.getValue()).getValue());
+
+		// Second property: age: 30
+		YamlProperty prop2 = (YamlProperty) mapping.getChild(1);
+		assertEquals("age", ((YamlScalar) prop2.getKey()).getValue());
+		assertEquals("30", ((YamlScalar) prop2.getValue()).getValue());
+		assertEquals(YamlTokenType.ScalarNumber, ((YamlScalar) prop2.getValue()).getScalarType());
+	}
+
+	@Test
+	public void nestedMapping() {
+		String content = "person:\n" + //
+				"  name: John\n" + //
+				"  age: 30";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+		assertEquals(1, document.getChildCount());
+
+		YamlMapping rootMapping = (YamlMapping) document.getChild(0);
+		assertEquals(1, rootMapping.getChildCount());
+
+		// person:
+		YamlProperty personProp = (YamlProperty) rootMapping.getChild(0);
+		assertEquals("person", ((YamlScalar) personProp.getKey()).getValue());
+
+		// Nested mapping
+		assertNotNull(personProp.getValue());
+		assertEquals(YamlNodeKind.YamlMapping, personProp.getValue().getKind());
+		YamlMapping nestedMapping = (YamlMapping) personProp.getValue();
+		assertEquals(2, nestedMapping.getChildCount());
+
+		YamlProperty nameProp = (YamlProperty) nestedMapping.getChild(0);
+		assertEquals("name", ((YamlScalar) nameProp.getKey()).getValue());
+		assertEquals("John", ((YamlScalar) nameProp.getValue()).getValue());
+
+		YamlProperty ageProp = (YamlProperty) nestedMapping.getChild(1);
+		assertEquals("age", ((YamlScalar) ageProp.getKey()).getValue());
+		assertEquals("30", ((YamlScalar) ageProp.getValue()).getValue());
+	}
+
+	@Test
+	public void simpleSequence() {
+		String content = "- item1\n- item2\n- item3";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+		assertEquals(1, document.getChildCount());
+
+		YamlNode first = document.getChild(0);
+		assertEquals(YamlNodeKind.YamlSequence, first.getKind());
+		YamlSequence sequence = (YamlSequence) first;
+		assertTrue(sequence.isClosed());
+
+		assertEquals(3, sequence.getChildCount());
+
+		YamlScalar item1 = (YamlScalar) sequence.getChild(0);
+		assertEquals("item1", item1.getValue());
+
+		YamlScalar item2 = (YamlScalar) sequence.getChild(1);
+		assertEquals("item2", item2.getValue());
+
+		YamlScalar item3 = (YamlScalar) sequence.getChild(2);
+		assertEquals("item3", item3.getValue());
+	}
+
+	@Test
+	public void sequenceOfMappings() {
+		String content = "items:\n" + //
+				"- name: John\n" + //
+				"  age: 30\n" + //
+				"- name: Jane\n" + //
+				"  age: 25";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+
+		YamlMapping rootMapping = (YamlMapping) document.getChild(0);
+		YamlProperty itemsProp = (YamlProperty) rootMapping.getChild(0);
+		assertNotNull(itemsProp.getKey());
+		assertEquals("items", ((YamlScalar) itemsProp.getKey()).getValue());
+
+		assertNotNull(itemsProp.getValue());
+		assertEquals(YamlNodeKind.YamlSequence, itemsProp.getValue().getKind());
+		YamlSequence sequence = (YamlSequence) itemsProp.getValue();
+		assertEquals(2, sequence.getChildCount());
+
+		// First item
+		YamlMapping item1 = (YamlMapping) sequence.getChild(0);
+		assertEquals(2, item1.getChildCount());
+		assertEquals("John", ((YamlScalar) ((YamlProperty) item1.getChild(0)).getValue()).getValue());
+		assertEquals("30", ((YamlScalar) ((YamlProperty) item1.getChild(1)).getValue()).getValue());
+
+		// Second item
+		YamlMapping item2 = (YamlMapping) sequence.getChild(1);
+		assertEquals(2, item2.getChildCount());
+		assertEquals("Jane", ((YamlScalar) ((YamlProperty) item2.getChild(0)).getValue()).getValue());
+		assertEquals("25", ((YamlScalar) ((YamlProperty) item2.getChild(1)).getValue()).getValue());
+	}
+
+	@Test
+	public void flowSequence() {
+		String content = "numbers: [1, 2, 3]";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+
+		YamlMapping mapping = (YamlMapping) document.getChild(0);
+		YamlProperty prop = (YamlProperty) mapping.getChild(0);
+		assertEquals("numbers", ((YamlScalar) prop.getKey()).getValue());
+
+		assertEquals(YamlNodeKind.YamlSequence, prop.getValue().getKind());
+		YamlSequence sequence = (YamlSequence) prop.getValue();
+		assertTrue(sequence.isClosed());
+		assertEquals(3, sequence.getChildCount());
+
+		assertEquals("1", ((YamlScalar) sequence.getChild(0)).getValue());
+		assertEquals("2", ((YamlScalar) sequence.getChild(1)).getValue());
+		assertEquals("3", ((YamlScalar) sequence.getChild(2)).getValue());
+	}
+
+	@Test
+	public void flowMapping() {
+		String content = "{name: John, age: 30}";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+		assertEquals(1, document.getChildCount());
+
+		YamlMapping mapping = (YamlMapping) document.getChild(0);
+		assertTrue(mapping.isClosed());
+		assertEquals(2, mapping.getChildCount());
+
+		YamlProperty prop1 = (YamlProperty) mapping.getChild(0);
+		assertEquals("name", ((YamlScalar) prop1.getKey()).getValue());
+		assertEquals("John", ((YamlScalar) prop1.getValue()).getValue());
+
+		YamlProperty prop2 = (YamlProperty) mapping.getChild(1);
+		assertEquals("age", ((YamlScalar) prop2.getKey()).getValue());
+		assertEquals("30", ((YamlScalar) prop2.getValue()).getValue());
+	}
+
+	@Test
+	public void quotedStrings() {
+		String content = "name: \"John Doe\"\n" + //
+				"title: 'Developer'";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+
+		YamlMapping mapping = (YamlMapping) document.getChild(0);
+		assertEquals(2, mapping.getChildCount());
+
+		YamlProperty prop1 = (YamlProperty) mapping.getChild(0);
+		YamlScalar value1 = (YamlScalar) prop1.getValue();
+		assertEquals("John Doe", value1.getValue());
+		assertTrue(value1.isQuoted());
+
+		YamlProperty prop2 = (YamlProperty) mapping.getChild(1);
+		YamlScalar value2 = (YamlScalar) prop2.getValue();
+		assertEquals("Developer", value2.getValue());
+		assertTrue(value2.isQuoted());
+	}
+
+	@Test
+	public void scalarTypes() {
+		String content = "string: hello\n" + //
+				"number: 42\n" + "float: 3.14\n" + //
+				"boolean: true\n" + //
+				"null: null";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+
+		YamlMapping mapping = (YamlMapping) document.getChild(0);
+		assertEquals(5, mapping.getChildCount());
+
+		assertEquals(YamlTokenType.ScalarString,
+				((YamlScalar) ((YamlProperty) mapping.getChild(0)).getValue()).getScalarType());
+		assertEquals(YamlTokenType.ScalarNumber,
+				((YamlScalar) ((YamlProperty) mapping.getChild(1)).getValue()).getScalarType());
+		assertEquals(YamlTokenType.ScalarNumber,
+				((YamlScalar) ((YamlProperty) mapping.getChild(2)).getValue()).getScalarType());
+		assertEquals(YamlTokenType.ScalarBoolean,
+				((YamlScalar) ((YamlProperty) mapping.getChild(3)).getValue()).getScalarType());
+		assertEquals(YamlTokenType.ScalarNull,
+				((YamlScalar) ((YamlProperty) mapping.getChild(4)).getValue()).getScalarType());
+	}
+
+	@Test
+	public void comments() {
+		String content = "# This is a comment\nkey: value # inline comment";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+
+		// The document has 2 children: a full-line comment and a mapping
+		assertEquals(2, document.getChildCount());
+
+		// First child: the full-line comment
+		YamlNode first = document.getChild(0);
+		assertEquals(YamlNodeKind.YamlComment, first.getKind());
+		YamlComment comment = (YamlComment) first;
+		assertEquals(" This is a comment", comment.getContent());
+
+		// Second child: the mapping
+		YamlMapping mapping = (YamlMapping) document.getChild(1);
+		assertEquals(2, mapping.getChildCount()); // property + inline comment
+
+		// First child of the mapping: the property
+		YamlProperty property = (YamlProperty) mapping.getChild(0);
+		assertEquals("key", ((YamlScalar) property.getKey()).getValue());
+		assertEquals("value ", ((YamlScalar) property.getValue()).getValue());
+
+		// Second child of the mapping: the inline comment
+		YamlComment inlineComment = (YamlComment) mapping.getChild(1);
+		assertEquals(" inline comment", inlineComment.getContent());
+	}
+
+	@Test
+	public void emptyValue() {
+		String content = "key:";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+
+		YamlMapping mapping = (YamlMapping) document.getChild(0);
+		YamlProperty prop = (YamlProperty) mapping.getChild(0);
+		assertEquals("key", ((YamlScalar) prop.getKey()).getValue());
+		// Value should be null when not provided
+		// In fault-tolerant mode, we accept this
+		assertTrue(prop.getValue() == null || prop.getValue().getKind() == YamlNodeKind.YamlScalar);
+	}
+
+	@Test
+	public void unclosedFlowSequence() {
+		String content = "[1, 2, 3";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+		assertEquals(1, document.getChildCount());
+
+		YamlSequence sequence = (YamlSequence) document.getChild(0);
+		// Fault-tolerant: should still parse the items
+		assertEquals(3, sequence.getChildCount());
+		// But the sequence is not closed
+		assertFalse(sequence.isClosed());
+	}
+
+	@Test
+	public void unclosedFlowMapping() {
+		String content = "{name: John, age: 30";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+		assertEquals(1, document.getChildCount());
+
+		YamlMapping mapping = (YamlMapping) document.getChild(0);
+		// Fault-tolerant: should still parse the properties
+		assertEquals(2, mapping.getChildCount());
+		// But the mapping is not closed
+		assertFalse(mapping.isClosed());
+	}
+
+	@Test
+	public void emptyDocument() {
+		String content = "";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+		assertEquals(0, document.getChildCount());
+	}
+
+	@Test
+	public void onlyComments() {
+		String content = "# Comment 1\n" + //
+				"# Comment 2";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+		assertEquals(2, document.getChildCount());
+
+		assertEquals(YamlNodeKind.YamlComment, document.getChild(0).getKind());
+		assertEquals(YamlNodeKind.YamlComment, document.getChild(1).getKind());
+	}
+
+	@Test
+	public void complexKubernetesStyle() {
+		String content = "apiVersion: v1\n" + //
+				"kind: Pod\n" + //
+				"metadata:\n" + //
+				"  name: nginx\n" + //
+				"  labels:\n" + //
+				"    app: nginx";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+
+		YamlMapping rootMapping = (YamlMapping) document.getChild(0);
+		assertEquals(3, rootMapping.getChildCount());
+
+		// apiVersion: v1
+		YamlProperty apiVersion = (YamlProperty) rootMapping.getChild(0);
+		assertEquals("apiVersion", ((YamlScalar) apiVersion.getKey()).getValue());
+		assertEquals("v1", ((YamlScalar) apiVersion.getValue()).getValue());
+
+		// kind: Pod
+		YamlProperty kind = (YamlProperty) rootMapping.getChild(1);
+		assertEquals("kind", ((YamlScalar) kind.getKey()).getValue());
+		assertEquals("Pod", ((YamlScalar) kind.getValue()).getValue());
+
+		// metadata:
+		YamlProperty metadata = (YamlProperty) rootMapping.getChild(2);
+		assertEquals("metadata", ((YamlScalar) metadata.getKey()).getValue());
+		assertEquals(YamlNodeKind.YamlMapping, metadata.getValue().getKind());
+
+		YamlMapping metadataMapping = (YamlMapping) metadata.getValue();
+		assertEquals(2, metadataMapping.getChildCount());
+
+		// metadata.name
+		YamlProperty name = (YamlProperty) metadataMapping.getChild(0);
+		assertEquals("name", ((YamlScalar) name.getKey()).getValue());
+		assertEquals("nginx", ((YamlScalar) name.getValue()).getValue());
+
+		// metadata.labels
+		YamlProperty labels = (YamlProperty) metadataMapping.getChild(1);
+		assertEquals("labels", ((YamlScalar) labels.getKey()).getValue());
+		assertEquals(YamlNodeKind.YamlMapping, labels.getValue().getKind());
+
+		YamlMapping labelsMapping = (YamlMapping) labels.getValue();
+		assertEquals(1, labelsMapping.getChildCount());
+
+		YamlProperty app = (YamlProperty) labelsMapping.getChild(0);
+		assertEquals("app", ((YamlScalar) app.getKey()).getValue());
+		assertEquals("nginx", ((YamlScalar) app.getValue()).getValue());
+	}
+
+	@Test
+	public void mixedFlowAndBlock() {
+		String content = "data:\n" + //
+				"  items: [1, 2, 3]\n" + //
+				"  config: {debug: true}";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+
+		YamlMapping rootMapping = (YamlMapping) document.getChild(0);
+		YamlProperty dataProp = (YamlProperty) rootMapping.getChild(0);
+		/*
+		 * YamlDocument └── YamlMapping └── YamlProperty (data) └── YamlMapping ├──
+		 * YamlProperty (items) │ └── YamlSequence [1, 2, 3] └── YamlProperty (config)
+		 * └── YamlMapping └── YamlProperty (debug → true)
+		 */
+
+		YamlMapping dataMapping = (YamlMapping) dataProp.getValue();
+		assertNotNull(dataMapping);
+		assertEquals(2, dataMapping.getChildCount());
+
+		// items: [1, 2, 3]
+		YamlProperty itemsProp = (YamlProperty) dataMapping.getChild(0);
+		assertEquals(YamlNodeKind.YamlSequence, itemsProp.getValue().getKind());
+		YamlSequence itemsSeq = (YamlSequence) itemsProp.getValue();
+		assertEquals(3, itemsSeq.getChildCount());
+
+		// config: {debug: true}
+		YamlProperty configProp = (YamlProperty) dataMapping.getChild(1);
+		assertEquals(YamlNodeKind.YamlMapping, configProp.getValue().getKind());
+		YamlMapping configMap = (YamlMapping) configProp.getValue();
+		assertEquals(1, configMap.getChildCount());
+	}
+
+	@Test
+	public void nestedFlowCollections() {
+		String content = "matrix: [[1, 2], [3, 4]]";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+
+		YamlMapping mapping = (YamlMapping) document.getChild(0);
+		YamlProperty prop = (YamlProperty) mapping.getChild(0);
+
+		YamlSequence outerSeq = (YamlSequence) prop.getValue();
+		assertEquals(2, outerSeq.getChildCount());
+
+		YamlSequence innerSeq1 = (YamlSequence) outerSeq.getChild(0);
+		assertEquals(2, innerSeq1.getChildCount());
+		assertEquals("1", ((YamlScalar) innerSeq1.getChild(0)).getValue());
+		assertEquals("2", ((YamlScalar) innerSeq1.getChild(1)).getValue());
+
+		YamlSequence innerSeq2 = (YamlSequence) outerSeq.getChild(1);
+		assertEquals(2, innerSeq2.getChildCount());
+		assertEquals("3", ((YamlScalar) innerSeq2.getChild(0)).getValue());
+		assertEquals("4", ((YamlScalar) innerSeq2.getChild(1)).getValue());
+	}
+
+	@Test
+	public void testFlowArrayWithFlowObject() {
+		String content = "list: [{ title: \"Applied AI\", year: 2005, tagline: \"AI guide for Java\" }]";
+
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+
+		// Root structure
+		assertEquals(1, document.getChildCount());
+		YamlMapping rootMapping = (YamlMapping) document.getChild(0);
+		assertEquals(1, rootMapping.getChildCount());
+		assertFalse(rootMapping.isFlowStyle());
+
+		// list property
+		YamlProperty listProp = (YamlProperty) rootMapping.getChild(0);
+		assertEquals("list", ((YamlScalar) listProp.getKey()).getValue());
+		assertNotNull(listProp.getValue());
+		assertEquals(YamlNodeKind.YamlSequence, listProp.getValue().getKind());
+
+		// Flow sequence
+		YamlSequence sequence = (YamlSequence) listProp.getValue();
+		assertTrue(sequence.isFlowStyle());
+		assertEquals(1, sequence.getChildCount());
+
+		// Flow mapping inside sequence
+		YamlMapping mapping = (YamlMapping) sequence.getChild(0);
+		assertTrue(mapping.isFlowStyle());
+		assertEquals(3, mapping.getChildCount());
+
+		// title property
+		YamlProperty titleProp = (YamlProperty) mapping.getChild(0);
+		assertEquals("title", ((YamlScalar) titleProp.getKey()).getValue());
+		YamlScalar titleValue = (YamlScalar) titleProp.getValue();
+		assertEquals("Applied AI", titleValue.getValue());
+		assertTrue(titleValue.isQuoted());
+		assertEquals(YamlTokenType.ScalarString, titleValue.getScalarType());
+
+		// year property
+		YamlProperty yearProp = (YamlProperty) mapping.getChild(1);
+		assertEquals("year", ((YamlScalar) yearProp.getKey()).getValue());
+		YamlScalar yearValue = (YamlScalar) yearProp.getValue();
+		assertEquals("2005", yearValue.getValue());
+		assertFalse(yearValue.isQuoted());
+		assertEquals(YamlTokenType.ScalarNumber, yearValue.getScalarType());
+
+		// tagline property
+		YamlProperty taglineProp = (YamlProperty) mapping.getChild(2);
+		assertEquals("tagline", ((YamlScalar) taglineProp.getKey()).getValue());
+		YamlScalar taglineValue = (YamlScalar) taglineProp.getValue();
+		assertEquals("AI guide for Java", taglineValue.getValue());
+		assertTrue(taglineValue.isQuoted());
+		assertEquals(YamlTokenType.ScalarString, taglineValue.getScalarType());
+	}
+
+	@Test
+	public void findNodeAt() {
+		String content = "person:\n  name: John\n  age: 30";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+
+		// Find node at offset 0 (start of "person")
+		YamlNode node = document.findNodeAt(0);
+		assertNotNull(node);
+
+		// Find node at offset in "John"
+		node = document.findNodeAt(17);
+		assertNotNull(node);
+		// Should find the scalar "John"
+		if (node.getKind() == YamlNodeKind.YamlScalar) {
+			assertEquals("John", ((YamlScalar) node).getValue());
+		}
+	}
+
+	@Test
+	public void multilineValue() {
+		String content = "description: This is a long description";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+
+		YamlMapping mapping = (YamlMapping) document.getChild(0);
+		YamlProperty prop = (YamlProperty) mapping.getChild(0);
+
+		assertEquals("description", ((YamlScalar) prop.getKey()).getValue());
+		assertEquals("This is a long description", ((YamlScalar) prop.getValue()).getValue());
+	}
+
+	@Test
+	public void booleanVariants() {
+		String content = "a: yes\n" + //
+				"b: no\n" + //
+				"c: true\n" + //
+				"d: false\n" + //
+				"e: on\n" + //
+				"f: off";
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+
+		YamlMapping mapping = (YamlMapping) document.getChild(0);
+		assertEquals(6, mapping.getChildCount());
+
+		// All should be recognized as booleans
+		for (int i = 0; i < 6; i++) {
+			YamlProperty prop = (YamlProperty) mapping.getChild(i);
+			YamlScalar value = (YamlScalar) prop.getValue();
+			assertEquals(YamlTokenType.ScalarBoolean, value.getScalarType());
+		}
+	}
+
+	@Test
+	public void testFrontMatter() {
+		String content = "title: Hello Roqers (1)\n" + //
+				"description: It is time to start Roqing 🚀!\n" + //
+				"layout: :theme/index (2)";
+
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+
+		// Root structure
+		assertEquals(1, document.getChildCount());
+		YamlMapping rootMapping = (YamlMapping) document.getChild(0);
+		assertEquals(3, rootMapping.getChildCount());
+		assertFalse(rootMapping.isFlowStyle());
+
+		// title property
+		YamlProperty titleProp = (YamlProperty) rootMapping.getChild(0);
+		assertEquals("title", ((YamlScalar) titleProp.getKey()).getValue());
+		assertNotNull(titleProp.getValue());
+		assertEquals(YamlNodeKind.YamlScalar, titleProp.getValue().getKind());
+
+		YamlScalar titleValue = (YamlScalar) titleProp.getValue();
+		assertEquals("Hello Roqers (1)", titleValue.getValue());
+		assertEquals(YamlTokenType.ScalarString, titleValue.getScalarType());
+		assertFalse(titleValue.isQuoted());
+
+		// description property
+		YamlProperty descProp = (YamlProperty) rootMapping.getChild(1);
+		assertEquals("description", ((YamlScalar) descProp.getKey()).getValue());
+		assertNotNull(descProp.getValue());
+
+		YamlScalar descValue = (YamlScalar) descProp.getValue();
+		assertEquals("It is time to start Roqing 🚀!", descValue.getValue());
+		assertEquals(YamlTokenType.ScalarString, descValue.getScalarType());
+		assertFalse(descValue.isQuoted());
+
+		// layout property
+		YamlProperty layoutProp = (YamlProperty) rootMapping.getChild(2);
+		assertEquals("layout", ((YamlScalar) layoutProp.getKey()).getValue());
+		assertNotNull(layoutProp.getValue());
+
+		YamlScalar layoutValue = (YamlScalar) layoutProp.getValue();
+		assertEquals(":theme/index (2)", layoutValue.getValue());
+		assertEquals(YamlTokenType.ScalarString, layoutValue.getScalarType());
+		assertFalse(layoutValue.isQuoted());
+	}
+
+	@Test
+	public void testBookList() {
+		String content = "list:\n" + //
+				"  - title: \"Book 1\"\n" + //
+				"    year: 2025\n" + //
+				"  - title: \"Book 2\"\n" + //
+				"    year: 2021";
+
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+
+		// Root structure
+		assertEquals(1, document.getChildCount());
+		YamlMapping rootMapping = (YamlMapping) document.getChild(0);
+		assertEquals(1, rootMapping.getChildCount());
+
+		// list property
+		YamlProperty listProp = (YamlProperty) rootMapping.getChild(0);
+		assertEquals("list", ((YamlScalar) listProp.getKey()).getValue());
+		assertNotNull(listProp.getValue());
+		assertEquals(YamlNodeKind.YamlSequence, listProp.getValue().getKind());
+
+		// Sequence with 2 items
+		YamlSequence sequence = (YamlSequence) listProp.getValue();
+		assertEquals(2, sequence.getChildCount());
+		assertFalse(sequence.isFlowStyle());
+
+		// First book
+		YamlMapping book1 = (YamlMapping) sequence.getChild(0);
+		assertEquals(2, book1.getChildCount());
+
+		YamlProperty title1 = (YamlProperty) book1.getChild(0);
+		assertEquals("title", ((YamlScalar) title1.getKey()).getValue());
+		YamlScalar titleValue1 = (YamlScalar) title1.getValue();
+		assertEquals("Book 1", titleValue1.getValue());
+		assertTrue(titleValue1.isQuoted());
+
+		YamlProperty year1 = (YamlProperty) book1.getChild(1);
+		assertEquals("year", ((YamlScalar) year1.getKey()).getValue());
+		assertEquals("2025", ((YamlScalar) year1.getValue()).getValue());
+		assertEquals(YamlTokenType.ScalarNumber, ((YamlScalar) year1.getValue()).getScalarType());
+
+		// Second book
+		YamlMapping book2 = (YamlMapping) sequence.getChild(1);
+		assertEquals(2, book2.getChildCount());
+
+		YamlProperty title2 = (YamlProperty) book2.getChild(0);
+		assertEquals("title", ((YamlScalar) title2.getKey()).getValue());
+		YamlScalar titleValue2 = (YamlScalar) title2.getValue();
+		assertEquals("Book 2", titleValue2.getValue());
+		assertTrue(titleValue2.isQuoted());
+
+		YamlProperty year2 = (YamlProperty) book2.getChild(1);
+		assertEquals("year", ((YamlScalar) year2.getKey()).getValue());
+		assertEquals("2021", ((YamlScalar) year2.getValue()).getValue());
+		assertEquals(YamlTokenType.ScalarNumber, ((YamlScalar) year2.getValue()).getScalarType());
+	}
+
+	@Test
+	public void testBookListWithTagline() {
+		String content = "list:\n" + //
+				"  - title: \"Applied AI\"\n" + //
+				"    year: 2025\n" + //
+				"    tagline: \"AI guide for Java\"\n" + //
+				"  - title: \"Modernizing Java\"\n" + //
+				"    year: 2021\n" + //
+				"    tagline: \"Bring apps to future\"";
+
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+
+		YamlMapping rootMapping = (YamlMapping) document.getChild(0);
+		YamlProperty listProp = (YamlProperty) rootMapping.getChild(0);
+		YamlSequence sequence = (YamlSequence) listProp.getValue();
+
+		assertEquals(2, sequence.getChildCount());
+
+		// First book - 3 properties
+		YamlMapping book1 = (YamlMapping) sequence.getChild(0);
+		assertEquals(3, book1.getChildCount());
+		assertEquals("Applied AI", ((YamlScalar) ((YamlProperty) book1.getChild(0)).getValue()).getValue());
+		assertEquals("2025", ((YamlScalar) ((YamlProperty) book1.getChild(1)).getValue()).getValue());
+		assertEquals("AI guide for Java", ((YamlScalar) ((YamlProperty) book1.getChild(2)).getValue()).getValue());
+
+		// Second book - 3 properties
+		YamlMapping book2 = (YamlMapping) sequence.getChild(1);
+		assertEquals(3, book2.getChildCount());
+		assertEquals("Modernizing Java", ((YamlScalar) ((YamlProperty) book2.getChild(0)).getValue()).getValue());
+		assertEquals("2021", ((YamlScalar) ((YamlProperty) book2.getChild(1)).getValue()).getValue());
+		assertEquals("Bring apps to future", ((YamlScalar) ((YamlProperty) book2.getChild(2)).getValue()).getValue());
+	}
+
+	@Test
+	public void testNestedSandwiches() {
+		String content = "sandwiches:\n" + //
+				"  - name: Turkey and Brie\n" + //
+				"    ingredients:\n" + //
+				"     - turkey\n" + //
+				"     - brie\n" + //
+				"     - apple\n" + //
+				"     - ciabatta\n" + //
+				"  - name: Ham and Cheese\n" + //
+				"    ingredients:\n" + //
+				"     - ham\n" + //
+				"     - cheddar\n" + //
+				"     - mustard\n" + //
+				"     - green leaf lettuce\n" + //
+				"     - whole grain bread";
+
+		YamlDocument document = YamlParser.parse(content, "test.yaml");
+
+		// Root structure
+		assertEquals(1, document.getChildCount());
+		YamlMapping rootMapping = (YamlMapping) document.getChild(0);
+		assertEquals(1, rootMapping.getChildCount());
+
+		// sandwiches property
+		YamlProperty sandwichesProp = (YamlProperty) rootMapping.getChild(0);
+		assertEquals("sandwiches", ((YamlScalar) sandwichesProp.getKey()).getValue());
+		assertNotNull(sandwichesProp.getValue());
+		assertEquals(YamlNodeKind.YamlSequence, sandwichesProp.getValue().getKind());
+
+		// Sequence with 2 sandwiches
+		YamlSequence sandwichesSeq = (YamlSequence) sandwichesProp.getValue();
+		assertEquals(2, sandwichesSeq.getChildCount());
+
+		// First sandwich
+		YamlMapping sandwich1 = (YamlMapping) sandwichesSeq.getChild(0);
+		assertEquals(2, sandwich1.getChildCount());
+
+		// name: Turkey and Brie
+		YamlProperty name1 = (YamlProperty) sandwich1.getChild(0);
+		assertEquals("name", ((YamlScalar) name1.getKey()).getValue());
+		assertEquals("Turkey and Brie", ((YamlScalar) name1.getValue()).getValue());
+
+		// ingredients: [turkey, brie, apple, ciabatta]
+		YamlProperty ingredients1 = (YamlProperty) sandwich1.getChild(1);
+		assertEquals("ingredients", ((YamlScalar) ingredients1.getKey()).getValue());
+		assertEquals(YamlNodeKind.YamlSequence, ingredients1.getValue().getKind());
+
+		YamlSequence ingredientsSeq1 = (YamlSequence) ingredients1.getValue();
+		assertEquals(4, ingredientsSeq1.getChildCount());
+		assertEquals("turkey", ((YamlScalar) ingredientsSeq1.getChild(0)).getValue());
+		assertEquals("brie", ((YamlScalar) ingredientsSeq1.getChild(1)).getValue());
+		assertEquals("apple", ((YamlScalar) ingredientsSeq1.getChild(2)).getValue());
+		assertEquals("ciabatta", ((YamlScalar) ingredientsSeq1.getChild(3)).getValue());
+
+		// Second sandwich
+		YamlMapping sandwich2 = (YamlMapping) sandwichesSeq.getChild(1);
+		assertEquals(2, sandwich2.getChildCount());
+
+		// name: Ham and Cheese
+		YamlProperty name2 = (YamlProperty) sandwich2.getChild(0);
+		assertEquals("name", ((YamlScalar) name2.getKey()).getValue());
+		assertEquals("Ham and Cheese", ((YamlScalar) name2.getValue()).getValue());
+
+		// ingredients: [ham, cheddar, mustard, green leaf lettuce, whole grain bread]
+		YamlProperty ingredients2 = (YamlProperty) sandwich2.getChild(1);
+		assertEquals("ingredients", ((YamlScalar) ingredients2.getKey()).getValue());
+		assertEquals(YamlNodeKind.YamlSequence, ingredients2.getValue().getKind());
+
+		YamlSequence ingredientsSeq2 = (YamlSequence) ingredients2.getValue();
+		assertEquals(5, ingredientsSeq2.getChildCount());
+		assertEquals("ham", ((YamlScalar) ingredientsSeq2.getChild(0)).getValue());
+		assertEquals("cheddar", ((YamlScalar) ingredientsSeq2.getChild(1)).getValue());
+		assertEquals("mustard", ((YamlScalar) ingredientsSeq2.getChild(2)).getValue());
+		assertEquals("green leaf lettuce", ((YamlScalar) ingredientsSeq2.getChild(3)).getValue());
+		assertEquals("whole grain bread", ((YamlScalar) ingredientsSeq2.getChild(4)).getValue());
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/parser/yaml/scanner/YamlScannerTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/parser/yaml/scanner/YamlScannerTest.java
@@ -1,0 +1,1007 @@
+package com.redhat.qute.parser.yaml.scanner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.parser.scanner.Scanner;
+
+/**
+ * Tests for YAML scanner {@link YamlScanner}.
+ * 
+ * @author Your Name
+ *
+ */
+public class YamlScannerTest {
+
+	private Scanner<YamlTokenType, YamlScannerState> scanner;
+
+	// ========== Basic Key-Value Tests ==========
+
+	@Test
+	public void testSimpleKeyValue() {
+		scanner = YamlScanner.createScanner("key: value");
+		assertOffsetAndToken(0, YamlTokenType.Key, "key");
+		assertOffsetAndToken(3, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(4, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(5, YamlTokenType.ScalarString, "value");
+		assertOffsetAndToken(10, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testKeyValueWithNumber() {
+		scanner = YamlScanner.createScanner("port: 8080");
+		assertOffsetAndToken(0, YamlTokenType.Key, "port");
+		assertOffsetAndToken(4, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(5, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(6, YamlTokenType.ScalarNumber, "8080");
+		assertOffsetAndToken(10, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testKeyValueWithBoolean() {
+		scanner = YamlScanner.createScanner("enabled: true");
+		assertOffsetAndToken(0, YamlTokenType.Key, "enabled");
+		assertOffsetAndToken(7, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(8, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(9, YamlTokenType.ScalarBoolean, "true");
+		assertOffsetAndToken(13, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testKeyValueWithNull() {
+		scanner = YamlScanner.createScanner("value: null");
+		assertOffsetAndToken(0, YamlTokenType.Key, "value");
+		assertOffsetAndToken(5, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(6, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(7, YamlTokenType.ScalarNull, "null");
+		assertOffsetAndToken(11, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testMultipleKeyValues() {
+		scanner = YamlScanner.createScanner("name: John\n" + //
+				"age: 30");
+		assertOffsetAndToken(0, YamlTokenType.Key, "name");
+		assertOffsetAndToken(4, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(5, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(6, YamlTokenType.ScalarString, "John");
+		assertOffsetAndToken(10, YamlTokenType.Newline, "\n");
+		assertOffsetAndToken(11, YamlTokenType.Key, "age");
+		assertOffsetAndToken(14, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(15, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(16, YamlTokenType.ScalarNumber, "30");
+		assertOffsetAndToken(18, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testMissingValue() {
+		scanner = YamlScanner.createScanner("name:     \n" + //
+				"age: 30");
+		assertOffsetAndToken(0, YamlTokenType.Key, "name");
+		assertOffsetAndToken(4, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(5, YamlTokenType.Whitespace, "     ");
+		// assertOffsetAndToken(6, YamlTokenType.ScalarString, "John");
+		assertOffsetAndToken(10, YamlTokenType.Newline, "\n");
+		assertOffsetAndToken(11, YamlTokenType.Key, "age");
+		assertOffsetAndToken(14, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(15, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(16, YamlTokenType.ScalarNumber, "30");
+		assertOffsetAndToken(18, YamlTokenType.EOS, "");
+	}
+
+	// ========== Quoted String Tests ==========
+
+	@Test
+	public void testDoubleQuotedString() {
+		scanner = YamlScanner.createScanner("name: \"John Doe\"");
+		assertOffsetAndToken(0, YamlTokenType.Key, "name");
+		assertOffsetAndToken(4, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(5, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(6, YamlTokenType.StartString, "\"");
+		assertOffsetAndToken(7, YamlTokenType.String, "John Doe");
+		assertOffsetAndToken(15, YamlTokenType.EndString, "\"");
+		assertOffsetAndToken(16, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testSingleQuotedString() {
+		scanner = YamlScanner.createScanner("name: 'Jane Doe'");
+		assertOffsetAndToken(0, YamlTokenType.Key, "name");
+		assertOffsetAndToken(4, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(5, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(6, YamlTokenType.StartString, "'");
+		assertOffsetAndToken(7, YamlTokenType.String, "Jane Doe");
+		assertOffsetAndToken(15, YamlTokenType.EndString, "'");
+		assertOffsetAndToken(16, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testQuotedStringWithEscape() {
+		scanner = YamlScanner.createScanner("text: \"Hello\\n" + //
+				"World\"");
+		assertOffsetAndToken(0, YamlTokenType.Key, "text");
+		assertOffsetAndToken(4, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(5, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(6, YamlTokenType.StartString, "\"");
+		assertOffsetAndToken(7, YamlTokenType.String, "Hello\\nWorld");
+		assertOffsetAndToken(19, YamlTokenType.EndString, "\"");
+		assertOffsetAndToken(20, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testUnclosedQuotedString() {
+		scanner = YamlScanner.createScanner("name: \"unclosed");
+		assertOffsetAndToken(0, YamlTokenType.Key, "name");
+		assertOffsetAndToken(4, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(5, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(6, YamlTokenType.StartString, "\"");
+		assertOffsetAndToken(7, YamlTokenType.String, "unclosed");
+		assertOffsetAndToken(15, YamlTokenType.EOS, "");
+	}
+
+	// ========== List/Array Tests ==========
+
+	@Test
+	public void testSimpleList() {
+		scanner = YamlScanner.createScanner("- item1\n" + //
+				"- item2");
+		assertOffsetAndToken(0, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(1, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(2, YamlTokenType.ScalarString, "item1");
+		assertOffsetAndToken(7, YamlTokenType.Newline, "\n");
+		assertOffsetAndToken(8, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(9, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(10, YamlTokenType.ScalarString, "item2");
+		assertOffsetAndToken(15, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testListWithNumbers() {
+		scanner = YamlScanner.createScanner("- 1\n" + //
+				"- 2\n" + //
+				"- 3");
+		assertOffsetAndToken(0, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(1, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(2, YamlTokenType.ScalarNumber, "1");
+		assertOffsetAndToken(3, YamlTokenType.Newline, "\n");
+		assertOffsetAndToken(4, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(5, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(6, YamlTokenType.ScalarNumber, "2");
+		assertOffsetAndToken(7, YamlTokenType.Newline, "\n");
+		assertOffsetAndToken(8, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(9, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(10, YamlTokenType.ScalarNumber, "3");
+		assertOffsetAndToken(11, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testNestedList() {
+		scanner = YamlScanner.createScanner("items:\n" + //
+				"- first\n" + //
+				"- second");
+		assertOffsetAndToken(0, YamlTokenType.Key, "items");
+		assertOffsetAndToken(5, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(6, YamlTokenType.Newline, "\n");
+		assertOffsetAndToken(7, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(8, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(9, YamlTokenType.ScalarString, "first");
+		assertOffsetAndToken(14, YamlTokenType.Newline, "\n");
+		assertOffsetAndToken(15, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(16, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(17, YamlTokenType.ScalarString, "second");
+		assertOffsetAndToken(23, YamlTokenType.EOS, "");
+	}
+
+	// ========== Flow Collection Tests (JSON-style) ==========
+
+	@Test
+	public void testFlowSequence() {
+		scanner = YamlScanner.createScanner("items: [1, 2, 3]");
+		assertOffsetAndToken(0, YamlTokenType.Key, "items");
+		assertOffsetAndToken(5, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(6, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(7, YamlTokenType.ArrayOpen, "[");
+		assertOffsetAndToken(8, YamlTokenType.ScalarNumber, "1");
+		assertOffsetAndToken(9, YamlTokenType.Comma, ",");
+		assertOffsetAndToken(10, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(11, YamlTokenType.ScalarNumber, "2");
+		assertOffsetAndToken(12, YamlTokenType.Comma, ",");
+		assertOffsetAndToken(13, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(14, YamlTokenType.ScalarNumber, "3");
+		assertOffsetAndToken(15, YamlTokenType.ArrayClose, "]");
+		assertOffsetAndToken(16, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testFlowSequenceWithStrings() {
+		scanner = YamlScanner.createScanner("[\"a\", \"b\", \"c\"]");
+		assertOffsetAndToken(0, YamlTokenType.ArrayOpen, "[");
+		assertOffsetAndToken(1, YamlTokenType.StartString, "\"");
+		assertOffsetAndToken(2, YamlTokenType.String, "a");
+		assertOffsetAndToken(3, YamlTokenType.EndString, "\"");
+		assertOffsetAndToken(4, YamlTokenType.Comma, ",");
+		assertOffsetAndToken(5, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(6, YamlTokenType.StartString, "\"");
+		assertOffsetAndToken(7, YamlTokenType.String, "b");
+		assertOffsetAndToken(8, YamlTokenType.EndString, "\"");
+		assertOffsetAndToken(9, YamlTokenType.Comma, ",");
+		assertOffsetAndToken(10, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(11, YamlTokenType.StartString, "\"");
+		assertOffsetAndToken(12, YamlTokenType.String, "c");
+		assertOffsetAndToken(13, YamlTokenType.EndString, "\"");
+		assertOffsetAndToken(14, YamlTokenType.ArrayClose, "]");
+		assertOffsetAndToken(15, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testFlowMapping() {
+		scanner = YamlScanner.createScanner("{name: John, age: 30}");
+		assertOffsetAndToken(0, YamlTokenType.ObjectOpen, "{");
+		assertOffsetAndToken(1, YamlTokenType.Key, "name");
+		assertOffsetAndToken(5, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(6, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(7, YamlTokenType.ScalarString, "John");
+		assertOffsetAndToken(11, YamlTokenType.Comma, ",");
+		assertOffsetAndToken(12, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(13, YamlTokenType.Key, "age");
+		assertOffsetAndToken(16, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(17, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(18, YamlTokenType.ScalarNumber, "30");
+		assertOffsetAndToken(20, YamlTokenType.ObjectClose, "}");
+		assertOffsetAndToken(21, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testNestedFlowCollections() {
+		scanner = YamlScanner.createScanner("data: [1, [2, 3]]");
+		assertOffsetAndToken(0, YamlTokenType.Key, "data");
+		assertOffsetAndToken(4, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(5, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(6, YamlTokenType.ArrayOpen, "[");
+		assertOffsetAndToken(7, YamlTokenType.ScalarNumber, "1");
+		assertOffsetAndToken(8, YamlTokenType.Comma, ",");
+		assertOffsetAndToken(9, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(10, YamlTokenType.ArrayOpen, "[");
+		assertOffsetAndToken(11, YamlTokenType.ScalarNumber, "2");
+		assertOffsetAndToken(12, YamlTokenType.Comma, ",");
+		assertOffsetAndToken(13, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(14, YamlTokenType.ScalarNumber, "3");
+		assertOffsetAndToken(15, YamlTokenType.ArrayClose, "]");
+		assertOffsetAndToken(16, YamlTokenType.ArrayClose, "]");
+		assertOffsetAndToken(17, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testFlowArrayWithFlowObject() {
+		scanner = YamlScanner
+				.createScanner("list: [{ title: \"Applied AI\", year: 2005, tagline: \"AI guide for Java\" }]");
+
+		// list:
+		assertOffsetAndToken(0, YamlTokenType.Key, "list");
+		assertOffsetAndToken(4, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(5, YamlTokenType.Whitespace, " ");
+
+		// [
+		assertOffsetAndToken(6, YamlTokenType.ArrayOpen, "[");
+
+		// {
+		assertOffsetAndToken(7, YamlTokenType.ObjectOpen, "{");
+		assertOffsetAndToken(8, YamlTokenType.Whitespace, " ");
+
+		// title: "Applied AI"
+		assertOffsetAndToken(9, YamlTokenType.Key, "title");
+		assertOffsetAndToken(14, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(15, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(16, YamlTokenType.StartString, "\"");
+		assertOffsetAndToken(17, YamlTokenType.String, "Applied AI");
+		assertOffsetAndToken(27, YamlTokenType.EndString, "\"");
+
+		// ,
+		assertOffsetAndToken(28, YamlTokenType.Comma, ",");
+		assertOffsetAndToken(29, YamlTokenType.Whitespace, " ");
+
+		// year: 2005
+		assertOffsetAndToken(30, YamlTokenType.Key, "year");
+		assertOffsetAndToken(34, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(35, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(36, YamlTokenType.ScalarNumber, "2005");
+
+		// ,
+		assertOffsetAndToken(40, YamlTokenType.Comma, ",");
+		assertOffsetAndToken(41, YamlTokenType.Whitespace, " ");
+
+		// tagline: "AI guide for Java"
+		assertOffsetAndToken(42, YamlTokenType.Key, "tagline");
+		assertOffsetAndToken(49, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(50, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(51, YamlTokenType.StartString, "\"");
+		assertOffsetAndToken(52, YamlTokenType.String, "AI guide for Java");
+		assertOffsetAndToken(69, YamlTokenType.EndString, "\"");
+		assertOffsetAndToken(70, YamlTokenType.Whitespace, " ");
+
+		// }
+		assertOffsetAndToken(71, YamlTokenType.ObjectClose, "}");
+
+		// ]
+		assertOffsetAndToken(72, YamlTokenType.ArrayClose, "]");
+
+		assertOffsetAndToken(73, YamlTokenType.EOS, "");
+	}
+
+	// ========== Comment Tests ==========
+
+	@Test
+	public void testSimpleComment() {
+		scanner = YamlScanner.createScanner("# This is a comment");
+		assertOffsetAndToken(0, YamlTokenType.StartComment, "#");
+		assertOffsetAndToken(1, YamlTokenType.Comment, " This is a comment");
+		assertOffsetAndToken(19, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testCommentAfterValue() {
+		scanner = YamlScanner.createScanner("key: value # comment");
+		assertOffsetAndToken(0, YamlTokenType.Key, "key");
+		assertOffsetAndToken(3, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(4, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(5, YamlTokenType.ScalarString, "value ");
+		assertOffsetAndToken(11, YamlTokenType.StartComment, "#");
+		assertOffsetAndToken(12, YamlTokenType.Comment, " comment");
+		assertOffsetAndToken(20, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testMultilineWithComments() {
+		scanner = YamlScanner.createScanner("# Header comment\n" + //
+				"key: value\n" + //
+				"# Footer comment");
+		assertOffsetAndToken(0, YamlTokenType.StartComment, "#");
+		assertOffsetAndToken(1, YamlTokenType.Comment, " Header comment");
+		assertOffsetAndToken(16, YamlTokenType.Newline, "\n");
+		assertOffsetAndToken(17, YamlTokenType.Key, "key");
+		assertOffsetAndToken(20, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(21, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(22, YamlTokenType.ScalarString, "value");
+		assertOffsetAndToken(27, YamlTokenType.Newline, "\n");
+		assertOffsetAndToken(28, YamlTokenType.StartComment, "#");
+		assertOffsetAndToken(29, YamlTokenType.Comment, " Footer comment");
+		assertOffsetAndToken(44, YamlTokenType.EOS, "");
+	}
+
+	// ========== Whitespace and Newline Tests ==========
+
+	@Test
+	public void testIndentation() {
+		scanner = YamlScanner.createScanner("  key: value");
+		assertOffsetAndToken(0, YamlTokenType.Whitespace, "  ");
+		assertOffsetAndToken(2, YamlTokenType.Key, "key");
+		assertOffsetAndToken(5, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(6, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(7, YamlTokenType.ScalarString, "value");
+		assertOffsetAndToken(12, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testCRLF() {
+		scanner = YamlScanner.createScanner("key1: value1\r\n" + //
+				"key2: value2");
+		assertOffsetAndToken(0, YamlTokenType.Key, "key1");
+		assertOffsetAndToken(4, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(5, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(6, YamlTokenType.ScalarString, "value1");
+		assertOffsetAndToken(12, YamlTokenType.Newline, "\r\n");
+		assertOffsetAndToken(14, YamlTokenType.Key, "key2");
+		assertOffsetAndToken(18, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(19, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(20, YamlTokenType.ScalarString, "value2");
+		assertOffsetAndToken(26, YamlTokenType.EOS, "");
+	}
+
+	// ========== Complex/Real-World Tests ==========
+
+	@Test
+	public void testComplexYamlDocument() {
+		scanner = YamlScanner.createScanner("name: MyApp\n" + //
+				"version: 1.0\n" + //
+				"enabled: true\n" + //
+				"ports:\n" + //
+				"  - 8080\n" + //
+				"  - 8443");
+
+		// name: MyApp
+		assertOffsetAndToken(0, YamlTokenType.Key, "name");
+		assertOffsetAndToken(4, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(5, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(6, YamlTokenType.ScalarString, "MyApp");
+		assertOffsetAndToken(11, YamlTokenType.Newline, "\n");
+
+		// version: 1.0
+		assertOffsetAndToken(12, YamlTokenType.Key, "version");
+		assertOffsetAndToken(19, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(20, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(21, YamlTokenType.ScalarNumber, "1.0");
+		assertOffsetAndToken(24, YamlTokenType.Newline, "\n");
+
+		// enabled: true
+		assertOffsetAndToken(25, YamlTokenType.Key, "enabled");
+		assertOffsetAndToken(32, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(33, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(34, YamlTokenType.ScalarBoolean, "true");
+		assertOffsetAndToken(38, YamlTokenType.Newline, "\n");
+
+		// ports:
+		assertOffsetAndToken(39, YamlTokenType.Key, "ports");
+		assertOffsetAndToken(44, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(45, YamlTokenType.Newline, "\n");
+
+		// - 8080
+		assertOffsetAndToken(46, YamlTokenType.Whitespace, "  ");
+		assertOffsetAndToken(48, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(49, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(50, YamlTokenType.ScalarNumber, "8080");
+		assertOffsetAndToken(54, YamlTokenType.Newline, "\n");
+
+		// - 8443
+		assertOffsetAndToken(55, YamlTokenType.Whitespace, "  ");
+		assertOffsetAndToken(57, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(58, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(59, YamlTokenType.ScalarNumber, "8443");
+		assertOffsetAndToken(63, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testKubernetesStyleYaml() {
+		scanner = YamlScanner.createScanner("apiVersion: v1\n" + //
+				"kind: Pod\n" + //
+				"metadata:\n" + //
+				"  name: nginx\n" + //
+				"  labels:\n" + //
+				"    app: nginx");
+
+		assertOffsetAndToken(0, YamlTokenType.Key, "apiVersion");
+		assertOffsetAndToken(10, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(11, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(12, YamlTokenType.ScalarString, "v1");
+		assertOffsetAndToken(14, YamlTokenType.Newline, "\n");
+
+		assertOffsetAndToken(15, YamlTokenType.Key, "kind");
+		assertOffsetAndToken(19, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(20, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(21, YamlTokenType.ScalarString, "Pod");
+		assertOffsetAndToken(24, YamlTokenType.Newline, "\n");
+
+		assertOffsetAndToken(25, YamlTokenType.Key, "metadata");
+		assertOffsetAndToken(33, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(34, YamlTokenType.Newline, "\n");
+
+		assertOffsetAndToken(35, YamlTokenType.Whitespace, "  ");
+		assertOffsetAndToken(37, YamlTokenType.Key, "name");
+		assertOffsetAndToken(41, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(42, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(43, YamlTokenType.ScalarString, "nginx");
+		assertOffsetAndToken(48, YamlTokenType.Newline, "\n");
+
+		assertOffsetAndToken(49, YamlTokenType.Whitespace, "  ");
+		assertOffsetAndToken(51, YamlTokenType.Key, "labels");
+		assertOffsetAndToken(57, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(58, YamlTokenType.Newline, "\n");
+
+		assertOffsetAndToken(59, YamlTokenType.Whitespace, "    ");
+		assertOffsetAndToken(63, YamlTokenType.Key, "app");
+		assertOffsetAndToken(66, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(67, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(68, YamlTokenType.ScalarString, "nginx");
+		assertOffsetAndToken(73, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testSequenceOfMappings() {
+		scanner = YamlScanner.createScanner("items:\n" + //
+				"- name: John\n" + //
+				"  age: 30\n" + //
+				"- name: Jane\n" + //
+				"  age: 25");
+
+		// items:
+		assertOffsetAndToken(0, YamlTokenType.Key, "items");
+		assertOffsetAndToken(5, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(6, YamlTokenType.Newline, "\n");
+
+		// - name: John
+		assertOffsetAndToken(7, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(8, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(9, YamlTokenType.Key, "name");
+		assertOffsetAndToken(13, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(14, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(15, YamlTokenType.ScalarString, "John");
+		assertOffsetAndToken(19, YamlTokenType.Newline, "\n");
+
+		// age: 30
+		assertOffsetAndToken(20, YamlTokenType.Whitespace, "  ");
+		assertOffsetAndToken(22, YamlTokenType.Key, "age");
+		assertOffsetAndToken(25, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(26, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(27, YamlTokenType.ScalarNumber, "30");
+		assertOffsetAndToken(29, YamlTokenType.Newline, "\n");
+
+		// - name: Jane
+		assertOffsetAndToken(30, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(31, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(32, YamlTokenType.Key, "name");
+		assertOffsetAndToken(36, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(37, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(38, YamlTokenType.ScalarString, "Jane");
+		assertOffsetAndToken(42, YamlTokenType.Newline, "\n");
+
+		// age: 25
+		assertOffsetAndToken(43, YamlTokenType.Whitespace, "  ");
+		assertOffsetAndToken(45, YamlTokenType.Key, "age");
+		assertOffsetAndToken(48, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(49, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(50, YamlTokenType.ScalarNumber, "25");
+
+		assertOffsetAndToken(52, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testMixedFlowAndBlock() {
+		scanner = YamlScanner.createScanner("data:\n" + //
+				"  items: [1, 2, 3]\n" + //
+				"  config: {debug: true}");
+
+		// data:
+		assertOffsetAndToken(0, YamlTokenType.Key, "data");
+		assertOffsetAndToken(4, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(5, YamlTokenType.Newline, "\n");
+
+		// First line indentation
+		assertOffsetAndToken(6, YamlTokenType.Whitespace, "  ");
+
+		// items:
+		assertOffsetAndToken(8, YamlTokenType.Key, "items");
+		assertOffsetAndToken(13, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(14, YamlTokenType.Whitespace, " ");
+
+		// [1, 2, 3]
+		assertOffsetAndToken(15, YamlTokenType.ArrayOpen, "[");
+		assertOffsetAndToken(16, YamlTokenType.ScalarNumber, "1");
+		assertOffsetAndToken(17, YamlTokenType.Comma, ",");
+		assertOffsetAndToken(18, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(19, YamlTokenType.ScalarNumber, "2");
+		assertOffsetAndToken(20, YamlTokenType.Comma, ",");
+		assertOffsetAndToken(21, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(22, YamlTokenType.ScalarNumber, "3");
+		assertOffsetAndToken(23, YamlTokenType.ArrayClose, "]");
+		assertOffsetAndToken(24, YamlTokenType.Newline, "\n");
+
+		// Second line indentation
+		assertOffsetAndToken(25, YamlTokenType.Whitespace, "  ");
+
+		// config:
+		assertOffsetAndToken(27, YamlTokenType.Key, "config");
+		assertOffsetAndToken(33, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(34, YamlTokenType.Whitespace, " ");
+
+		// {debug: true}
+		assertOffsetAndToken(35, YamlTokenType.ObjectOpen, "{");
+		assertOffsetAndToken(36, YamlTokenType.Key, "debug");
+		assertOffsetAndToken(41, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(42, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(43, YamlTokenType.ScalarBoolean, "true");
+		assertOffsetAndToken(47, YamlTokenType.ObjectClose, "}");
+
+		assertOffsetAndToken(48, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testFrontMatter() {
+		scanner = YamlScanner.createScanner("title: Hello Roqers (1)\n" + //
+				"description: It is time to start Roqing!\n" + //
+				"layout: :theme/index (2)");
+
+		// title: Hello Roqers (1)
+		assertOffsetAndToken(0, YamlTokenType.Key, "title");
+		assertOffsetAndToken(5, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(6, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(7, YamlTokenType.ScalarString, "Hello Roqers (1)");
+		assertOffsetAndToken(23, YamlTokenType.Newline, "\n");
+
+		// description: It is time to start Roqing 🚀!
+		assertOffsetAndToken(24, YamlTokenType.Key, "description");
+		assertOffsetAndToken(35, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(36, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(37, YamlTokenType.ScalarString, "It is time to start Roqing!");
+		assertOffsetAndToken(64, YamlTokenType.Newline, "\n");
+
+		// layout: :theme/index (2)
+		assertOffsetAndToken(65, YamlTokenType.Key, "layout");
+		assertOffsetAndToken(71, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(72, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(73, YamlTokenType.ScalarString, ":theme/index (2)");
+		assertOffsetAndToken(89, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testBookList() {
+		scanner = YamlScanner.createScanner("list:\n" + //
+				"  - title: \"Book 1\"\n" + //
+				"    year: 2025\n" + //
+				"  - title: \"Book 2\"\n" + //
+				"    year: 2021");
+
+		// list:
+		assertOffsetAndToken(0, YamlTokenType.Key, "list");
+		assertOffsetAndToken(4, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(5, YamlTokenType.Newline, "\n");
+
+		// First item - indentation
+		assertOffsetAndToken(6, YamlTokenType.Whitespace, "  ");
+		assertOffsetAndToken(8, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(9, YamlTokenType.Whitespace, " ");
+
+		// title: "Book 1"
+		assertOffsetAndToken(10, YamlTokenType.Key, "title");
+		assertOffsetAndToken(15, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(16, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(17, YamlTokenType.StartString, "\"");
+		assertOffsetAndToken(18, YamlTokenType.String, "Book 1");
+		assertOffsetAndToken(24, YamlTokenType.EndString, "\"");
+		assertOffsetAndToken(25, YamlTokenType.Newline, "\n");
+
+		// year: 2025
+		assertOffsetAndToken(26, YamlTokenType.Whitespace, "    ");
+		assertOffsetAndToken(30, YamlTokenType.Key, "year");
+		assertOffsetAndToken(34, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(35, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(36, YamlTokenType.ScalarNumber, "2025");
+		assertOffsetAndToken(40, YamlTokenType.Newline, "\n");
+
+		// Second item - indentation
+		assertOffsetAndToken(41, YamlTokenType.Whitespace, "  ");
+		assertOffsetAndToken(43, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(44, YamlTokenType.Whitespace, " ");
+
+		// title: "Book 2"
+		assertOffsetAndToken(45, YamlTokenType.Key, "title");
+		assertOffsetAndToken(50, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(51, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(52, YamlTokenType.StartString, "\"");
+		assertOffsetAndToken(53, YamlTokenType.String, "Book 2");
+		assertOffsetAndToken(59, YamlTokenType.EndString, "\"");
+		assertOffsetAndToken(60, YamlTokenType.Newline, "\n");
+
+		// year: 2021
+		assertOffsetAndToken(61, YamlTokenType.Whitespace, "    ");
+		assertOffsetAndToken(65, YamlTokenType.Key, "year");
+		assertOffsetAndToken(69, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(70, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(71, YamlTokenType.ScalarNumber, "2021");
+
+		assertOffsetAndToken(75, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testBookListWithTagline() {
+		scanner = YamlScanner.createScanner("list:\n" + //
+				"  - title: \"Applied AI\"\n" + //
+				"    year: 2025\n" + //
+				"    tagline: \"AI guide for Java\"\n" + //
+				"  - title: \"Modernizing Java\"\n" + //
+				"    year: 2021\n" + //
+				"    tagline: \"Bring apps to future\"");
+
+		// list:
+		assertOffsetAndToken(0, YamlTokenType.Key, "list");
+		assertOffsetAndToken(4, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(5, YamlTokenType.Newline, "\n");
+
+		// First item
+		assertOffsetAndToken(6, YamlTokenType.Whitespace, "  ");
+		assertOffsetAndToken(8, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(9, YamlTokenType.Whitespace, " ");
+
+		// title: "Applied AI"
+		assertOffsetAndToken(10, YamlTokenType.Key, "title");
+		assertOffsetAndToken(15, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(16, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(17, YamlTokenType.StartString, "\"");
+		assertOffsetAndToken(18, YamlTokenType.String, "Applied AI");
+		assertOffsetAndToken(28, YamlTokenType.EndString, "\"");
+		assertOffsetAndToken(29, YamlTokenType.Newline, "\n");
+
+		// year: 2025
+		assertOffsetAndToken(30, YamlTokenType.Whitespace, "    ");
+		assertOffsetAndToken(34, YamlTokenType.Key, "year");
+		assertOffsetAndToken(38, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(39, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(40, YamlTokenType.ScalarNumber, "2025");
+		assertOffsetAndToken(44, YamlTokenType.Newline, "\n");
+
+		// tagline: "AI guide for Java"
+		assertOffsetAndToken(45, YamlTokenType.Whitespace, "    ");
+		assertOffsetAndToken(49, YamlTokenType.Key, "tagline");
+		assertOffsetAndToken(56, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(57, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(58, YamlTokenType.StartString, "\"");
+		assertOffsetAndToken(59, YamlTokenType.String, "AI guide for Java");
+		assertOffsetAndToken(76, YamlTokenType.EndString, "\"");
+		assertOffsetAndToken(77, YamlTokenType.Newline, "\n");
+
+		// Second item
+		assertOffsetAndToken(78, YamlTokenType.Whitespace, "  ");
+		assertOffsetAndToken(80, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(81, YamlTokenType.Whitespace, " ");
+
+		// title: "Modernizing Java"
+		assertOffsetAndToken(82, YamlTokenType.Key, "title");
+		assertOffsetAndToken(87, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(88, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(89, YamlTokenType.StartString, "\"");
+		assertOffsetAndToken(90, YamlTokenType.String, "Modernizing Java");
+		assertOffsetAndToken(106, YamlTokenType.EndString, "\"");
+		assertOffsetAndToken(107, YamlTokenType.Newline, "\n");
+
+		// year: 2021
+		assertOffsetAndToken(108, YamlTokenType.Whitespace, "    ");
+		assertOffsetAndToken(112, YamlTokenType.Key, "year");
+		assertOffsetAndToken(116, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(117, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(118, YamlTokenType.ScalarNumber, "2021");
+		assertOffsetAndToken(122, YamlTokenType.Newline, "\n");
+
+		// tagline: "Bring apps to future"
+		assertOffsetAndToken(123, YamlTokenType.Whitespace, "    ");
+		assertOffsetAndToken(127, YamlTokenType.Key, "tagline");
+		assertOffsetAndToken(134, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(135, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(136, YamlTokenType.StartString, "\"");
+		assertOffsetAndToken(137, YamlTokenType.String, "Bring apps to future");
+		assertOffsetAndToken(157, YamlTokenType.EndString, "\"");
+
+		assertOffsetAndToken(158, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testNestedSandwiches() {
+		scanner = YamlScanner.createScanner("sandwiches:\n" + //
+				"  - name: Turkey and Brie\n" + //
+				"    ingredients:\n" + //
+				"     - turkey\n" + //
+				"     - brie\n" + //
+				"  - name: Ham and Cheese\n" + //
+				"    ingredients:\n" + //
+				"     - ham\n" + //
+				"     - cheddar");
+
+		// sandwiches:
+		assertOffsetAndToken(0, YamlTokenType.Key, "sandwiches");
+		assertOffsetAndToken(10, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(11, YamlTokenType.Newline, "\n");
+
+		// First sandwich
+		assertOffsetAndToken(12, YamlTokenType.Whitespace, "  ");
+		assertOffsetAndToken(14, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(15, YamlTokenType.Whitespace, " ");
+
+		// name: Turkey and Brie
+		assertOffsetAndToken(16, YamlTokenType.Key, "name");
+		assertOffsetAndToken(20, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(21, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(22, YamlTokenType.ScalarString, "Turkey and Brie");
+		assertOffsetAndToken(37, YamlTokenType.Newline, "\n");
+
+		// ingredients:
+		assertOffsetAndToken(38, YamlTokenType.Whitespace, "    ");
+		assertOffsetAndToken(42, YamlTokenType.Key, "ingredients");
+		assertOffsetAndToken(53, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(54, YamlTokenType.Newline, "\n");
+
+		// - turkey
+		assertOffsetAndToken(55, YamlTokenType.Whitespace, "     ");
+		assertOffsetAndToken(60, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(61, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(62, YamlTokenType.ScalarString, "turkey");
+		assertOffsetAndToken(68, YamlTokenType.Newline, "\n");
+
+		// - brie
+		assertOffsetAndToken(69, YamlTokenType.Whitespace, "     ");
+		assertOffsetAndToken(74, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(75, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(76, YamlTokenType.ScalarString, "brie");
+		assertOffsetAndToken(80, YamlTokenType.Newline, "\n");
+
+		// Second sandwich
+		assertOffsetAndToken(81, YamlTokenType.Whitespace, "  ");
+		assertOffsetAndToken(83, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(84, YamlTokenType.Whitespace, " ");
+
+		// name: Ham and Cheese
+		assertOffsetAndToken(85, YamlTokenType.Key, "name");
+		assertOffsetAndToken(89, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(90, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(91, YamlTokenType.ScalarString, "Ham and Cheese");
+		assertOffsetAndToken(105, YamlTokenType.Newline, "\n");
+
+		// ingredients:
+		assertOffsetAndToken(106, YamlTokenType.Whitespace, "    ");
+		assertOffsetAndToken(110, YamlTokenType.Key, "ingredients");
+		assertOffsetAndToken(121, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(122, YamlTokenType.Newline, "\n");
+
+		// - ham
+		assertOffsetAndToken(123, YamlTokenType.Whitespace, "     ");
+		assertOffsetAndToken(128, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(129, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(130, YamlTokenType.ScalarString, "ham");
+		assertOffsetAndToken(133, YamlTokenType.Newline, "\n");
+
+		// - cheddar
+		assertOffsetAndToken(134, YamlTokenType.Whitespace, "     ");
+		assertOffsetAndToken(139, YamlTokenType.Dash, "-");
+		assertOffsetAndToken(140, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(141, YamlTokenType.ScalarString, "cheddar");
+
+		assertOffsetAndToken(148, YamlTokenType.EOS, "");
+	}
+
+	// ========== Edge Cases and Fault Tolerance ==========
+
+	@Test
+	public void testEmptyDocument() {
+		scanner = YamlScanner.createScanner("");
+		assertOffsetAndToken(0, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testOnlyWhitespace() {
+		scanner = YamlScanner.createScanner("   \t  \n  ");
+		assertOffsetAndToken(0, YamlTokenType.Whitespace, "   \t  ");
+		assertOffsetAndToken(6, YamlTokenType.Newline, "\n");
+		assertOffsetAndToken(7, YamlTokenType.Whitespace, "  ");
+		assertOffsetAndToken(9, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testOnlyComments() {
+		scanner = YamlScanner.createScanner("# Comment 1\n# Comment 2");
+		assertOffsetAndToken(0, YamlTokenType.StartComment, "#");
+		assertOffsetAndToken(1, YamlTokenType.Comment, " Comment 1");
+		assertOffsetAndToken(11, YamlTokenType.Newline, "\n");
+		assertOffsetAndToken(12, YamlTokenType.StartComment, "#");
+		assertOffsetAndToken(13, YamlTokenType.Comment, " Comment 2");
+		assertOffsetAndToken(23, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testMissingColon() {
+		scanner = YamlScanner.createScanner("key value");
+		assertOffsetAndToken(0, YamlTokenType.ScalarString, "key value");
+		assertOffsetAndToken(9, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testSpecialNumberFormats() {
+		scanner = YamlScanner.createScanner("hex: 0xFF\n" + //
+				"octal: 0o77\n" + //
+				"float: 3.14e-10");
+
+		assertOffsetAndToken(0, YamlTokenType.Key, "hex");
+		assertOffsetAndToken(3, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(4, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(5, YamlTokenType.ScalarNumber, "0xFF");
+		assertOffsetAndToken(9, YamlTokenType.Newline, "\n");
+
+		assertOffsetAndToken(10, YamlTokenType.Key, "octal");
+		assertOffsetAndToken(15, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(16, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(17, YamlTokenType.ScalarNumber, "0o77");
+		assertOffsetAndToken(21, YamlTokenType.Newline, "\n");
+
+		assertOffsetAndToken(22, YamlTokenType.Key, "float");
+		assertOffsetAndToken(27, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(28, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(29, YamlTokenType.ScalarNumber, "3.14e-10");
+		assertOffsetAndToken(37, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testBooleanVariants() {
+		scanner = YamlScanner.createScanner("a: yes\n" + //
+				"b: no\n" + //
+				"c: on\n" + //
+				"d: off");
+
+		assertOffsetAndToken(0, YamlTokenType.Key, "a");
+		assertOffsetAndToken(1, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(2, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(3, YamlTokenType.ScalarBoolean, "yes");
+		assertOffsetAndToken(6, YamlTokenType.Newline, "\n");
+
+		assertOffsetAndToken(7, YamlTokenType.Key, "b");
+		assertOffsetAndToken(8, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(9, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(10, YamlTokenType.ScalarBoolean, "no");
+		assertOffsetAndToken(12, YamlTokenType.Newline, "\n");
+
+		assertOffsetAndToken(13, YamlTokenType.Key, "c");
+		assertOffsetAndToken(14, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(15, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(16, YamlTokenType.ScalarBoolean, "on");
+		assertOffsetAndToken(18, YamlTokenType.Newline, "\n");
+
+		assertOffsetAndToken(19, YamlTokenType.Key, "d");
+		assertOffsetAndToken(20, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(21, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(22, YamlTokenType.ScalarBoolean, "off");
+		assertOffsetAndToken(25, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testUnclosedFlowSequence() {
+		scanner = YamlScanner.createScanner("[1, 2, 3");
+		assertOffsetAndToken(0, YamlTokenType.ArrayOpen, "[");
+		assertOffsetAndToken(1, YamlTokenType.ScalarNumber, "1");
+		assertOffsetAndToken(2, YamlTokenType.Comma, ",");
+		assertOffsetAndToken(3, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(4, YamlTokenType.ScalarNumber, "2");
+		assertOffsetAndToken(5, YamlTokenType.Comma, ",");
+		assertOffsetAndToken(6, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(7, YamlTokenType.ScalarNumber, "3");
+		assertOffsetAndToken(8, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testUnclosedFlowMapping() {
+		scanner = YamlScanner.createScanner("{name: John");
+		assertOffsetAndToken(0, YamlTokenType.ObjectOpen, "{");
+		assertOffsetAndToken(1, YamlTokenType.Key, "name");
+		assertOffsetAndToken(5, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(6, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(7, YamlTokenType.ScalarString, "John");
+		assertOffsetAndToken(11, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testEmptyValue() {
+		scanner = YamlScanner.createScanner("key:");
+		assertOffsetAndToken(0, YamlTokenType.Key, "key");
+		assertOffsetAndToken(3, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(4, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testEmptyList() {
+		scanner = YamlScanner.createScanner("items: []");
+		assertOffsetAndToken(0, YamlTokenType.Key, "items");
+		assertOffsetAndToken(5, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(6, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(7, YamlTokenType.ArrayOpen, "[");
+		assertOffsetAndToken(8, YamlTokenType.ArrayClose, "]");
+		assertOffsetAndToken(9, YamlTokenType.EOS, "");
+	}
+
+	@Test
+	public void testEmptyObject() {
+		scanner = YamlScanner.createScanner("data: {}");
+		assertOffsetAndToken(0, YamlTokenType.Key, "data");
+		assertOffsetAndToken(4, YamlTokenType.Colon, ":");
+		assertOffsetAndToken(5, YamlTokenType.Whitespace, " ");
+		assertOffsetAndToken(6, YamlTokenType.ObjectOpen, "{");
+		assertOffsetAndToken(7, YamlTokenType.ObjectClose, "}");
+		assertOffsetAndToken(8, YamlTokenType.EOS, "");
+	}
+
+	public void assertOffsetAndToken(int tokenOffset, YamlTokenType tokenType) {
+		YamlTokenType token = scanner.scan();
+		assertEquals(tokenOffset, scanner.getTokenOffset());
+		assertEquals(tokenType, token);
+	}
+
+	public void assertOffsetAndToken(int tokenOffset, YamlTokenType tokenType, String tokenText) {
+		YamlTokenType token = scanner.scan();
+		assertEquals(tokenOffset, scanner.getTokenOffset());
+		assertEquals(tokenType, token);
+		assertEquals(tokenText, scanner.getTokenText());
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/MockProjectQuteLanguageServer.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/MockProjectQuteLanguageServer.java
@@ -27,6 +27,7 @@ import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 
 import com.redhat.qute.commons.FileUtils;
+import com.redhat.qute.commons.ProjectFeature;
 import com.redhat.qute.commons.ProjectInfo;
 import com.redhat.qute.commons.QuteProjectParams;
 import com.redhat.qute.commons.TemplateRootPath;
@@ -36,16 +37,25 @@ public class MockProjectQuteLanguageServer extends MockQuteLanguageServer {
 
 	private final String projectUri;
 
-	private final Path resourcesPath;
+	private final Set<ProjectFeature> features;
+	private Path projectFolder;
+
+	private final Path resourcesFolder;
 
 	private final Path templatesPath;
 
 	private final ProjectInfo projectInfo;
 
 	public MockProjectQuteLanguageServer(String projectUri) {
+		this(projectUri, Collections.emptySet());
+	}
+
+	public MockProjectQuteLanguageServer(String projectUri, Set<ProjectFeature> features) {
 		this.projectUri = projectUri;
-		this.resourcesPath = FileUtils.createPath("src/test/resources/projects/" + projectUri + "/src/main/resources");
-		this.templatesPath = resourcesPath.resolve("templates");
+		this.features = features;
+		this.projectFolder = FileUtils.createPath("src/test/resources/projects/" + projectUri);
+		this.resourcesFolder = projectFolder.resolve("src/main/resources");
+		this.templatesPath = resourcesFolder.resolve("templates");
 		this.projectInfo = createProject();
 	}
 
@@ -109,9 +119,12 @@ public class MockProjectQuteLanguageServer extends MockQuteLanguageServer {
 	}
 
 	private ProjectInfo createProject() {
-		return new ProjectInfo(projectUri, Collections.emptyList(), //
+		return new ProjectInfo(projectUri, //
+				FileUtils.toUri(projectFolder), //
+				Collections.emptyList(), //
 				List.of(new TemplateRootPath(FileUtils.toUri(templatesPath))), //
-				Set.of(FileUtils.toUri(resourcesPath)));
+				Set.of(FileUtils.toUri(resourcesFolder)), //
+				features);
 	}
 
 	private Path getTemplatesPath() {

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/MockQuteProjectRegistry.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/MockQuteProjectRegistry.java
@@ -87,13 +87,13 @@ public class MockQuteProjectRegistry extends QuteProjectRegistry {
 			return new QuteProjectB(this);
 		}
 		if (RoqProject.PROJECT_URI.equals(projectInfo.getUri())) {
-			return new RoqProject(projectInfo, this);
+			return new RoqProject(this);
 		}
 		if (QuteWebProject.PROJECT_URI.equals(projectInfo.getUri())) {
 			return new QuteWebProject(projectInfo, this);
 		}
 		if (RenardeProject.PROJECT_URI.equals(projectInfo.getUri())) {
-			return new RenardeProject(projectInfo, this);
+			return new RenardeProject(this);
 		}
 		return super.createProject(projectInfo);
 	}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/multiple/QuteProjectA.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/multiple/QuteProjectA.java
@@ -11,7 +11,6 @@
 *******************************************************************************/
 package com.redhat.qute.project.multiple;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -32,9 +31,13 @@ public class QuteProjectA extends MockQuteProject {
 	public final static String PROJECT_URI = "project-a";
 
 	public QuteProjectA(QuteProjectRegistry projectRegistry) {
-		super(new ProjectInfo(PROJECT_URI, Collections.emptyList(),
-				Arrays.asList(new TemplateRootPath(getProjectPath(PROJECT_URI) + "/src/main/resources/templates")),
-				Collections.emptySet()), projectRegistry);
+		super(new ProjectInfo(PROJECT_URI, //
+				null, //
+				Collections.emptyList(), //
+				List.of(new TemplateRootPath(getProjectPath(PROJECT_URI) + "/src/main/resources/templates")),
+				Collections.emptySet(), //
+				Collections.emptySet()), //
+				projectRegistry);
 	}
 
 	@Override

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/multiple/QuteProjectB.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/multiple/QuteProjectB.java
@@ -11,7 +11,6 @@
 *******************************************************************************/
 package com.redhat.qute.project.multiple;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -32,12 +31,20 @@ public class QuteProjectB extends MockQuteProject {
 	public final static String PROJECT_URI = "project-b";
 
 	public QuteProjectB(QuteProjectRegistry projectRegistry) {
-		super(new ProjectInfo(PROJECT_URI, Collections.emptyList(),
-				Arrays.asList(new TemplateRootPath(getProjectPath(PROJECT_URI) + "/src/main/resources/templates")), //
-				Collections.emptySet()), projectRegistry);
+		super(new ProjectInfo(PROJECT_URI, //
+				null, //
+				Collections.emptyList(), //
+				List.of(new TemplateRootPath(getProjectPath(PROJECT_URI) + "/src/main/resources/templates")),
+				Collections.emptySet(), //
+				Collections.emptySet()), //
+				projectRegistry);
 		// project-b dependends from project-a
-		super.getProjectDependencies().add(projectRegistry.getProject(new ProjectInfo(QuteProjectA.PROJECT_URI,
-				Collections.emptyList(), Arrays.asList(new TemplateRootPath("")), Collections.emptySet())));
+		super.getProjectDependencies().add(projectRegistry.getProject(new ProjectInfo(QuteProjectA.PROJECT_URI, //
+				null, //
+				Collections.emptyList(), //
+				List.of(new TemplateRootPath("")), //
+				Collections.emptySet(), //
+				Collections.emptySet())));
 	}
 
 	@Override

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/renarde/RenardeProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/renarde/RenardeProject.java
@@ -11,12 +11,12 @@
 *******************************************************************************/
 package com.redhat.qute.project.renarde;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.redhat.qute.commons.ProjectFeature;
 import com.redhat.qute.commons.ProjectInfo;
 import com.redhat.qute.commons.TemplateRootPath;
 import com.redhat.qute.commons.datamodel.DataModelParameter;
@@ -30,10 +30,13 @@ public class RenardeProject extends BaseQuteProject {
 
 	public final static String PROJECT_URI = "renarde";
 
-	public RenardeProject(ProjectInfo projectInfo, QuteProjectRegistry projectRegistry) {
-		super(new ProjectInfo(PROJECT_URI, Collections.emptyList(),
-				Arrays.asList(new TemplateRootPath(getProjectPath(PROJECT_URI) + "/src/main/resources/templates")),
-				Set.of(getProjectPath(PROJECT_URI) + "/src/main/resources")), projectRegistry);
+	public RenardeProject(QuteProjectRegistry projectRegistry) {
+		super(new ProjectInfo(PROJECT_URI, //
+				getProjectPath(PROJECT_URI), //
+				Collections.emptyList(), //
+				List.of(new TemplateRootPath(getProjectPath(PROJECT_URI) + "/src/main/resources/templates")), //
+				Set.of(getProjectPath(PROJECT_URI) + "/src/main/resources"), //
+				Set.of(ProjectFeature.Renarde)), projectRegistry);
 	}
 
 	@Override

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/roq/RoqProject.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/roq/RoqProject.java
@@ -11,12 +11,17 @@
 *******************************************************************************/
 package com.redhat.qute.project.roq;
 
+import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import com.redhat.qute.commons.ProjectFeature;
 import com.redhat.qute.commons.ProjectInfo;
 import com.redhat.qute.commons.ResolvedJavaTypeInfo;
+import com.redhat.qute.commons.TemplateRootPath;
 import com.redhat.qute.commons.datamodel.DataModelParameter;
 import com.redhat.qute.commons.datamodel.DataModelProject;
 import com.redhat.qute.commons.datamodel.DataModelTemplate;
@@ -24,6 +29,7 @@ import com.redhat.qute.commons.datamodel.DataModelTemplateMatcher;
 import com.redhat.qute.commons.datamodel.resolvers.NamespaceResolverInfo;
 import com.redhat.qute.commons.datamodel.resolvers.ValueResolverInfo;
 import com.redhat.qute.project.BaseQuteProject;
+import com.redhat.qute.project.MockQuteProject;
 import com.redhat.qute.project.QuteProjectRegistry;
 
 /**
@@ -34,8 +40,13 @@ public class RoqProject extends BaseQuteProject {
 	public static final String PROJECT_URI = "roq";
 	private DataModelProject<DataModelTemplate<?>> dataModel;
 
-	public RoqProject(ProjectInfo projectInfo, QuteProjectRegistry projectRegistry) {
-		super(projectInfo, projectRegistry);
+	public RoqProject(QuteProjectRegistry projectRegistry) {
+		super(new ProjectInfo(PROJECT_URI, //
+				getProjectPath(PROJECT_URI), //
+				Collections.emptyList(), //
+				List.of(new TemplateRootPath(getProjectPath(PROJECT_URI) + "/src/main/resources/templates")), //
+				Set.of(getProjectPath(PROJECT_URI) + "/src/main/resources"), //
+				Set.of(ProjectFeature.Roq)), projectRegistry);
 	}
 
 	@Override
@@ -51,7 +62,8 @@ public class RoqProject extends BaseQuteProject {
 
 	@Override
 	protected void fillTemplates(List<DataModelTemplate<DataModelParameter>> templates) {
-		// Inject 'page' and 'site' for all Qute templates which belongs to a Roq application 
+		// Inject 'page' and 'site' for all Qute templates which belongs to a Roq
+		// application
 		DataModelTemplate<DataModelParameter> roqTemplate = new DataModelTemplate<DataModelParameter>();
 		roqTemplate.setTemplateMatcher(new DataModelTemplateMatcher(Arrays.asList("**/**")));
 
@@ -85,6 +97,11 @@ public class RoqProject extends BaseQuteProject {
 	@Override
 	protected void fillNamespaceResolverInfos(Map<String, NamespaceResolverInfo> namespaces) {
 
+	}
+
+	public static String getDataFileUri(String fileName) {
+		return Paths.get(MockQuteProject.getProjectPath(RoqProject.PROJECT_URI) + "/data/" + fileName).toAbsolutePath()
+				.toUri().toASCIIString();
 	}
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/user_tags/RenardeProjectQuteLanguageServer.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/project/user_tags/RenardeProjectQuteLanguageServer.java
@@ -1,12 +1,15 @@
 package com.redhat.qute.project.user_tags;
 
+import java.util.Set;
+
+import com.redhat.qute.commons.ProjectFeature;
 import com.redhat.qute.project.MockProjectQuteLanguageServer;
 import com.redhat.qute.project.renarde.RenardeProject;
 
 public class RenardeProjectQuteLanguageServer extends MockProjectQuteLanguageServer {
 
 	public RenardeProjectQuteLanguageServer() {
-		super(RenardeProject.PROJECT_URI);
+		super(RenardeProject.PROJECT_URI, Set.of(ProjectFeature.Renarde));
 	}
 
 }

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/commands/QuteGenerateTemplateContentCommandHandlerTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/commands/QuteGenerateTemplateContentCommandHandlerTest.java
@@ -36,8 +36,9 @@ public class QuteGenerateTemplateContentCommandHandlerTest {
 
 	private QuteProjectRegistry createProjectRegistry() {
 		QuteProjectRegistry projectRegistry = new MockQuteProjectRegistry();
-		projectRegistry.getProject(new ProjectInfo(PROJECT_URI, Collections.emptyList(),
+		projectRegistry.getProject(new ProjectInfo(PROJECT_URI, null, Collections.emptyList(),
 				Arrays.asList(new TemplateRootPath(TEMPLATE_BASE_DIR)), //
+				Collections.emptySet(), //
 				Collections.emptySet()));
 		return projectRegistry;
 	}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/roq/RoqDataJsonCompletionsTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/roq/RoqDataJsonCompletionsTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.completions.roq;
+
+import static com.redhat.qute.QuteAssert.c;
+import static com.redhat.qute.QuteAssert.r;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.QuteAssert;
+import com.redhat.qute.project.roq.RoqProject;
+
+/**
+ * Test completion with Roq Quarkus extension and data files.
+ *
+ * @author Angelo ZERR
+ * 
+ */
+public class RoqDataJsonCompletionsTest {
+
+	@Test
+	public void books() throws Exception {
+		String template = "{inject:books-json.|}";
+		testCompletionFor(template, //
+				c("or(base : T, arg : Object) : T", "or(arg)", r(0, 19, 0, 19)), //
+				c("list : Collection<Object>", "list", r(0, 19, 0, 19)));
+	}
+
+	@Test
+	public void booksItem() throws Exception {
+		String template = "{#for b in inject:books-json.list}\r\n" + //
+				"    {b.|}\r\n" + //
+				"{/for}";
+		testCompletionFor(template, //
+				c("or(base : T, arg : Object) : T", "or(arg)", r(1, 7, 1, 7)), //
+				c("title : String", "title", r(1, 7, 1, 7)));
+	}
+
+	public static void testCompletionFor(String value, CompletionItem... expectedItems) throws Exception {
+		QuteAssert.testCompletionFor(value, false, QuteAssert.FILE_URI, null, RoqProject.PROJECT_URI,
+				QuteAssert.TEMPLATE_BASE_DIR, null, expectedItems);
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/roq/RoqDataYamlCompletionsTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/roq/RoqDataYamlCompletionsTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.completions.roq;
+
+import static com.redhat.qute.QuteAssert.c;
+import static com.redhat.qute.QuteAssert.r;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.QuteAssert;
+import com.redhat.qute.project.roq.RoqProject;
+
+/**
+ * Test completion with Roq Quarkus extension and data files.
+ *
+ * @author Angelo ZERR
+ * 
+ */
+public class RoqDataYamlCompletionsTest {
+
+	@Test
+	public void books() throws Exception {
+		String template = "{inject:books.|}";
+		testCompletionFor(template, //
+				c("or(base : T, arg : Object) : T", "or(arg)", r(0, 14, 0, 14)), //
+				c("list : Collection<Object>", "list", r(0, 14, 0, 14)));
+	}
+
+	@Test
+	public void booksItem() throws Exception {
+		String template = "{#for b in inject:books.list}\r\n" + //
+				"    {b.|}\r\n" + //
+				"{/for}";
+		testCompletionFor(template, //
+				c("or(base : T, arg : Object) : T", "or(arg)", r(1, 7, 1, 7)), //
+				c("title : String", "title", r(1, 7, 1, 7)));
+	}
+
+	public static void testCompletionFor(String value, CompletionItem... expectedItems) throws Exception {
+		QuteAssert.testCompletionFor(value, false, QuteAssert.FILE_URI, null, RoqProject.PROJECT_URI,
+				QuteAssert.TEMPLATE_BASE_DIR, null, expectedItems);
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/roq/RoqSiteCompletionsTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/completions/roq/RoqSiteCompletionsTest.java
@@ -26,7 +26,7 @@ import com.redhat.qute.project.roq.RoqProject;
  * @author Angelo ZERR
  * 
  */
-public class RoqCompletionsTest {
+public class RoqSiteCompletionsTest {
 
 	@Test
 	public void site() throws Exception {

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/definition/renarde/RenardeMessagesDefinitionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/definition/renarde/RenardeMessagesDefinitionTest.java
@@ -24,7 +24,7 @@ import com.redhat.qute.project.MockQuteProject;
 import com.redhat.qute.project.renarde.RenardeProject;
 
 /**
- * Test definition in Renarde.
+ * Test definition in Renarde with messages properties.
  * 
  * @author Angelo ZERR
  *

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/definition/roq/RoqDataJsonDefinitionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/definition/roq/RoqDataJsonDefinitionTest.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.definition.roq;
+
+import static com.redhat.qute.QuteAssert.ll;
+import static com.redhat.qute.QuteAssert.r;
+import static com.redhat.qute.project.roq.RoqProject.getDataFileUri;
+
+import org.eclipse.lsp4j.LocationLink;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.QuteAssert;
+import com.redhat.qute.project.roq.RoqProject;
+
+/**
+ * Test definition in Roq with data file.
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class RoqDataJsonDefinitionTest {
+
+	@Test
+	public void books() throws Exception {
+		String booksUri = getDataFileUri("books.yaml");
+		String template = "{inject:bo|oks}";
+		testDefinitionFor(template, //
+				ll(booksUri, r(0, 8, 0, 13), r(0, 0, 0, 0)));
+	}
+
+	@Test
+	public void books_list() throws Exception {
+		String booksUri = getDataFileUri("books-json.json");
+
+		String template = "{inj|ect:books-json.list}";
+		testDefinitionFor(template);
+
+		template = "{inject:books-json.li|st}";
+		testDefinitionFor(template, //
+				ll(booksUri, r(0, 19, 0, 23), r(0, 0, 0, 0)));
+	}
+
+	@Test
+	public void books_list_title() throws Exception {
+		String booksUri = getDataFileUri("books-json.json");
+
+		String template = "{#for b in inject:books-json.list}\r\n" + //
+				"    {b.ti|tle}\r\n" + //
+				"{/for}";
+		testDefinitionFor(template, //
+				ll(booksUri, r(1, 7, 1, 12), r(0, 0, 0, 0)));
+	}
+
+	public static void testDefinitionFor(String value, LocationLink... expected) throws Exception {
+		QuteAssert.testDefinitionFor(value, null, RoqProject.PROJECT_URI, QuteAssert.TEMPLATE_BASE_DIR, expected);
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/definition/roq/RoqDataYamlDefinitionTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/definition/roq/RoqDataYamlDefinitionTest.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.definition.roq;
+
+import static com.redhat.qute.QuteAssert.ll;
+import static com.redhat.qute.QuteAssert.r;
+import static com.redhat.qute.project.roq.RoqProject.getDataFileUri;
+
+import org.eclipse.lsp4j.LocationLink;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.QuteAssert;
+import com.redhat.qute.project.roq.RoqProject;
+
+/**
+ * Test definition in Roq with data file.
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class RoqDataYamlDefinitionTest {
+
+	@Test
+	public void books() throws Exception {
+		String booksUri = getDataFileUri("books.yaml");
+		String template = "{inject:bo|oks}";
+		testDefinitionFor(template, //
+				ll(booksUri, r(0, 8, 0, 13), r(0, 0, 0, 0)));
+	}
+
+	@Test
+	public void books_list() throws Exception {
+		String booksUri = getDataFileUri("books.yaml");
+
+		String template = "{inj|ect:books.list}";
+		testDefinitionFor(template);
+
+		template = "{inject:books.li|st}";
+		testDefinitionFor(template, //
+				ll(booksUri, r(0, 14, 0, 18), r(0, 0, 0, 0)));
+	}
+
+	@Test
+	public void books_list_title() throws Exception {
+		String booksUri = getDataFileUri("books.yaml");
+
+		String template = "{#for b in inject:books.list}\r\n" + //
+				"    {b.ti|tle}\r\n" + //
+				"{/for}";
+		testDefinitionFor(template, //
+				ll(booksUri, r(1, 7, 1, 12), r(0, 0, 0, 0)));
+	}
+
+	public static void testDefinitionFor(String value, LocationLink... expected) throws Exception {
+		QuteAssert.testDefinitionFor(value, null, RoqProject.PROJECT_URI, QuteAssert.TEMPLATE_BASE_DIR, expected);
+	}
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/roq/RoqDataJsonDiagnosticsTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/roq/RoqDataJsonDiagnosticsTest.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.diagnostics.roq;
+
+import static com.redhat.qute.QuteAssert.d;
+
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.QuteAssert;
+import com.redhat.qute.project.roq.RoqProject;
+import com.redhat.qute.services.diagnostics.QuteErrorCode;
+
+/**
+ * Test diagnostics with Roq Quarkus extension and data files.
+ *
+ * @author Angelo ZERR
+ *
+ */
+public class RoqDataJsonDiagnosticsTest {
+
+	@Test
+	public void validInjectDataFile() throws Exception {
+		// data/books.yaml
+		String template = "{inject:books-json}";
+		testDiagnosticsFor(template);
+		template = "{inject:books-json.list}";
+		testDiagnosticsFor(template);
+
+		// data/sandwiches.yaml
+		template = "{inject:sandwiches}";
+		testDiagnosticsFor(template);
+		template = "{inject:sandwiches.sandwiches}";
+		testDiagnosticsFor(template);
+	}
+
+	@Test
+	public void invalidInjectDataFile() throws Exception {
+		String template = "{inject:books-jsonXXX}";
+		testDiagnosticsFor(template, //
+				d(0, 8, 0, 21, QuteErrorCode.UndefinedObject, "`books-jsonXXX` cannot be resolved to an object.", //
+						"qute", DiagnosticSeverity.Warning));
+		template = "{inject:books-json.listXXX}";
+		testDiagnosticsFor(template, //
+				d(0, 19, 0, 26, QuteErrorCode.UnknownProperty,
+						"`listXXX` cannot be resolved or is not a field of `null` Java type.", //
+						"qute", DiagnosticSeverity.Error));
+	}
+
+	@Test
+	public void validInjectDataFileInForSection() throws Exception {
+		String template = "{#for b in inject:books-json.list}\r\n" + //
+				"    {b.title}\r\n" + //
+				"{/for}";
+		testDiagnosticsFor(template);
+	}
+
+	@Test
+	public void nestedFields() throws Exception {
+		String template = "{#for item in inject:sandwiches-json.sandwiches}\r\n" + //
+				"    <h2>{item.name}</h2>\r\n" + //
+				"    <ul>\r\n" + //
+				"    {#for ingredient in item.ingredients}\r\n" + //
+				"        <li>{ingredient}</li>\r\n" + //
+				"    {/for}\r\n" + //
+				"    </ul>\r\n" + //
+				"{/for}";
+		testDiagnosticsFor(template);
+	}
+
+	@Test
+	public void invalidInjectDataFileInForSection() throws Exception {
+		String template = "{#for b in inject:books-json.list}\r\n" + //
+				"    {b.titleXXX}\r\n" + //
+				"{/for}";
+		testDiagnosticsFor(template, //
+				d(1, 7, 1, 15, QuteErrorCode.UnknownProperty,
+						"`titleXXX` cannot be resolved or is not a field of `java.lang.Object` Java type.", //
+						"qute", DiagnosticSeverity.Error));
+	}
+
+	private static void testDiagnosticsFor(String value, Diagnostic... expected) {
+		QuteAssert.testDiagnosticsFor(value, QuteAssert.FILE_URI, null, RoqProject.PROJECT_URI,
+				QuteAssert.TEMPLATE_BASE_DIR, false, null, expected);
+	}
+	
+	
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/roq/RoqDataYamlDiagnosticsTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/roq/RoqDataYamlDiagnosticsTest.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.diagnostics.roq;
+
+import static com.redhat.qute.QuteAssert.d;
+
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.QuteAssert;
+import com.redhat.qute.project.roq.RoqProject;
+import com.redhat.qute.services.diagnostics.QuteErrorCode;
+
+/**
+ * Test diagnostics with Roq Quarkus extension and data files.
+ *
+ * @author Angelo ZERR
+ *
+ */
+public class RoqDataYamlDiagnosticsTest {
+
+	@Test
+	public void validInjectDataFile() throws Exception {
+		// data/books.yaml
+		String template = "{inject:books}";
+		testDiagnosticsFor(template);
+		template = "{inject:books.list}";
+		testDiagnosticsFor(template);
+
+		// data/sandwiches.yaml
+		template = "{inject:sandwiches}";
+		testDiagnosticsFor(template);
+		template = "{inject:sandwiches.sandwiches}";
+		testDiagnosticsFor(template);
+	}
+
+	@Test
+	public void invalidInjectDataFile() throws Exception {
+		String template = "{inject:booksXXX}";
+		testDiagnosticsFor(template, //
+				d(0, 8, 0, 16, QuteErrorCode.UndefinedObject, "`booksXXX` cannot be resolved to an object.", //
+						"qute", DiagnosticSeverity.Warning));
+		template = "{inject:books.listXXX}";
+		testDiagnosticsFor(template, //
+				d(0, 14, 0, 21, QuteErrorCode.UnknownProperty,
+						"`listXXX` cannot be resolved or is not a field of `null` Java type.", //
+						"qute", DiagnosticSeverity.Error));
+	}
+
+	@Test
+	public void validInjectDataFileInForSection() throws Exception {
+		String template = "{#for b in inject:books.list}\r\n" + //
+				"    {b.title}\r\n" + //
+				"{/for}";
+		testDiagnosticsFor(template);
+	}
+
+	@Test
+	public void nestedFields() throws Exception {
+		String template = "{#for item in inject:sandwiches.sandwiches}\r\n" + //
+				"    <h2>{item.name}</h2>\r\n" + //
+				"    <ul>\r\n" + //
+				"    {#for ingredient in item.ingredients}\r\n" + //
+				"        <li>{ingredient}</li>\r\n" + //
+				"    {/for}\r\n" + //
+				"    </ul>\r\n" + //
+				"{/for}";
+		testDiagnosticsFor(template);
+	}
+
+	@Test
+	public void invalidInjectDataFileInForSection() throws Exception {
+		String template = "{#for b in inject:books.list}\r\n" + //
+				"    {b.titleXXX}\r\n" + //
+				"{/for}";
+		testDiagnosticsFor(template, //
+				d(1, 7, 1, 15, QuteErrorCode.UnknownProperty,
+						"`titleXXX` cannot be resolved or is not a field of `java.lang.Object` Java type.", //
+						"qute", DiagnosticSeverity.Error));
+	}
+
+	private static void testDiagnosticsFor(String value, Diagnostic... expected) {
+		QuteAssert.testDiagnosticsFor(value, QuteAssert.FILE_URI, null, RoqProject.PROJECT_URI,
+				QuteAssert.TEMPLATE_BASE_DIR, false, null, expected);
+	}
+	
+	
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/roq/RoqSiteDiagnosticsTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/diagnostics/roq/RoqSiteDiagnosticsTest.java
@@ -18,12 +18,12 @@ import com.redhat.qute.QuteAssert;
 import com.redhat.qute.project.roq.RoqProject;
 
 /**
- * Test diagnostics with Roq Quarkus extension.
+ * Test diagnostics with Roq Quarkus extension and site data model.
  *
  * @author Angelo ZERR
  *
  */
-public class RoqDiagnosticsTest {
+public class RoqSiteDiagnosticsTest {
  
 	@Test
 	public void noErrorByUsingMatchNameAny() throws Exception {

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/hover/renarde/RenardeMessagesHoverTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/hover/renarde/RenardeMessagesHoverTest.java
@@ -20,7 +20,7 @@ import com.redhat.qute.QuteAssert;
 import com.redhat.qute.project.renarde.RenardeProject;
 
 /**
- * Tests for Qute hover in expression.
+ * Tests with Renarde Quarkus extension and resources message.
  *
  * @author Angelo ZERR
  *
@@ -28,13 +28,13 @@ import com.redhat.qute.project.renarde.RenardeProject;
 public class RenardeMessagesHoverTest {
 
 	@Test
-	public void invaliddMessageKey() throws Exception {
+	public void invalidMessageKey() throws Exception {
 		String template = "{m:main.lo|ginXXX}";
 		assertHover(template, null, null);
 	}
 
 	@Test
-	public void validdMessageKey() throws Exception {
+	public void validMessageKey() throws Exception {
 		String template = "{m:main.lo|gin}";
 		assertHover(template, //
 				" * default: **Login/Register**\n" + //
@@ -44,7 +44,7 @@ public class RenardeMessagesHoverTest {
 	}
 
 	@Test
-	public void validdMessageKeyEncoding() throws Exception {
+	public void validMessageKeyEncoding() throws Exception {
 		String template = "{m:todos.message.dele|ted}";
 		assertHover(template, //
 				" * default: **Task deleted: %s**\n" + //

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/hover/roq/RoqDataJsonHoverTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/hover/roq/RoqDataJsonHoverTest.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.hover.roq;
+
+import static com.redhat.qute.QuteAssert.r;
+import static com.redhat.qute.project.roq.RoqProject.getDataFileUri;
+
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.QuteAssert;
+import com.redhat.qute.project.roq.RoqProject;
+
+/**
+ * Tests hover with Roq Quarkus extension and Json data files.
+ *
+ * @author Angelo ZERR
+ *
+ */
+public class RoqDataJsonHoverTest {
+
+	@Test
+	public void books() throws Exception {
+		String booksUri = getDataFileUri("books-json.json");
+		String template = "{inject:bo|oks-json}";
+		assertHover(template, //
+				"Open [books-json.json](" + booksUri + ")", //
+				r(0, 8, 0, 18));
+	}
+
+	@Test
+	public void books_invalid() throws Exception {
+		String template = "{inject:books-json.li|s}";
+		assertHover(template, null, null);
+	}
+
+	@Test
+	public void books_list() throws Exception {
+		String booksUri = getDataFileUri("books-json.json");
+		String template = "{inject:books-json.li|st}";
+		assertHover(template, //
+				"```java" + System.lineSeparator() + //
+						"Collection<Object> list" + System.lineSeparator() + //
+						"```" + System.lineSeparator() + //
+						"Source: [books-json.json](" + booksUri + ")", //
+				r(0, 19, 0, 23));
+	}
+
+	public static void assertHover(String value, String expectedHoverLabel, Range expectedHoverRange) throws Exception {
+		QuteAssert.assertHover(value, QuteAssert.FILE_URI, null, RoqProject.PROJECT_URI, expectedHoverLabel,
+				expectedHoverRange);
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/hover/roq/RoqDataYamlHoverTest.java
+++ b/qute.ls/com.redhat.qute.ls/src/test/java/com/redhat/qute/services/hover/roq/RoqDataYamlHoverTest.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.qute.services.hover.roq;
+
+import static com.redhat.qute.QuteAssert.r;
+import static com.redhat.qute.project.roq.RoqProject.getDataFileUri;
+
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.qute.QuteAssert;
+import com.redhat.qute.project.roq.RoqProject;
+
+/**
+ * Tests hover with Roq Quarkus extension and Yaml data files.
+ *
+ * @author Angelo ZERR
+ *
+ */
+public class RoqDataYamlHoverTest {
+
+	@Test
+	public void books() throws Exception {
+		String booksUri = getDataFileUri("books.yaml");
+		String template = "{inject:bo|oks}";
+		assertHover(template, //
+				"Open [books.yaml](" + booksUri + ")", //
+				r(0, 8, 0, 13));
+	}
+
+	@Test
+	public void books_invalid() throws Exception {
+		String template = "{inject:books.li|s}";
+		assertHover(template, null, null);
+	}
+
+	@Test
+	public void books_list() throws Exception {
+		String booksUri = getDataFileUri("books.yaml");
+		String template = "{inject:books.li|st}";
+		assertHover(template, //
+				"```java" + System.lineSeparator() + //
+						"Collection<Object> list" + System.lineSeparator() + //
+						"```" + System.lineSeparator() + //
+						"Source: [books.yaml](" + booksUri + ")", //
+				r(0, 14, 0, 18));
+	}
+
+	public static void assertHover(String value, String expectedHoverLabel, Range expectedHoverRange) throws Exception {
+		QuteAssert.assertHover(value, QuteAssert.FILE_URI, null, RoqProject.PROJECT_URI, expectedHoverLabel,
+				expectedHoverRange);
+	}
+
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/resources/projects/roq/data/books-json.json
+++ b/qute.ls/com.redhat.qute.ls/src/test/resources/projects/roq/data/books-json.json
@@ -1,0 +1,33 @@
+{
+	"list": [
+		{
+			"title": "Applied AI for Enterprise Java Development",
+			"pyear": 2025,
+			"foo": ":foo/bar",
+			"tagline": "Enter this clear-cut, no-nonsense guide to integrating generative AI into your Java enterprise ecosystem.",
+			"cover": "applied_ai_for_enterprise_java.jpeg",
+			"buy": "https://www.oreilly.com/library/view/applied-ai-for/9781098174491/"
+		},
+		{
+			"title": "Modernizing Enterprise Java",
+			"pyear": 2021,
+			"tagline": "This practical book helps developers examine long-established Java-based models and demonstrates how to bring these monolithic applications successfully into the future.",
+			"cover": "modernizing_enterprise_java.jpeg",
+			"buy": "https://www.amazon.com/Modernizing-Enterprise-Java-Concise-Developers/dp/1098102142"
+		},
+		{
+			"title": "Modern Java EE Design Pattern",
+			"pyear": 2016,
+			"tagline": "Bridge that gap by building microservice-based architectures on top of Java EE..",
+			"cover": "modern_javaee_designpattern.png",
+			"buy": "https://www.oreilly.com/library/view/modern-java-ee/9781492042266/"
+		},
+		{
+			"title": "Developing Reactive Microservices",
+			"pyear": 2016,
+			"tagline": "People, resilience, and the cost of downtime.",
+			"cover": "developing_reactive_microservices.jpeg",
+			"buy": "https://www.oreilly.com/library/view/developing-reactive-microservices/9781491975640/"
+		}
+	]
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/resources/projects/roq/data/books.yaml
+++ b/qute.ls/com.redhat.qute.ls/src/test/resources/projects/roq/data/books.yaml
@@ -1,0 +1,22 @@
+list:
+  - title: "Applied AI for Enterprise Java Development"
+    pyear: 2025
+    foo: :foo/bar
+    tagline: "Enter this clear-cut, no-nonsense guide to integrating generative AI into your Java enterprise ecosystem."
+    cover: "applied_ai_for_enterprise_java.jpeg"
+    buy: "https://www.oreilly.com/library/view/applied-ai-for/9781098174491/"
+  - title: "Modernizing Enterprise Java"
+    pyear: 2021
+    tagline: "This practical book helps developers examine long-established Java-based models and demonstrates how to bring these monolithic applications successfully into the future."
+    cover: "modernizing_enterprise_java.jpeg"
+    buy: "https://www.amazon.com/Modernizing-Enterprise-Java-Concise-Developers/dp/1098102142"
+  - title: "Modern Java EE Design Pattern"
+    pyear: 2016
+    tagline: "Bridge that gap by building microservice-based architectures on top of Java EE.."
+    cover: "modern_javaee_designpattern.png"
+    buy: "https://www.oreilly.com/library/view/modern-java-ee/9781492042266/"
+  - title: "Developing Reactive Microservices"
+    pyear: 2016
+    tagline: "People, resilience, and the cost of downtime."
+    cover: "developing_reactive_microservices.jpeg"
+    buy: "https://www.oreilly.com/library/view/developing-reactive-microservices/9781491975640/"

--- a/qute.ls/com.redhat.qute.ls/src/test/resources/projects/roq/data/sandwiches-json.json
+++ b/qute.ls/com.redhat.qute.ls/src/test/resources/projects/roq/data/sandwiches-json.json
@@ -1,0 +1,23 @@
+{
+  "sandwiches": [
+    {
+      "name": "Turkey and Brie",
+      "ingredients": [
+        "turkey",
+        "brie",
+        "apple",
+        "ciabatta"
+      ]
+    },
+    {
+      "name": "Ham and Cheese",
+      "ingredients": [
+        "ham",
+        "cheddar",
+        "mustard",
+        "green leaf lettuce",
+        "whole grain bread"
+      ]
+    }
+  ]
+}

--- a/qute.ls/com.redhat.qute.ls/src/test/resources/projects/roq/data/sandwiches.yaml
+++ b/qute.ls/com.redhat.qute.ls/src/test/resources/projects/roq/data/sandwiches.yaml
@@ -1,0 +1,14 @@
+sandwiches:
+  - name: Turkey and Brie
+    ingredients:
+     - turkey
+     - brie
+     - apple
+     - ciabatta
+  - name: Ham and Cheese
+    ingredients:
+     - ham
+     - cheddar
+     - mustard
+     - green leaf lettuce
+     - whole grain bread


### PR DESCRIPTION
Support for Roq Data files

To implement this PR I am using https://github.com/myfear/ejq_substack_articles/tree/main/roq-author-website usecase.

To test the PR:

 * open  https://github.com/myfear/ejq_substack_articles/tree/main/roq-author-website usecase.
 * create a foo.html file in the content folder

```
{#for b in inject:books.list}
    {b.buy}
{/for}
```

you should have no error. Here a demo which show the support in action to write this content (completion, validation, hover and definition)

![InjectDataDemo2](https://github.com/user-attachments/assets/7841d7ac-a874-4c10-94b9-77ecb92f0131)


This PR tracks also changes of data files (stored in data folder https://github.com/myfear/ejq_substack_articles/tree/main/roq-author-website/data . It mean that if you create, delete or update yaml files, the validation of template must be retrrigered and completion etc should be refreshed also.

![InjectDataDemo3](https://github.com/user-attachments/assets/8022f16f-db3e-4e93-b3bc-1dca331ea9dc)

I need to:

 * improve hover of property coming from yaml files
 * improve inlay hint

Definition (ctrl+Click) open the file on the first line of the files and not where the property is defined. I will not support that in this PR but in a future PR because this PR is already big.

